### PR TITLE
Serialize precise AST as s-expressions

### DIFF
--- a/semantic.cabal
+++ b/semantic.cabal
@@ -271,6 +271,7 @@ library
                      -- Serialization
                      , Serializing.Format
                      , Serializing.SExpression
+                     , Serializing.SExpression.Precise
                      , Tags.Taggable
                      , Tags.Tagging
                      -- Custom Prelude

--- a/src/Serializing/SExpression/Precise.hs
+++ b/src/Serializing/SExpression/Precise.hs
@@ -55,5 +55,8 @@ instance (GToSExpression f, GToSExpression g) => GToSExpression (f :*: g) where
 instance GToSExpression U1 where
   gtoSExpression _ _ = []
 
+instance GToSExpression f => GToSExpression (M1 S s f) where
+  gtoSExpression = gtoSExpression . unM1 -- FIXME: show the selector name, if any
+
 instance ToSExpression k => GToSExpression (K1 R k) where
   gtoSExpression k = pure . toSExpression (unK1 k)

--- a/src/Serializing/SExpression/Precise.hs
+++ b/src/Serializing/SExpression/Precise.hs
@@ -26,3 +26,6 @@ instance (GToSExpression f, GToSExpression g) => GToSExpression (f :+: g) where
 
 instance (Constructor c, GToSExpression f) => GToSExpression (M1 C c f) where
   gtoSExpression' m n = stringUtf8 (conName m) : gtoSExpression' (unM1 m) (n + 1)
+
+instance (GToSExpression f, GToSExpression g) => GToSExpression (f :*: g) where
+  gtoSExpression' (l :*: r) = gtoSExpression' l <> gtoSExpression' r

--- a/src/Serializing/SExpression/Precise.hs
+++ b/src/Serializing/SExpression/Precise.hs
@@ -1,0 +1,2 @@
+module Serializing.SExpression.Precise
+() where

--- a/src/Serializing/SExpression/Precise.hs
+++ b/src/Serializing/SExpression/Precise.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, FlexibleInstances, OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts, FlexibleInstances, OverloadedStrings, TypeOperators #-}
 module Serializing.SExpression.Precise
 ( serializeSExpression
 ) where
@@ -19,6 +19,10 @@ class GToSExpression f where
 
 instance GToSExpression f => GToSExpression (M1 D d f) where
   gtoSExpression' = gtoSExpression' . unM1
+
+instance (GToSExpression f, GToSExpression g) => GToSExpression (f :+: g) where
+  gtoSExpression' (L1 l) = gtoSExpression' l
+  gtoSExpression' (R1 r) = gtoSExpression' r
 
 instance (Constructor c, GToSExpression f) => GToSExpression (M1 C c f) where
   gtoSExpression' m n = stringUtf8 (conName m) : gtoSExpression' (unM1 m) (n + 1)

--- a/src/Serializing/SExpression/Precise.hs
+++ b/src/Serializing/SExpression/Precise.hs
@@ -11,3 +11,6 @@ serializeSExpression t = gtoSExpression (from t) 0 <> "\n"
 
 class GToSExpression f where
   gtoSExpression :: f (Int -> Builder) -> (Int -> Builder)
+
+instance GToSExpression f => GToSExpression (M1 D d f) where
+  gtoSExpression = gtoSExpression . unM1

