### PR TITLE
Don't build twice on the builders.

### DIFF
--- a/semantic.cabal
+++ b/semantic.cabal
@@ -400,8 +400,6 @@ test-suite test
                      , HUnit ^>= 1.6.0.0
                      , leancheck >= 0.8 && <1
                      , temporary ^>= 1.3
-  if flag(release)
-    ghc-options:       -dynamic
 
 test-suite parse-examples
   import:              haskell, dependencies, executable-flags


### PR DESCRIPTION
This stray `-dynamic` was making us produce two object files. Distasteful.