### PR TITLE
Source generators produce multiline strings

### DIFF
--- a/semantic.cabal
+++ b/semantic.cabal
@@ -397,11 +397,9 @@ test-suite test
                      , tasty-hedgehog ^>= 1.0.0.1
                      , tasty-hspec ^>= 1.1.5.1
                      , tasty-hunit ^>= 0.10.0.2
-                     , tasty-quickcheck ^>= 0.10
                      , HUnit ^>= 1.6.0.0
                      , leancheck >= 0.8 && <1
                      , temporary ^>= 1.3
-                     , QuickCheck ^>= 2.13
   if flag(release)
     ghc-options:       -dynamic
 

--- a/semantic.cabal
+++ b/semantic.cabal
@@ -397,9 +397,11 @@ test-suite test
                      , tasty-hedgehog ^>= 1.0.0.1
                      , tasty-hspec ^>= 1.1.5.1
                      , tasty-hunit ^>= 0.10.0.2
+                     , tasty-quickcheck ^>= 0.10
                      , HUnit ^>= 1.6.0.0
                      , leancheck >= 0.8 && <1
                      , temporary ^>= 1.3
+                     , QuickCheck ^>= 2.13
   if flag(release)
     ghc-options:       -dynamic
 

--- a/test/Data/Source/Spec.hs
+++ b/test/Data/Source/Spec.hs
@@ -99,5 +99,5 @@ insetRange Range {..} = Range (succ start) (pred end)
 
 
 instance QC.Arbitrary Source where
-  arbitrary = fromText . Text.pack <$> QC.listOf (QC.oneof [ pure '\r' , pure '\n' , QC.arbitraryUnicodeChar ])
+  arbitrary = fromText . Text.pack <$> QC.listOf (QC.oneof [ pure '\r', pure '\n', QC.arbitraryUnicodeChar ])
   shrink src = fromText . Text.pack <$> QC.shrinkList QC.shrinkNothing (Text.unpack (toText src))

--- a/test/Data/Source/Spec.hs
+++ b/test/Data/Source/Spec.hs
@@ -28,7 +28,7 @@ testTree :: Tasty.TestTree
 testTree = Tasty.testGroup "Data.Source"
   [ Tasty.testGroup "sourceLineRanges"
     [ QC.testProperty "produces 1 more range than there are newlines" $
-      \ source -> length (sourceLineRanges source) QC.=== succ (Text.count "\n" (toText source))
+      \ source -> QC.label (summarize source) $ length (sourceLineRanges source) QC.=== succ (Text.count "\n" (toText source))
 
     , prop "produces exhaustive ranges" $
       \ source -> foldMap (`slice` source) (sourceLineRanges source) === source
@@ -70,6 +70,9 @@ testTree = Tasty.testGroup "Data.Source"
     ]
 
   ]
+  where summarize src
+          | nullSource src = "empty"
+          | otherwise      = "non-empty"
 
 spec :: Spec
 spec = do

