### PR TITLE
Git ls tree fixes

### DIFF
--- a/semantic.cabal
+++ b/semantic.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.4
 
 name:                semantic
-version:             0.6.0.0
+version:             0.7.0.0
 synopsis:            Framework and executable for analyzing and diffing untrusted code.
 description:         Semantic is a library for parsing, analyzing, and comparing source code across many languages.
 homepage:            http://github.com/github/semantic#readme

--- a/src/Semantic/Git.hs
+++ b/src/Semantic/Git.hs
@@ -60,8 +60,8 @@ entryParser = TreeEntry
   <*> oidParser <* AP.char '\t'
   <*> (unpack <$> AP.takeWhile (/= '\NUL'))
     where
-      typeParser = AP.choice [BlobObject <$ "blob", TreeObject <$ "tree"]
-      modeParser = AP.choice [NormalMode <$ "100644", ExecutableMode <$ "100755", SymlinkMode <$ "120000", TreeMode <$ "040000"]
+      typeParser = AP.choice [BlobObject <$ "blob", TreeObject <$ "tree", OtherObjectType <$ AP.takeWhile isAlphaNum]
+      modeParser = AP.choice [NormalMode <$ "100644", ExecutableMode <$ "100755", SymlinkMode <$ "120000", TreeMode <$ "040000", OtherMode <$ AP.takeWhile isAlphaNum]
       oidParser = OID <$> AP.takeWhile isHexDigit
 
 newtype OID = OID Text

--- a/test/Semantic/Spec.hs
+++ b/test/Semantic/Spec.hs
@@ -44,5 +44,10 @@ spec = do
       let expected = [ TreeEntry NormalMode TreeObject (OID "abcdef") "/this/is/the/path", TreeEntry SymlinkMode BlobObject (OID "17776") "/dev/urandom"]
       parseEntries input `shouldBe` expected
 
+    it "parses submodules and other types" $ do
+      let input = "160000 commit 50865e8895c54037bf06c4c1691aa925d030a59d\tgemoji"
+      let expected = Right $ TreeEntry OtherMode OtherObjectType (OID "50865e8895c54037bf06c4c1691aa925d030a59d") "gemoji"
+      parseEntry input `shouldBe` expected
+
   where
     methodsBlob = makeBlob "def foo\nend\n" "methods.rb" Ruby mempty


### PR DESCRIPTION
In the switch to autoparsec parsing of `git ls-tree` output (see #99) we lost the ability to handle things like commit objects (used for submodules) and other valid modes. Unfortunately things fail by just returning an empty list if parsing fails so this was a little challenging to catch.

This fixes the parsing and adds a test.