### PR TITLE
Disable optimizations on CI builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,12 @@ before_install:
 - cabal --version
 
 install:
-- cabal new-update -v hackage.haskell.org
+- cabal new-update -v
 - cabal new-configure --enable-tests --write-ghc-environment-files=always --jobs=2
-- cabal new-build --only-dependencies -j
+- cabal new-build --only-dependencies
 
 script:
-- cabal new-build -j
+- cabal new-build
 - cabal new-run semantic:test
 - cabal new-run semantic-core:spec
 # parse-examples is disabled because it slaughters our CI

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
 
 install:
 - cabal new-update -v
-- cabal new-configure --enable-tests --write-ghc-environment-files=always --jobs=2
+- cabal new-configure --enable-tests --disable-optimization --write-ghc-environment-files=always --jobs=2
 - cabal new-build --only-dependencies
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
 
 install:
 - cabal new-update -v hackage.haskell.org
-- cabal new-configure --enable-tests --write-ghc-environment-files=always
+- cabal new-configure --enable-tests --write-ghc-environment-files=always --jobs=2
 - cabal new-build --only-dependencies -j
 
 script:


### PR DESCRIPTION
Build times are killing us. This gets us down to 9 minutes from 40. Docker builds should be unaffected because we don’t pass --disable-optimizations to new-configure in the Dockerfile.