### PR TITLE
Add a Dockerfile that builds the CLI tool

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ RUN cabal new-update
 # Build our upstream dependencies after copying in only enough to tell cabal
 # what they are.  This will make these layers cache better even as we change the
 # code of semantic itself.
-COPY semantic.cabal /build/
-COPY cabal.project /build/
-COPY semantic-core/semantic-core.cabal /build/semantic-core/
-COPY vendor /build/vendor
+COPY semantic.cabal .
+COPY cabal.project .
+COPY semantic-core/semantic-core.cabal ./semantic-core/
+COPY vendor ./vendor
 RUN cabal new-build --only-dependencies
 
 # Once the dependencies are built, copy in the rest of the code and compile
@@ -21,7 +21,8 @@ RUN cp $(find dist-newstyle -name semantic -type f -perm -u=x) /usr/local/bin/se
 
 # Create a fresh image containing only the compiled CLI program, so that the
 # image isn't bulked up by all of the extra build state.
-FROM debian:stretch
+FROM debian:stretch-slim
+
 RUN apt-get update && \
   apt-get install -y \
     libgmp10 \
@@ -29,5 +30,7 @@ RUN apt-get update && \
   apt-get autoremove -y && \
   apt-get clean -y && \
   rm -rf /var/lib/apt/lists/*
+
 COPY --from=build /usr/local/bin/semantic /usr/local/bin/semantic
+
 ENTRYPOINT ["/usr/local/bin/semantic"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM haskell:8.6 as build
+WORKDIR /build
+RUN cabal new-update
+COPY . /build
+RUN cabal new-build semantic:exe:semantic
+
+# A fake `install` target until we can get `cabal new-install` to work
+RUN cp $(find dist-newstyle -name semantic -type f -perm -u=x) /semantic
+
+FROM debian:stretch
+RUN apt-get update && \
+  apt-get install -y \
+    libgmp10 \
+    && \
+  apt-get autoremove -y && \
+  apt-get clean -y && \
+  rm -rf /var/lib/apt/lists/*
+COPY --from=build /semantic /usr/local/bin/semantic
+ENTRYPOINT ["/usr/local/bin/semantic"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,26 @@
 FROM haskell:8.6 as build
 WORKDIR /build
 RUN cabal new-update
+
+# Build our upstream dependencies after copying in only enough to tell cabal
+# what they are.  This will make these layers cache better even as we change the
+# code of semantic itself.
+COPY semantic.cabal /build/
+COPY cabal.project /build/
+COPY semantic-core/semantic-core.cabal /build/semantic-core/
+COPY vendor /build/vendor
+RUN cabal new-build --only-dependencies
+
+# Once the dependencies are built, copy in the rest of the code and compile
+# semantic itself.
 COPY . /build
 RUN cabal new-build semantic:exe:semantic
 
 # A fake `install` target until we can get `cabal new-install` to work
-RUN cp $(find dist-newstyle -name semantic -type f -perm -u=x) /semantic
+RUN cp $(find dist-newstyle -name semantic -type f -perm -u=x) /usr/local/bin/semantic
 
+# Create a fresh image containing only the compiled CLI program, so that the
+# image isn't bulked up by all of the extra build state.
 FROM debian:stretch
 RUN apt-get update && \
   apt-get install -y \
@@ -15,5 +29,5 @@ RUN apt-get update && \
   apt-get autoremove -y && \
   apt-get clean -y && \
   rm -rf /var/lib/apt/lists/*
-COPY --from=build /semantic /usr/local/bin/semantic
+COPY --from=build /usr/local/bin/semantic /usr/local/bin/semantic
 ENTRYPOINT ["/usr/local/bin/semantic"]


### PR DESCRIPTION
I think this should be set up to build the dependencies separately, so that Docker layer caching kicks in, skipping that step when they haven't changed.

cf #62 