### PR TITLE
Bump minimum base version.

### DIFF
--- a/semantic-core/semantic-core.cabal
+++ b/semantic-core/semantic-core.cabal
@@ -35,7 +35,7 @@ library
   -- other-modules:
   -- other-extensions:
   build-depends:       algebraic-graphs            ^>= 0.3
-                     , base                         >= 4.11 && < 5
+                     , base                         >= 4.12 && < 5
                      , containers                  ^>= 0.6
                      , directory                   ^>= 1.3
                      , filepath                    ^>= 1.4

--- a/semantic.cabal
+++ b/semantic.cabal
@@ -41,7 +41,7 @@ common haskell
 -- as caret-operator bounds relative to a version in Stackage.
 -- These are currently pinned to lts-13.13.
 common dependencies
-  build-depends:       base >= 4.8 && < 5
+  build-depends:       base >= 4.12 && < 5
                      , aeson ^>= 1.4.2.0
                      , algebraic-graphs ^>= 0.3
                      , async ^>= 2.2.1
@@ -273,7 +273,7 @@ library
                      -- Custom Prelude
                      , Prologue
 
-  build-depends:       base >= 4.8 && < 5
+  build-depends:       base >= 4.12 && < 5
                      , ansi-terminal ^>= 0.8.2
                      , array ^>= 0.5.3.0
                      , attoparsec ^>= 0.13.2.2


### PR DESCRIPTION
This should hopefully provide a more informative error message when
someone attempts to build the project with too old of a GHC.