### PR TITLE
Only build PR branches once in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,9 @@ script:
 - cabal new-build -j semantic-core semantic:exe:semantic
 - cabal new-test semantic:test semantic-core:spec
 - cabal new-run semantic:parse-examples
+
+# Any branch linked with a pull request will be built, as well as the non-PR
+# branches listed below:
+branches:
+  only:
+    - master


### PR DESCRIPTION
We didn't have a branch exclusion filter in place, so Travis has been building each PR twice.