### PR TITLE
New options for readBlobsFromGitRepo

### DIFF
--- a/src/Semantic/CLI.hs
+++ b/src/Semantic/CLI.hs
@@ -133,7 +133,9 @@ tsParseCommand = command "ts-parse" (info tsParseArgumentsParser (progDesc "Gene
                       <$> option str (long "gitDir" <> help "A .git directory to read from")
                       <*> option shaReader (long "sha" <> help "The commit SHA1 to read from")
                       <*> ( ExcludePaths <$> many (option str (long "exclude" <> short 'x' <> help "Paths to exclude"))
-                        <|> ExcludeFromHandle <$> flag' stdin (long "exclude-stdin" <> help "Exclude paths given to stdin"))
+                        <|> ExcludeFromHandle <$> flag' stdin (long "exclude-stdin" <> help "Exclude paths given to stdin")
+                        <|> OnlyPaths <$> many (option str (long "only" <> help "Only include the specified paths"))
+                        <|> OnlyPathsFromHandle <$> flag' stdin (long "only-stdin" <> help "Include only the paths given to stdin"))
                   <|> FilesFromPaths <$> some (argument filePathReader (metavar "FILES..."))
                   <|> pure (FilesFromHandle stdin)
       pure $ Task.readBlobs filesOrStdin >>= AST.runASTParse format

--- a/src/Semantic/CLI.hs
+++ b/src/Semantic/CLI.hs
@@ -115,8 +115,8 @@ parseCommand = command "parse" (info parseArgumentsParser (progDesc "Generate pa
                       <*> option shaReader (long "sha" <> help "The commit SHA1 to read from")
                       <*> ( ExcludePaths <$> many (option str (long "exclude" <> short 'x' <> help "Paths to exclude"))
                         <|> ExcludeFromHandle <$> flag' stdin (long "exclude-stdin" <> help "Exclude paths given to stdin")
-                        <|> OnlyPaths <$> many (option str (long "only" <> help "Only include the specified paths"))
-                        <|> OnlyPathsFromHandle <$> flag' stdin (long "only-stdin" <> help "Include only the paths given to stdin"))
+                        <|> IncludePaths <$> many (option str (long "only" <> help "Only include the specified paths"))
+                        <|> IncludePathsFromHandle <$> flag' stdin (long "only-stdin" <> help "Include only the paths given to stdin"))
                   <|> FilesFromPaths <$> some (argument filePathReader (metavar "FILES..."))
                   <|> pure (FilesFromHandle stdin)
       pure $ Task.readBlobs filesOrStdin >>= renderer
@@ -134,8 +134,8 @@ tsParseCommand = command "ts-parse" (info tsParseArgumentsParser (progDesc "Gene
                       <*> option shaReader (long "sha" <> help "The commit SHA1 to read from")
                       <*> ( ExcludePaths <$> many (option str (long "exclude" <> short 'x' <> help "Paths to exclude"))
                         <|> ExcludeFromHandle <$> flag' stdin (long "exclude-stdin" <> help "Exclude paths given to stdin")
-                        <|> OnlyPaths <$> many (option str (long "only" <> help "Only include the specified paths"))
-                        <|> OnlyPathsFromHandle <$> flag' stdin (long "only-stdin" <> help "Include only the paths given to stdin"))
+                        <|> IncludePaths <$> many (option str (long "only" <> help "Only include the specified paths"))
+                        <|> IncludePathsFromHandle <$> flag' stdin (long "only-stdin" <> help "Include only the paths given to stdin"))
                   <|> FilesFromPaths <$> some (argument filePathReader (metavar "FILES..."))
                   <|> pure (FilesFromHandle stdin)
       pure $ Task.readBlobs filesOrStdin >>= AST.runASTParse format

--- a/src/Semantic/CLI.hs
+++ b/src/Semantic/CLI.hs
@@ -114,7 +114,9 @@ parseCommand = command "parse" (info parseArgumentsParser (progDesc "Generate pa
                       <$> option str (long "gitDir" <> help "A .git directory to read from")
                       <*> option shaReader (long "sha" <> help "The commit SHA1 to read from")
                       <*> ( ExcludePaths <$> many (option str (long "exclude" <> short 'x' <> help "Paths to exclude"))
-                        <|> ExcludeFromHandle <$> flag' stdin (long "exclude-stdin" <> help "Exclude paths given to stdin"))
+                        <|> ExcludeFromHandle <$> flag' stdin (long "exclude-stdin" <> help "Exclude paths given to stdin")
+                        <|> OnlyPaths <$> many (option str (long "only" <> help "Only include the specified paths"))
+                        <|> OnlyPathsFromHandle <$> flag' stdin (long "only-stdin" <> help "Include only the paths given to stdin"))
                   <|> FilesFromPaths <$> some (argument filePathReader (metavar "FILES..."))
                   <|> pure (FilesFromHandle stdin)
       pure $ Task.readBlobs filesOrStdin >>= renderer

--- a/src/Semantic/Task/Files.hs
+++ b/src/Semantic/Task/Files.hs
@@ -45,8 +45,8 @@ data Destination = ToPath FilePath | ToHandle (Handle 'IO.WriteMode)
 data PathFilter
   = ExcludePaths [FilePath]
   | ExcludeFromHandle (Handle 'IO.ReadMode)
-  | OnlyPaths [FilePath]
-  | OnlyPathsFromHandle (Handle 'IO.ReadMode)
+  | IncludePaths [FilePath]
+  | IncludePathsFromHandle (Handle 'IO.ReadMode)
 
 -- | An effect to read/write 'Blob's from 'Handle's or 'FilePath's.
 data Files (m :: * -> *) k
@@ -84,8 +84,8 @@ instance (Member (Error SomeException) sig, Member Catch sig, MonadIO m, Carrier
     Read (FromDir dir) k                                      -> rethrowing (readBlobsFromDir dir) >>= k
     Read (FromGitRepo path sha (ExcludePaths excludePaths)) k -> rethrowing (readBlobsFromGitRepo path sha excludePaths mempty) >>= k
     Read (FromGitRepo path sha (ExcludeFromHandle handle)) k  -> rethrowing (readPathsFromHandle handle >>= (\x -> readBlobsFromGitRepo path sha x mempty)) >>= k
-    Read (FromGitRepo path sha (OnlyPaths onlyPaths)) k       -> rethrowing (readBlobsFromGitRepo path sha mempty onlyPaths) >>= k
-    Read (FromGitRepo path sha (OnlyPathsFromHandle h)) k     -> rethrowing (readPathsFromHandle h >>= readBlobsFromGitRepo path sha mempty) >>= k
+    Read (FromGitRepo path sha (IncludePaths includePaths)) k -> rethrowing (readBlobsFromGitRepo path sha mempty includePaths) >>= k
+    Read (FromGitRepo path sha (IncludePathsFromHandle h)) k  -> rethrowing (readPathsFromHandle h >>= readBlobsFromGitRepo path sha mempty) >>= k
     Read (FromPathPair paths) k                               -> rethrowing (runBothWith readFilePair paths) >>= k
     Read (FromPairHandle handle) k                            -> rethrowing (readBlobPairsFromHandle handle) >>= k
     ReadProject rootDir dir language excludeDirs k            -> rethrowing (readProjectFromPaths rootDir dir language excludeDirs) >>= k

--- a/src/Semantic/Task/Files.hs
+++ b/src/Semantic/Task/Files.hs
@@ -14,7 +14,7 @@ module Semantic.Task.Files
   , Handle (..)
   , FilesC(..)
   , FilesArg(..)
-  , Excludes(..)
+  , PathFilter(..)
   ) where
 
 import           Control.Effect.Carrier
@@ -36,15 +36,17 @@ data Source blob where
   FromPath       :: File                            -> Source Blob
   FromHandle     :: Handle 'IO.ReadMode             -> Source [Blob]
   FromDir        :: FilePath                        -> Source [Blob]
-  FromGitRepo    :: FilePath -> Git.OID -> Excludes -> Source [Blob]
+  FromGitRepo    :: FilePath -> Git.OID -> PathFilter -> Source [Blob]
   FromPathPair   :: Both File                       -> Source BlobPair
   FromPairHandle :: Handle 'IO.ReadMode             -> Source [BlobPair]
 
 data Destination = ToPath FilePath | ToHandle (Handle 'IO.WriteMode)
 
-data Excludes
+data PathFilter
   = ExcludePaths [FilePath]
   | ExcludeFromHandle (Handle 'IO.ReadMode)
+  | OnlyPaths [FilePath]
+  | OnlyPathsFromHandle (Handle 'IO.ReadMode)
 
 -- | An effect to read/write 'Blob's from 'Handle's or 'FilePath's.
 data Files (m :: * -> *) k
@@ -80,8 +82,10 @@ instance (Member (Error SomeException) sig, Member Catch sig, MonadIO m, Carrier
     Read (FromPath path) k                                    -> rethrowing (readBlobFromFile' path) >>= k
     Read (FromHandle handle) k                                -> rethrowing (readBlobsFromHandle handle) >>= k
     Read (FromDir dir) k                                      -> rethrowing (readBlobsFromDir dir) >>= k
-    Read (FromGitRepo path sha (ExcludePaths excludePaths)) k -> rethrowing (readBlobsFromGitRepo path sha excludePaths) >>= k
-    Read (FromGitRepo path sha (ExcludeFromHandle handle)) k  -> rethrowing (readPathsFromHandle handle >>= readBlobsFromGitRepo path sha) >>= k
+    Read (FromGitRepo path sha (ExcludePaths excludePaths)) k -> rethrowing (readBlobsFromGitRepo path sha excludePaths mempty) >>= k
+    Read (FromGitRepo path sha (ExcludeFromHandle handle)) k  -> rethrowing (readPathsFromHandle handle >>= (\x -> readBlobsFromGitRepo path sha x mempty)) >>= k
+    Read (FromGitRepo path sha (OnlyPaths onlyPaths)) k       -> rethrowing (readBlobsFromGitRepo path sha mempty onlyPaths) >>= k
+    Read (FromGitRepo path sha (OnlyPathsFromHandle h)) k     -> rethrowing (readPathsFromHandle h >>= readBlobsFromGitRepo path sha mempty) >>= k
     Read (FromPathPair paths) k                               -> rethrowing (runBothWith readFilePair paths) >>= k
     Read (FromPairHandle handle) k                            -> rethrowing (readBlobPairsFromHandle handle) >>= k
     ReadProject rootDir dir language excludeDirs k            -> rethrowing (readProjectFromPaths rootDir dir language excludeDirs) >>= k
@@ -96,7 +100,7 @@ readBlob file = send (Read (FromPath file) pure)
 data FilesArg
   = FilesFromHandle (Handle 'IO.ReadMode)
   | FilesFromPaths [File]
-  | FilesFromGitRepo FilePath Git.OID Excludes
+  | FilesFromGitRepo FilePath Git.OID PathFilter
 
 -- | A task which reads a list of 'Blob's from a 'Handle' or a list of 'FilePath's optionally paired with 'Language's.
 readBlobs :: (Member Files sig, Carrier sig m, MonadIO m) => FilesArg -> m [Blob]
@@ -107,7 +111,7 @@ readBlobs (FilesFromPaths [path]) = do
     then send (Read (FromDir (filePath path)) pure)
     else pure <$> send (Read (FromPath path) pure)
 readBlobs (FilesFromPaths paths) = traverse (send . flip Read pure . FromPath) paths
-readBlobs (FilesFromGitRepo path sha excludes) = send (Read (FromGitRepo path sha excludes) pure)
+readBlobs (FilesFromGitRepo path sha filter) = send (Read (FromGitRepo path sha filter) pure)
 
 -- | A task which reads a list of pairs of 'Blob's from a 'Handle' or a list of pairs of 'FilePath's optionally paired with 'Language's.
 readBlobPairs :: (Member Files sig, Carrier sig m) => Either (Handle 'IO.ReadMode) [Both File] -> m [BlobPair]


### PR DESCRIPTION
Allows specifying only the paths you want to parse when reading from a git repo. This is the inverse of the existing args `--exclude` and `--exclude-stdin`.
