### PR TITLE
Require Cabal 2.4.

### DIFF
--- a/semantic-core/semantic-core.cabal
+++ b/semantic-core/semantic-core.cabal
@@ -1,4 +1,4 @@
-cabal-version:       2.2
+cabal-version:       2.4
 
 name:                semantic-core
 version:             0.0.0.0

--- a/semantic.cabal
+++ b/semantic.cabal
@@ -1,4 +1,4 @@
-cabal-version:       2.2
+cabal-version:       2.4
 name:                semantic
 version:             0.6.0.0
 synopsis:            Framework and executable for analyzing and diffing untrusted code.


### PR DESCRIPTION
Enforcing this seems to address part of what was observed in #139.