### PR TITLE
Include vertex IDs in JSON graph output and fix their format.

### DIFF
--- a/src/Data/Graph.hs
+++ b/src/Data/Graph.hs
@@ -111,5 +111,5 @@ instance (Ord vertex, ToJSON vertex, VertexTag vertex) => ToJSON (Graph vertex) 
 newtype Edge vertex = Edge (vertex, vertex)
 
 instance (ToJSON vertex, VertexTag vertex) => ToJSON (Edge vertex) where
-  toJSON     (Edge (a, b)) = object ["source" .= uniqueTag a,   "target" .= uniqueTag b]
-  toEncoding (Edge (a, b)) = pairs  ("source" .= uniqueTag a <> "target" .= uniqueTag b)
+  toJSON     (Edge (a, b)) = object ["source" .= show (uniqueTag a),   "target" .= show (uniqueTag b)]
+  toEncoding (Edge (a, b)) = pairs  ("source" .= show (uniqueTag a) <>  "target" .= show (uniqueTag b))

--- a/src/Data/Graph/ControlFlowVertex.hs
+++ b/src/Data/Graph/ControlFlowVertex.hs
@@ -86,7 +86,14 @@ instance Lower ControlFlowVertex where lowerBound = Package ""
 instance VertexTag ControlFlowVertex where uniqueTag = hash . vertexIdentifier
 
 instance ToJSON ControlFlowVertex where
-  toJSON v = object [ "name" .= vertexIdentifier v, "type" .= vertexToType v ]
+  toJSON v = object [ "name" .= vertexIdentifier v
+                    , "type" .= vertexToType v
+                    , "id"   .= show (uniqueTag v)
+                    ]
+  toEncoding v = pairs $ mconcat [ "name" .= vertexIdentifier v
+                                 , "type" .= vertexToType v
+                                 , "id"   .= show (uniqueTag v)
+                                 ]
 
 -- TODO: This is potentially valuable just to get name's out of declarable things.
 -- Typeclasses to create 'ControlFlowVertex's from 'Term's. Also extracts


### PR DESCRIPTION
As reported in #189, the `edges` field of JSON graph output refers to
information not reflected in the rest of the output, specifically the
vertex IDs. This patch adds that information to the `ToJSON` instance
for `ControlFlowVertex`. It also includes a `toEncoding` instance for
a free speed boost.

During this patch, I realized that, because `hash` tends to return a
large number (since `Int` is 64-bit), we may run into errors when
decoding JSON. One example hash is `3500157981503982114`; passing that
to a JS engine's `Number.isSafeInteger` function returns false. The
correct thing to do here is return ids as strings, which I have done.
This is backwards-incompatible, but since this information was never
properly exposed, the impact is negligable.