### PR TITLE
Fix typos across semantic repository

### DIFF
--- a/src/Data/Abstract/Address/Monovariant.hs
+++ b/src/Data/Abstract/Address/Monovariant.hs
@@ -9,7 +9,7 @@ import Data.Abstract.Name
 import qualified Data.Set as Set
 import Prologue
 
--- | 'Monovariant' models using one address for a particular name. It trackes the set of values that a particular address takes and uses it's name to lookup in the store and only allocation if new.
+-- | 'Monovariant' models using one address for a particular name. It tracks the set of values that a particular address takes and uses it's name to lookup in the store and only allocation if new.
 newtype Monovariant = Monovariant { unMonovariant :: Name }
   deriving (Eq, Ord)
 

--- a/src/Data/Abstract/ScopeGraph.hs
+++ b/src/Data/Abstract/ScopeGraph.hs
@@ -76,7 +76,7 @@ instance Ord AccessControl where
   (<=) Private _           = True
   (<=) _       Private     = False
 
-  -- | Protected AccessControl is inbetween Private and Public in the order specification.
+  -- | Protected AccessControl is in between Private and Public in the order specification.
   -- Protected AccessControl "on the left" has access to Protected or Public AccessControls "on the right".
   (<=) Protected Public    = True
   (<=) Protected Protected = True

--- a/src/Language/Go/Assignment.hs
+++ b/src/Language/Go/Assignment.hs
@@ -661,6 +661,6 @@ manyTermsTill step end = manyTill (step <|> comment) end
 manyTerm :: Assignment Term -> Assignment [Term]
 manyTerm = many . term
 
--- | Match a term and contextualize any comments preceeding or proceeding the term.
+-- | Match a term and contextualize any comments preceding or proceeding the term.
 term :: Assignment Term -> Assignment Term
 term term' = contextualize comment term' <|> makeTerm1 <$> (Syntax.Context <$> some1 comment <*> emptyTerm)

--- a/src/Rendering/TOC.hs
+++ b/src/Rendering/TOC.hs
@@ -96,7 +96,7 @@ newtype DedupeKey = DedupeKey (T.Text, T.Text) deriving (Eq, Ord)
 -- different behaviors:
 -- 1. Identical entries are in the list.
 --    Action: take the first one, drop all subsequent.
--- 2. Two similar entries (defined by a case insensitive comparision of their
+-- 2. Two similar entries (defined by a case insensitive comparison of their
 --    identifiers) are in the list.
 --    Action: Combine them into a single Replaced entry.
 dedupe :: [Entry Declaration] -> [Entry Declaration]


### PR DESCRIPTION
:blue_heart: Fix typos across **semantic** repository

### Fixed files :wrench: 

<details><summary>See all fixed files</summary>
<p>

```
semantic/src/Data/Abstract/Address/Monovariant.hs:12:70: "trackes" is a misspelling of "trackers"
semantic/src/Data/Abstract/ScopeGraph.hs:79:34: "inbetween" is a misspelling of "between"
semantic/src/Language/Go/Assignment.hs:664:49: "preceeding" is a misspelling of "preceding"
semantic/src/Rendering/TOC.hs:99:57: "comparision" is a misspelling of "comparison"
```

</p>
</details>

**FYI:** I used [**Go Spellchecker**](https://github.com/liamzdenek/go-spellcheck) :smile_cat: