### PR TITLE
The trailing period creates a broken link.

### DIFF
--- a/docs/why-haskell.md
+++ b/docs/why-haskell.md
@@ -52,4 +52,4 @@ At this point, we are pretty firmly attached to Haskell's language features to e
 [Stack]: https://docs.haskellstack.org/en/stable/README/
 [GHC]: https://en.wikipedia.org/wiki/Glasgow_Haskell_Compiler
 [Facebook]: https://github.com/facebook/Haxl
-[Advanced Overlap]: https://wiki.haskell.org/GHC/AdvancedOverlap.
+[Advanced Overlap]: https://wiki.haskell.org/GHC/AdvancedOverlap


### PR DESCRIPTION
The period at the end of AdvancedOverlap creates a broken link.