### PR TITLE
Switch over to using lingo for language detection

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,3 +14,8 @@ source-repository-package
   type: git
   location: https://github.com/joshvera/proto3-wire.git
   tag: 84664e22f01beb67870368f1f88ada5d0ad01f56
+
+source-repository-package
+  type: git
+  location: https://github.com/tclem/lingo-haskell.git
+  tag: 7a453568556d7b6ab6fb4573b158b41cef56f7cc

--- a/semantic.cabal
+++ b/semantic.cabal
@@ -73,6 +73,7 @@ common dependencies
                      , unix ^>= 2.7.2.2
                      , proto3-suite
                      , proto3-wire
+                     , lingo
 
 common executable-flags
   ghc-options:         -threaded -rtsopts "-with-rtsopts=-N -A4m -n2m"

--- a/src/Data/Blob/IO.hs
+++ b/src/Data/Blob/IO.hs
@@ -38,7 +38,7 @@ readBlobsFromDir :: MonadIO m => FilePath -> m [Blob]
 readBlobsFromDir path = liftIO . fmap catMaybes $
   findFilesInDir path supportedExts mempty >>= Async.mapConcurrently (readBlobFromFile . fileForPath)
 
--- | Read all blobs from the Git repo with Language.supportedExts
+-- | Read all blobs from a git repo
 readBlobsFromGitRepo :: MonadIO m => FilePath -> Git.OID -> [FilePath] -> [FilePath] -> m [Blob]
 readBlobsFromGitRepo path oid excludePaths includePaths = liftIO . fmap catMaybes $
   Git.lsTree path oid >>= Async.mapConcurrently (blobFromTreeEntry path)

--- a/src/Data/Language.hs
+++ b/src/Data/Language.hs
@@ -7,12 +7,12 @@ module Data.Language
   , knownLanguage
   , languageForFilePath
   , pathIsMinified
-  , languageForType
   , supportedExts
   , codeNavLanguages
   ) where
 
 import           Data.Aeson
+import qualified Data.Languages as Lingo
 import qualified Data.Text as T
 import           Prologue
 import           System.FilePath.Posix
@@ -98,25 +98,6 @@ parseLanguage l = case T.toLower l of
 knownLanguage :: Language -> Bool
 knownLanguage = (/= Unknown)
 
--- | Returns a Language based on the file extension (including the ".").
-languageForType :: String -> Language
-languageForType mediaType = case mediaType of
-    ".java" -> Java
-    ".json" -> JSON
-    ".hs"   -> Haskell
-    ".md"   -> Markdown
-    ".rb"   -> Ruby
-    ".go"   -> Go
-    ".js"   -> JavaScript
-    ".mjs"  -> JavaScript
-    ".ts"   -> TypeScript
-    ".tsx"  -> TSX
-    ".jsx"  -> JSX
-    ".py"   -> Python
-    ".php"  -> PHP
-    ".phpt" -> PHP
-    _       -> Unknown
-
 extensionsForLanguage :: Language -> [String]
 extensionsForLanguage language = case language of
   Go         -> [".go"]
@@ -130,9 +111,22 @@ extensionsForLanguage language = case language of
   JSX        -> [".jsx"]
   _          -> []
 
--- | Return a language based on a FilePath's extension, or Nothing if extension is not found or not supported.
+-- | Return a language based on a FilePath's extension.
 languageForFilePath :: FilePath -> Language
-languageForFilePath = languageForType . takeExtension
+languageForFilePath path = case Lingo.languageName <$> Lingo.languageForPath path of
+  Just "Go" -> Go
+  Just "Haskell" -> Haskell
+  Just "Java" -> Java
+  Just "JavaScript" -> JavaScript
+  Just "JSON" -> JSON
+  Just "JSX" -> JSX
+  Just "Markdown" -> Markdown
+  Just "PHP" -> PHP
+  Just "Python" -> Python
+  Just "Ruby" -> Ruby
+  Just "TSX" -> TSX
+  Just "TypeScript" -> TypeScript
+  _ -> Unknown
 
 supportedExts :: [String]
 supportedExts = [".go", ".py", ".rb", ".js", ".mjs", ".ts", ".php", ".phpt"]


### PR DESCRIPTION
Right now semantic uses some very basic file extension matching for language detection. This moves us toward a slightly more sophisticated approach based on linguist's canonical list of [languages](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml).

I don't think we're ready to pull in a full dependency on linguist (it's a ruby gem), but this is a nice intermediate step. Lingo does some compile time map generation of extensions and common filenames to language, allowing fast lookups. We don't support anything where languages share a file extension (first one wins), but that's not an issue for the languages we currently target. 