--- a/src/Serializing/SExpression/Precise.hs
+++ b/src/Serializing/SExpression/Precise.hs
@@ -20,16 +20,16 @@ instance (ToSExpressionWithStrategy strategy t, strategy ~ ToSExpressionStrategy
   toSExpression = toSExpressionWithStrategy @strategy undefined
 
 
-data Strategy = Generic | Custom
+data Strategy = Generic | Show
 
 type family ToSExpressionStrategy t :: Strategy where
-  ToSExpressionStrategy Text = 'Custom
+  ToSExpressionStrategy Text = 'Show
   ToSExpressionStrategy _    = 'Generic
 
 class ToSExpressionWithStrategy (strategy :: Strategy) t where
   toSExpressionWithStrategy :: proxy strategy -> t -> Int -> Builder
 
-instance ToSExpressionWithStrategy 'Custom Text where
+instance Show t => ToSExpressionWithStrategy 'Show t where
   toSExpressionWithStrategy _ t _ = stringUtf8 (show t)
 
 instance (Generic t, GToSExpression (Rep t)) => ToSExpressionWithStrategy 'Generic t where

--- a/src/Serializing/SExpression/Precise.hs
+++ b/src/Serializing/SExpression/Precise.hs
@@ -54,3 +54,6 @@ instance (GToSExpression f, GToSExpression g) => GToSExpression (f :*: g) where
 
 instance GToSExpression U1 where
   gtoSExpression _ _ = []
+
+instance ToSExpression k => GToSExpression (K1 R k) where
+  gtoSExpression k = pure . toSExpression (unK1 k)

--- a/src/Serializing/SExpression/Precise.hs
+++ b/src/Serializing/SExpression/Precise.hs
@@ -1,6 +1,8 @@
-{-# LANGUAGE DataKinds, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings, ScopedTypeVariables, TypeApplications, TypeFamilies, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DataKinds, DeriveGeneric, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings, ScopedTypeVariables, TypeApplications, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Serializing.SExpression.Precise
 ( serializeSExpression
+, Expr(..)
+, Identifier(..)
 ) where
 
 import Data.ByteString.Builder
@@ -31,8 +33,9 @@ instance (ToSExpressionWithStrategy strategy t, strategy ~ ToSExpressionStrategy
 data Strategy = Generic | Show
 
 type family ToSExpressionStrategy t :: Strategy where
-  ToSExpressionStrategy Text = 'Show
-  ToSExpressionStrategy _    = 'Generic
+  ToSExpressionStrategy Text    = 'Show
+  ToSExpressionStrategy Integer = 'Show
+  ToSExpressionStrategy _       = 'Generic
 
 class ToSExpressionWithStrategy (strategy :: Strategy) t where
   toSExpressionWithStrategy :: proxy strategy -> t -> Int -> Builder
@@ -68,3 +71,10 @@ instance GToSExpression f => GToSExpression (M1 S s f) where
 
 instance ToSExpression k => GToSExpression (K1 R k) where
   gtoSExpression k = pure . toSExpression (unK1 k)
+
+
+data Expr = Var Identifier | Lam Identifier Expr | App Expr Expr | Int Integer
+  deriving (Generic)
+
+newtype Identifier = Identifier Text
+  deriving (Generic)

--- a/src/Serializing/SExpression/Precise.hs
+++ b/src/Serializing/SExpression/Precise.hs
@@ -1,2 +1,13 @@
+{-# LANGUAGE FlexibleContexts, FlexibleInstances, OverloadedStrings #-}
 module Serializing.SExpression.Precise
-() where
+( serializeSExpression
+) where
+
+import Data.ByteString.Builder
+import GHC.Generics
+
+serializeSExpression :: (Generic t, GToSExpression (Rep t)) => t -> Builder
+serializeSExpression t = gtoSExpression (from t) 0 <> "\n"
+
+class GToSExpression f where
+  gtoSExpression :: f (Int -> Builder) -> (Int -> Builder)

--- a/src/Serializing/SExpression/Precise.hs
+++ b/src/Serializing/SExpression/Precise.hs
@@ -51,3 +51,6 @@ instance (Constructor c, GToSExpression f) => GToSExpression (M1 C c f) where
 
 instance (GToSExpression f, GToSExpression g) => GToSExpression (f :*: g) where
   gtoSExpression (l :*: r) = gtoSExpression l <> gtoSExpression r
+
+instance GToSExpression U1 where
+  gtoSExpression _ _ = []

--- a/src/Serializing/SExpression/Precise.hs
+++ b/src/Serializing/SExpression/Precise.hs
@@ -4,13 +4,21 @@ module Serializing.SExpression.Precise
 ) where
 
 import Data.ByteString.Builder
+import Data.Foldable (fold)
+import Data.List (intersperse)
 import GHC.Generics
 
 serializeSExpression :: (Generic t, GToSExpression (Rep t)) => t -> Builder
 serializeSExpression t = gtoSExpression (from t) 0 <> "\n"
 
+gtoSExpression :: GToSExpression f => f (Int -> Builder) -> (Int -> Builder)
+gtoSExpression f n = "(" <> fold (intersperse " " (gtoSExpression' f n)) <> ")"
+
 class GToSExpression f where
-  gtoSExpression :: f (Int -> Builder) -> (Int -> Builder)
+  gtoSExpression' :: f (Int -> Builder) -> (Int -> [Builder])
 
 instance GToSExpression f => GToSExpression (M1 D d f) where
-  gtoSExpression = gtoSExpression . unM1
+  gtoSExpression' = gtoSExpression' . unM1
+
+instance (Constructor c, GToSExpression f) => GToSExpression (M1 C c f) where
+  gtoSExpression' m n = stringUtf8 (conName m) : gtoSExpression' (unM1 m) (n + 1)

--- a/src/Serializing/SExpression/Precise.hs
+++ b/src/Serializing/SExpression/Precise.hs
@@ -1,8 +1,6 @@
-{-# LANGUAGE DataKinds, DeriveGeneric, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings, ScopedTypeVariables, TypeApplications, TypeFamilies, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DataKinds, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings, ScopedTypeVariables, TypeApplications, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Serializing.SExpression.Precise
 ( serializeSExpression
-, Expr(..)
-, Identifier(..)
 ) where
 
 import Data.ByteString.Builder
@@ -33,9 +31,8 @@ instance (ToSExpressionWithStrategy strategy t, strategy ~ ToSExpressionStrategy
 data Strategy = Generic | Show
 
 type family ToSExpressionStrategy t :: Strategy where
-  ToSExpressionStrategy Text    = 'Show
-  ToSExpressionStrategy Integer = 'Show
-  ToSExpressionStrategy _       = 'Generic
+  ToSExpressionStrategy Text = 'Show
+  ToSExpressionStrategy _    = 'Generic
 
 class ToSExpressionWithStrategy (strategy :: Strategy) t where
   toSExpressionWithStrategy :: proxy strategy -> t -> Int -> Builder
@@ -71,10 +68,3 @@ instance GToSExpression f => GToSExpression (M1 S s f) where
 
 instance ToSExpression k => GToSExpression (K1 R k) where
   gtoSExpression k = pure . toSExpression (unK1 k)
-
-
-data Expr = Var Identifier | Lam Identifier Expr | App Expr Expr | Int Integer
-  deriving (Generic)
-
-newtype Identifier = Identifier Text
-  deriving (Generic)

--- a/src/Serializing/SExpression/Precise.hs
+++ b/src/Serializing/SExpression/Precise.hs
@@ -13,6 +13,14 @@ serializeSExpression :: ToSExpression t => t -> Builder
 serializeSExpression t = toSExpression t 0 <> "\n"
 
 
+nl :: Int -> Builder
+nl n | n <= 0    = ""
+     | otherwise = "\n"
+
+pad :: Int -> Builder
+pad n = stringUtf8 (replicate (2 * n) ' ')
+
+
 class ToSExpression t where
   toSExpression :: t -> Int -> Builder
 
@@ -33,7 +41,7 @@ instance Show t => ToSExpressionWithStrategy 'Show t where
   toSExpressionWithStrategy _ t _ = stringUtf8 (show t)
 
 instance (Generic t, GToSExpression (Rep t)) => ToSExpressionWithStrategy 'Generic t where
-  toSExpressionWithStrategy _ t n = "(" <> fold (intersperse " " (gtoSExpression (from t) n)) <> ")"
+  toSExpressionWithStrategy _ t n = nl n <> pad n <> "(" <> fold (intersperse " " (gtoSExpression (from t) n)) <> ")"
 
 
 class GToSExpression f where


### PR DESCRIPTION
This PR adds a generic mechanism for s-expression serialization of precise ASTs, e.g. those generated by @aymannadeem’s TH derivation of datatypes from tree-sitter grammars: https://github.com/tree-sitter/haskell-tree-sitter/pull/90.

It does not actually hook this up internally anywhere and use it, however; that will happen sometime after the above PR is merged and a new version of the `tree-sitter` cabal package is pushed to hackage.