### PR TITLE
Remove HasDefault and Primitive instances for Language.

### DIFF
--- a/src/Data/Language.hs
+++ b/src/Data/Language.hs
@@ -36,7 +36,7 @@ data Language
     | TypeScript
     | PHP
     | TSX
-    deriving (Eq, Generic, Ord, Read, Show, Bounded, Hashable, ToJSON, Named, Enum, MessageField, NFData)
+    deriving (Eq, Generic, Ord, Read, Show, Bounded, Hashable, ToJSON, Enum, NFData)
 
 class SLanguage (lang :: Language) where
   reflect :: proxy lang -> Language

--- a/src/Data/Language.hs
+++ b/src/Data/Language.hs
@@ -77,12 +77,6 @@ instance SLanguage 'TypeScript where
 instance SLanguage 'PHP where
   reflect _ = PHP
 
-
--- This ensures that the protobuf file is generated with ALL_CAPS_NAMES.
-instance Finite Language where
-  enumerate _ = fmap go [Unknown ..] where
-    go x = (fromString (fmap toUpper (show x)), fromEnum x)
-
 instance FromJSON Language where
   parseJSON = withText "Language" $ \l ->
     pure $ fromMaybe Unknown (parseLanguage l)

--- a/src/Data/Language.hs
+++ b/src/Data/Language.hs
@@ -17,7 +17,6 @@ import           Data.Char (toUpper)
 import           Data.String
 import qualified Data.Text as T
 import           Prologue
-import           Proto3.Suite
 import           System.FilePath.Posix
 
 -- | The various languages we support.
@@ -106,18 +105,6 @@ parseLanguage l = case T.toLower l of
 -- | Predicate failing on 'Unknown' and passing in all other cases.
 knownLanguage :: Language -> Bool
 knownLanguage = (/= Unknown)
-
--- | Defaults to 'Unknown'.
-instance HasDefault Language where def = Unknown
-
--- | Piggybacks on top of the 'Enumerated' instance, as the generated code would.
--- This instance will get easier when we have DerivingVia.
-instance Primitive Language where
-  primType _ = primType (Proxy @(Enumerated Language))
-  encodePrimitive f = encodePrimitive f . Enumerated . Right
-  decodePrimitive   = decodePrimitive >>= \case
-    (Enumerated (Right r)) -> pure r
-    other                  -> Prelude.fail ("Language decodeMessageField: unexpected value" <> show other)
 
 -- | Returns a Language based on the file extension (including the ".").
 languageForType :: String -> Language


### PR DESCRIPTION
Those instances are handled by the bridged data types in `Semantic.Api`.
Keeping this around is both unnecessary and is making #139 go all
wobbly for reasons that are still unclear to me.