### PR TITLE
Build (and publish) docker image for the semantic CLI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,8 @@
 Dockerfile
+.licenses
+.ghc.environment.x86_64-darwin-8.6.5
+
+/bin
+/dist-newstyle
+/notices
+/docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,13 @@
 FROM haskell:8.6 as build
 WORKDIR /build
+
 RUN cabal new-update
 
-# Build our upstream dependencies after copying in only enough to tell cabal
-# what they are.  This will make these layers cache better even as we change the
-# code of semantic itself.
-COPY semantic.cabal .
-COPY cabal.project .
-COPY semantic-core/semantic-core.cabal ./semantic-core/
-COPY vendor ./vendor
-RUN cabal new-build --only-dependencies
-
-# Once the dependencies are built, copy in the rest of the code and compile
-# semantic itself.
-COPY . /build
-RUN cabal new-build semantic:exe:semantic
+COPY . .
+RUN cabal new-build --flags="release" semantic:exe:semantic
 
 # A fake `install` target until we can get `cabal new-install` to work
-RUN cp $(find dist-newstyle -name semantic -type f -perm -u=x) /usr/local/bin/semantic
+RUN cp $(find dist-newstyle/build/x86_64-linux -name semantic -type f -perm -u=x) /usr/local/bin/semantic
 
 # Create a fresh image containing only the compiled CLI program, so that the
 # image isn't bulked up by all of the extra build state.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 FROM haskell:8.6 as build
 WORKDIR /build
 
-RUN cabal new-update
+# Build and cache the dependencies first so we can cache these layers.
+COPY semantic.cabal .
+COPY semantic-core semantic-core
+RUN cabal new-update hackage.haskell.org,HEAD
+RUN cabal new-configure semantic semantic-core
+RUN cabal new-build --only-dependencies
 
+# Copy in and build the entire project
 COPY . .
 RUN cabal new-build --flags="release" semantic:exe:semantic
 

--- a/script/publish
+++ b/script/publish
@@ -21,6 +21,6 @@ docker run --rm $DOCKER_IMAGE --version
 docker tag $DOCKER_IMAGE $DOCKER_IMAGE:latest
 docker tag $DOCKER_IMAGE $DOCKER_IMAGE:$VERSION
 docker tag $DOCKER_IMAGE $DOCKER_IMAGE:sha_$BUILD_SHA
-docker push $DOCKER_IMAGE:latest
-docker push $DOCKER_IMAGE:$VERSION
 docker push $DOCKER_IMAGE:sha_$BUILD_SHA
+docker push $DOCKER_IMAGE:$VERSION
+docker push $DOCKER_IMAGE:latest

--- a/script/publish
+++ b/script/publish
@@ -1,0 +1,26 @@
+#!/bin/bash
+#/ Usage: script/publish
+#/
+#/ Build a docker image of the semantic CLI and publish to the GitHub Package Registry
+
+set -e
+cd $(dirname "$0")/..
+
+VERSION="0.6.0"
+BUILD_SHA=$(git rev-parse HEAD 2>/dev/null)
+DOCKER_IMAGE=docker.pkg.github.com/github/semantic/semantic
+
+# Build
+docker build -t $DOCKER_IMAGE .
+
+# Make sure semantic is in the image.
+docker run --rm $DOCKER_IMAGE --version
+
+# Requires that you've logged in to the GPR (e.g. `docker login docker.pkg.github.com`)
+# https://help.github.com/en/articles/configuring-docker-for-use-with-github-package-registry
+docker tag $DOCKER_IMAGE $DOCKER_IMAGE:latest
+docker tag $DOCKER_IMAGE $DOCKER_IMAGE:$VERSION
+docker tag $DOCKER_IMAGE $DOCKER_IMAGE:sha_$BUILD_SHA
+docker push $DOCKER_IMAGE:latest
+docker push $DOCKER_IMAGE:$VERSION
+docker push $DOCKER_IMAGE:sha_$BUILD_SHA


### PR DESCRIPTION
Depends on https://github.com/github/semantic/pull/110
Fixes https://github.com/github/semantic/issues/62

Builds a docker image of the semantic CLI and provides a script to publish to the GitHub Package Registry.

Published the first release here: https://github.com/github/semantic/packages/11609