### PR TITLE
Remove unused RankNTypes extension

### DIFF
--- a/src/Semantic/CLI.hs
+++ b/src/Semantic/CLI.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ApplicativeDo, RankNTypes #-}
+{-# LANGUAGE ApplicativeDo #-}
 module Semantic.CLI (main) where
 
 import           Control.Exception as Exc (displayException)


### PR DESCRIPTION
I found in this module add `RankNTypes` extension, but currently don't use it.