### PR TITLE
Remove unused NamedFieldPuns extension in Data.Source.Spec

### DIFF
--- a/test/Data/Source/Spec.hs
+++ b/test/Data/Source/Spec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
 module Data.Source.Spec (spec, testTree) where
 
 import Data.Range


### PR DESCRIPTION
We can delete `NamedFieldPuns` because we don't use feature of this extension in this module.