### PR TITLE
Cache the dist-newstyle directory.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache:
   directories:
     - $HOME/.cabal/packages
     - $HOME/.cabal/store
+    - $TRAVIS_BUILD_DIR/dist-newstyle
 
 before_cache:
   - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log


### PR DESCRIPTION
This should address #88. We might even be able to turn -O1 on again.