### PR TITLE
Add golden tests for `parse --proto-symbols` output.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 test/fixtures linguist-vendored
 test/repos linguist-vendored
 vendor linguist-vendored
+*.protobuf.bin binary

--- a/test/Data/Functor/Listable.hs
+++ b/test/Data/Functor/Listable.hs
@@ -107,8 +107,8 @@ liftCons4 tiers1 tiers2 tiers3 tiers4 f = mapT (uncurry4 f) (tiers1 >< tiers2 ><
 -- | Lifts a quinary constructor to a list of tiers, given lists of tiers for its arguments.
 --
 --   Commonly used in the definition of 'Listable1' and 'Listable2' instances.
-liftCons5 :: [Tier a] -> [Tier b] -> [Tier c] -> [Tier d] -> [Tier e] -> (a -> b -> c -> d -> e -> f) -> [Tier f]
-liftCons5 tiers1 tiers2 tiers3 tiers4 tiers5 f = mapT (uncurry5 f) (tiers1 >< tiers2 >< tiers3 >< tiers4 >< tiers5) `addWeight` 1
+_liftCons5 :: [Tier a] -> [Tier b] -> [Tier c] -> [Tier d] -> [Tier e] -> (a -> b -> c -> d -> e -> f) -> [Tier f]
+_liftCons5 tiers1 tiers2 tiers3 tiers4 tiers5 f = mapT (uncurry5 f) (tiers1 >< tiers2 >< tiers3 >< tiers4 >< tiers5) `addWeight` 1
   where uncurry5 f (a, (b, (c, (d, e)))) = f a b c d e
 
 -- | Lifts a senary constructor to a list of tiers, given lists of tiers for its arguments.

--- a/test/Data/Functor/Listable.hs
+++ b/test/Data/Functor/Listable.hs
@@ -104,13 +104,6 @@ liftCons4 :: [Tier a] -> [Tier b] -> [Tier c] -> [Tier d] -> (a -> b -> c -> d -
 liftCons4 tiers1 tiers2 tiers3 tiers4 f = mapT (uncurry4 f) (tiers1 >< tiers2 >< tiers3 >< tiers4) `addWeight` 1
   where uncurry4 f (a, (b, (c, d))) = f a b c d
 
--- | Lifts a quinary constructor to a list of tiers, given lists of tiers for its arguments.
---
---   Commonly used in the definition of 'Listable1' and 'Listable2' instances.
-_liftCons5 :: [Tier a] -> [Tier b] -> [Tier c] -> [Tier d] -> [Tier e] -> (a -> b -> c -> d -> e -> f) -> [Tier f]
-_liftCons5 tiers1 tiers2 tiers3 tiers4 tiers5 f = mapT (uncurry5 f) (tiers1 >< tiers2 >< tiers3 >< tiers4 >< tiers5) `addWeight` 1
-  where uncurry5 f (a, (b, (c, (d, e)))) = f a b c d e
-
 -- | Lifts a senary constructor to a list of tiers, given lists of tiers for its arguments.
 --
 --   Commonly used in the definition of 'Listable1' and 'Listable2' instances.

--- a/test/Semantic/CLI/Spec.hs
+++ b/test/Semantic/CLI/Spec.hs
@@ -53,6 +53,7 @@ parseFixtures =
   , ("json", parseTermBuilder TermJSONTree, path', prefix </> "parse-trees.json")
   , ("json", parseTermBuilder TermJSONTree, [], prefix </> "parse-tree-empty.json")
   , ("symbols", parseSymbolsBuilder Serializing.Format.JSON, path'', prefix </> "parse-tree.symbols.json")
+  , ("protobuf symbols", parseSymbolsBuilder Serializing.Format.Proto, path'', prefix </> "parse-tree.symbols.protobuf.bin")
   ]
   where path = [File "test/fixtures/ruby/corpus/and-or.A.rb" Ruby]
         path' = [File "test/fixtures/ruby/corpus/and-or.A.rb" Ruby, File "test/fixtures/ruby/corpus/and-or.B.rb" Ruby]
@@ -64,6 +65,7 @@ diffFixtures =
   [ ("json diff", parseDiffBuilder DiffJSONTree, pathMode, prefix </> "diff-tree.json")
   , ("s-expression diff", parseDiffBuilder DiffSExpression, pathMode, "test/fixtures/ruby/corpus/method-declaration.diffA-B.txt")
   , ("toc summaries diff", diffSummaryBuilder Serializing.Format.JSON, pathMode, prefix </> "diff-tree.toc.json")
+  , ("protobuf diff", diffSummaryBuilder Serializing.Format.Proto, pathMode, prefix </> "diff-tree.toc.protobuf.bin")
   ]
   where pathMode = [Both (File "test/fixtures/ruby/corpus/method-declaration.A.rb" Ruby) (File "test/fixtures/ruby/corpus/method-declaration.B.rb"  Ruby)]
         prefix = "test/fixtures/cli"

--- a/test/Semantic/IO/Spec.hs
+++ b/test/Semantic/IO/Spec.hs
@@ -5,7 +5,6 @@ import Prelude hiding (readFile)
 import Control.Monad.IO.Class
 import Data.List
 import System.Directory
-import System.Exit (ExitCode (..))
 import System.IO.Temp
 import Data.String
 

--- a/test/Semantic/Stat/Spec.hs
+++ b/test/Semantic/Stat/Spec.hs
@@ -11,7 +11,6 @@ import System.Environment
 
 import Test.Tasty
 import Test.Tasty.HUnit
-import Test.Tasty.Runners
 
 withSocketPair :: ((Socket, Socket) -> IO c) -> IO c
 withSocketPair = bracket create release
@@ -32,7 +31,7 @@ testTree = testCaseSteps "Semantic.Stat.Spec" $ \step -> do
   step "Handles stats addr with just hostname"
   case_handles_stats_addr_with_just_hostname
   step "takes dogstats host from environment"
-  case_takes_stats_addr_from_environment
+  case_takes_dogstats_host_from_environment
   step "rendering"
   case_render_counters *> case_render_tags
   step "stats deliver datagram"

--- a/test/fixtures/cli/diff-tree.toc.protobuf.bin
+++ b/test/fixtures/cli/diff-tree.toc.protobuf.bin
@@ -1,0 +1,5 @@
+
+
+ftest/fixtures/ruby/corpus/method-declaration.A.rb -> test/fixtures/ruby/corpus/method-declaration.B.rbRuby
+Methodbar
+ 

--- a/test/fixtures/cli/parse-tree.symbols.protobuf.bin
+++ b/test/fixtures/cli/parse-tree.symbols.protobuf.bin
@@ -1,0 +1,5 @@
+
+_
+1test/fixtures/ruby/corpus/method-declaration.A.rbRuby$
+fooMethoddef foo"
+


### PR DESCRIPTION
This should help us ensure that we don't break CLI output, since our CLI is an API.

This was made super-easy thanks to `tasty-golden`. I literally added those two lines of code and it automatically created the reference `.protobuf.bin` files. Slick as hell.