--- a/test/Data/Source/Spec.hs
+++ b/test/Data/Source/Spec.hs
@@ -29,7 +29,7 @@ testTree = Tasty.testGroup "Data.Source"
   [ Tasty.testGroup "sourceLineRanges"
     [ QC.testProperty "produces 1 more range than there are newlines" $
       \ source -> QC.label (summarize source) $
-        length (sourceLineRanges source) QC.=== succ (Text.count "\n" (toText source))
+        length (sourceLineRanges source) QC.=== length (Text.splitOn "\r\n" (toText source)>>= Text.splitOn "\r" >>= Text.splitOn "\n")
 
     , prop "produces exhaustive ranges" $
       \ source -> foldMap (`slice` source) (sourceLineRanges source) === source

--- a/test/Data/Source/Spec.hs
+++ b/test/Data/Source/Spec.hs
@@ -29,7 +29,7 @@ testTree = Tasty.testGroup "Data.Source"
   [ Tasty.testGroup "sourceLineRanges"
     [ QC.testProperty "produces 1 more range than there are newlines" $
       \ source -> QC.label (summarize source) $
-        length (sourceLineRanges source) QC.=== length (Text.splitOn "\r\n" (toText source)>>= Text.splitOn "\r" >>= Text.splitOn "\n")
+        length (sourceLineRanges source) QC.=== length (Text.splitOn "\r\n" (toText source) >>= Text.splitOn "\r" >>= Text.splitOn "\n")
 
     , QC.testProperty "produces exhaustive ranges" $
       \ source -> QC.label (summarize source) $

--- a/test/Data/Source/Spec.hs
+++ b/test/Data/Source/Spec.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -Wno-orphans #-}
 module Data.Source.Spec (spec, testTree) where
 
 import Data.Range

--- a/test/Data/Source/Spec.hs
+++ b/test/Data/Source/Spec.hs
@@ -28,7 +28,8 @@ testTree :: Tasty.TestTree
 testTree = Tasty.testGroup "Data.Source"
   [ Tasty.testGroup "sourceLineRanges"
     [ QC.testProperty "produces 1 more range than there are newlines" $
-      \ source -> QC.label (summarize source) $ length (sourceLineRanges source) QC.=== succ (Text.count "\n" (toText source))
+      \ source -> QC.label (summarize source) $
+        length (sourceLineRanges source) QC.=== succ (Text.count "\n" (toText source))
 
     , prop "produces exhaustive ranges" $
       \ source -> foldMap (`slice` source) (sourceLineRanges source) === source

--- a/test/Data/Source/Spec.hs
+++ b/test/Data/Source/Spec.hs
@@ -70,9 +70,10 @@ testTree = Tasty.testGroup "Data.Source"
     ]
 
   ]
-  where summarize src
-          | nullSource src = "empty"
-          | otherwise      = "non-empty"
+  where summarize src = case sourceLines src of
+          []  -> "empty"
+          [x] -> if nullSource x then "empty" else "single-line"
+          _   -> "multiple lines"
 
 spec :: Spec
 spec = do

--- a/test/Data/Source/Spec.hs
+++ b/test/Data/Source/Spec.hs
@@ -101,5 +101,5 @@ insetRange Range {..} = Range (succ start) (pred end)
 
 
 instance QC.Arbitrary Source where
-  arbitrary = fromText . Text.pack <$> QC.listOf (QC.oneof [ pure '\r', pure '\n', QC.arbitraryUnicodeChar ])
+  arbitrary = fromText . Text.pack <$> QC.listOf (QC.frequency [ (1, pure '\r'), (1, pure '\n'), (20, QC.arbitraryUnicodeChar) ])
   shrink src = fromText . Text.pack <$> QC.shrinkList QC.shrinkNothing (Text.unpack (toText src))

--- a/test/Data/Source/Spec.hs
+++ b/test/Data/Source/Spec.hs
@@ -31,8 +31,9 @@ testTree = Tasty.testGroup "Data.Source"
       \ source -> QC.label (summarize source) $
         length (sourceLineRanges source) QC.=== length (Text.splitOn "\r\n" (toText source)>>= Text.splitOn "\r" >>= Text.splitOn "\n")
 
-    , prop "produces exhaustive ranges" $
-      \ source -> foldMap (`slice` source) (sourceLineRanges source) === source
+    , QC.testProperty "produces exhaustive ranges" $
+      \ source -> QC.label (summarize source) $
+        foldMap (`slice` source) (sourceLineRanges source) QC.=== source
     ]
 
   , Tasty.testGroup "spanToRange"

--- a/test/Generators.hs
+++ b/test/Generators.hs
@@ -9,4 +9,4 @@ import qualified Data.Source
 import Data.Functor.Identity
 
 source :: (GenBase m ~ Identity, MonadGen m) => Hedgehog.Range Int -> m Data.Source.Source
-source r = Data.Source.fromUTF8 <$> Gen.utf8 r (Gen.choice [pure '\r', pure '\n', Gen.unicode])
+source r = Data.Source.fromUTF8 <$> Gen.utf8 r (Gen.frequency [ (1, pure '\r'), (1, pure '\n'), (20, Gen.unicode) ])

--- a/test/Generators.hs
+++ b/test/Generators.hs
@@ -9,4 +9,4 @@ import qualified Data.Source
 import Data.Functor.Identity
 
 source :: (GenBase m ~ Identity, MonadGen m) => Hedgehog.Range Int -> m Data.Source.Source
-source r = Data.Source.fromUTF8 <$> Gen.utf8 r Gen.unicode
+source r = Data.Source.fromUTF8 <$> Gen.utf8 r (Gen.choice [pure '\r', pure '\n', Gen.unicode])


### PR DESCRIPTION
This PR:

1. Corrects `Source` generation to produce multiline values, especially ones involving carriage returns as well as newlines.
2. Corrects the expectation of a `sourceLineRanges` property w.r.t. the number of lines produced to factor in carriage returns.
3. Labels the properties with 0/1/n lines, so we can see how many values were tested in each category.

Fixes #215.