### PR TITLE
Source coverage “guarantees”

### DIFF
--- a/test/Data/Source/Spec.hs
+++ b/test/Data/Source/Spec.hs
@@ -71,6 +71,7 @@ testTree = Tasty.testGroup "Data.Source"
   ]
   where summarize src = do
           let lines = sourceLines src
+          -- FIXME: this should be using cover (reverted in 1b427b995), but that leads to flaky tests: hedgehog’s 'cover' implementation fails tests instead of warning, and currently has no equivalent to 'checkCoverage'.
           classify "empty"          $ nullSource src
           classify "single-line"    $ length lines == 1
           classify "multiple lines" $ length lines >  1

--- a/test/Data/Source/Spec.hs
+++ b/test/Data/Source/Spec.hs
@@ -25,13 +25,11 @@ prop desc f
 testTree :: Tasty.TestTree
 testTree = Tasty.testGroup "Data.Source"
   [ Tasty.testGroup "sourceLineRanges"
-    [ testProperty "produces 1 more range than there are newlines" $ property $ do
-        source <- forAll (Gen.source (Hedgehog.Range.linear 0 100))
+    [ prop "produces 1 more range than there are newlines" $ \ source -> do
         label (summarize source)
-        (length (sourceLineRanges source) === length (Text.splitOn "\r\n" (toText source) >>= Text.splitOn "\r" >>= Text.splitOn "\n"))
+        length (sourceLineRanges source) === length (Text.splitOn "\r\n" (toText source) >>= Text.splitOn "\r" >>= Text.splitOn "\n")
 
-    , testProperty "produces exhaustive ranges" $ property $ do
-        source <- forAll (Gen.source (Hedgehog.Range.linear 0 100))
+    , prop "produces exhaustive ranges" $ \ source -> do
         label (summarize source)
         foldMap (`slice` source) (sourceLineRanges source) === source
     ]

--- a/test/Data/Source/Spec.hs
+++ b/test/Data/Source/Spec.hs
@@ -72,9 +72,9 @@ testTree = Tasty.testGroup "Data.Source"
   ]
   where summarize src = do
           let lines = sourceLines src
-          classify "empty"          $ nullSource src
-          classify "single-line"    $ length lines == 1
-          classify "multiple lines" $ length lines >  1
+          cover  5 "empty"          $ nullSource src
+          cover 20 "single-line"    $ length lines == 1
+          cover 50 "multiple lines" $ length lines >  1
 
 spec :: Spec
 spec = do

--- a/test/Data/Source/Spec.hs
+++ b/test/Data/Source/Spec.hs
@@ -26,11 +26,11 @@ testTree :: Tasty.TestTree
 testTree = Tasty.testGroup "Data.Source"
   [ Tasty.testGroup "sourceLineRanges"
     [ prop "produces 1 more range than there are newlines" $ \ source -> do
-        label (summarize source)
+        summarize source
         length (sourceLineRanges source) === length (Text.splitOn "\r\n" (toText source) >>= Text.splitOn "\r" >>= Text.splitOn "\n")
 
     , prop "produces exhaustive ranges" $ \ source -> do
-        label (summarize source)
+        summarize source
         foldMap (`slice` source) (sourceLineRanges source) === source
     ]
 
@@ -70,7 +70,7 @@ testTree = Tasty.testGroup "Data.Source"
     ]
 
   ]
-  where summarize src = case sourceLines src of
+  where summarize src = label $ case sourceLines src of
           []  -> "empty"
           [x] -> if nullSource x then "empty" else "single-line"
           _   -> "multiple lines"

--- a/test/Data/Source/Spec.hs
+++ b/test/Data/Source/Spec.hs
@@ -8,10 +8,9 @@ import qualified Data.Text as Text
 import Test.Hspec
 
 import qualified Generators as Gen
-import qualified Hedgehog.Gen as Gen
-import           Hedgehog ((===))
-import qualified Hedgehog.Range
 import           Hedgehog hiding (Range)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range
 import qualified Test.Tasty as Tasty
 import           Test.Tasty.Hedgehog (testProperty)
 

--- a/test/Data/Source/Spec.hs
+++ b/test/Data/Source/Spec.hs
@@ -9,7 +9,7 @@ import Test.Hspec
 
 import qualified Generators as Gen
 import qualified Hedgehog.Gen as Gen
-import           Hedgehog ((===), label)
+import           Hedgehog ((===))
 import qualified Hedgehog.Range
 import           Hedgehog hiding (Range)
 import qualified Test.Tasty as Tasty
@@ -70,10 +70,11 @@ testTree = Tasty.testGroup "Data.Source"
     ]
 
   ]
-  where summarize src = label $ case sourceLines src of
-          []  -> "empty"
-          [x] -> if nullSource x then "empty" else "single-line"
-          _   -> "multiple lines"
+  where summarize src = do
+          let lines = sourceLines src
+          classify "empty"          $ nullSource src
+          classify "single-line"    $ length lines == 1
+          classify "multiple lines" $ length lines >  1
 
 spec :: Spec
 spec = do

--- a/test/Data/Source/Spec.hs
+++ b/test/Data/Source/Spec.hs
@@ -72,9 +72,9 @@ testTree = Tasty.testGroup "Data.Source"
   ]
   where summarize src = do
           let lines = sourceLines src
-          cover  5 "empty"          $ nullSource src
-          cover 20 "single-line"    $ length lines == 1
-          cover 50 "multiple lines" $ length lines >  1
+          classify "empty"          $ nullSource src
+          classify "single-line"    $ length lines == 1
+          classify "multiple lines" $ length lines >  1
 
 spec :: Spec
 spec = do

--- a/test/Generators.hs
+++ b/test/Generators.hs
@@ -9,4 +9,6 @@ import qualified Data.Source
 import Data.Functor.Identity
 
 source :: (GenBase m ~ Identity, MonadGen m) => Hedgehog.Range Int -> m Data.Source.Source
-source r = Data.Source.fromUTF8 <$> Gen.utf8 r (Gen.frequency [ (1, pure '\r'), (1, pure '\n'), (20, Gen.unicode) ])
+source r = Gen.frequency [ (1, empty), (20, nonEmpty) ]
+  where empty    = pure mempty
+        nonEmpty = Data.Source.fromUTF8 <$> Gen.utf8 r (Gen.frequency [ (1, pure '\r'), (1, pure '\n'), (20, Gen.unicode) ])


### PR DESCRIPTION
This PR tidies up the `sourceLineRanges` tests a little further and lays some groundwork for testing the distribution itself. Unfortunately, this is blocked due to limitations of `hedgehog`: `cover` fails tests (which would lead to flakiness), and there’s no statistically-sound means to check coverage like QuickCheck’s `checkCoverage` (altho cf https://github.com/hedgehogqa/haskell-hedgehog/pull/288).

🎩 @patrickt
🎩 John Hughes’ _[Building on developers’ intuitions to create effective property-based tests](https://www.youtube.com/watch?v=NcJOiQlzlXQ)_