### PR TITLE
Match `FormalParameter` symbol

### DIFF
--- a/src/Data/Language.hs
+++ b/src/Data/Language.hs
@@ -134,10 +134,10 @@ languageForFilePath :: FilePath -> Language
 languageForFilePath = languageForType . takeExtension
 
 supportedExts :: [String]
-supportedExts = [".go", ".py", ".rb", ".js", ".ts"]
+supportedExts = [".go", ".py", ".rb", ".js", ".ts", ".php", ".phpt"]
 
 codeNavLanguages :: [Language]
-codeNavLanguages = [Go, Ruby, Python, JavaScript, TypeScript]
+codeNavLanguages = [Go, Ruby, Python, JavaScript, PHP, TypeScript]
 
 pathIsMinified :: FilePath -> Bool
 pathIsMinified = isExtensionOf ".min.js"

--- a/src/Language/PHP/Assignment.hs
+++ b/src/Language/PHP/Assignment.hs
@@ -388,7 +388,7 @@ anonymousFunctionCreationExpression = makeTerm <$> symbol AnonymousFunctionCreat
     makeFunction identifier parameters functionUseClause returnType statement = Declaration.Function [functionUseClause, returnType] identifier parameters statement
 
 parameters :: Assignment [Term]
-parameters = manyTerm (simpleParameter <|> variadicParameter)
+parameters = symbol FormalParameters *> children (manyTerm (simpleParameter <|> variadicParameter))
 
 simpleParameter :: Assignment Term
 simpleParameter = makeTerm <$> symbol SimpleParameter <*> children (makeAnnotation <$> (term typeDeclaration <|> emptyTerm) <*> (makeAssignment <$> location <*> term variableName <*> (term defaultArgumentSpecifier <|> emptyTerm)))


### PR DESCRIPTION
Based on a change to the way [parameter productions are produced in `tree-sitter-php`](https://github.com/tree-sitter/tree-sitter-php/pull/35), there is a named `formal_parameter` node that we are currently not handling correctly in PHP Assignment. This patch adds support for matching a `FormalParameter` symbol. This makes it possible for rules like `functionDefinition` and `methodDefinition` to assign without warnings.