### PR TITLE
Don't load pretty-show/hscolour by default. (#16)

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,6 +1,3 @@
--- Load the pretty-show & hscolour packages for use with :pretty.
-:set -package pretty-show -package hscolour
-
 -- See docs/💡ProTip!.md
 :def! pretty \ _ -> return ":set -interactive-print Semantic.Util.Pretty.prettyShow"
 :def! no-pretty \_ -> return ":set -interactive-print System.IO.print"


### PR DESCRIPTION
As @mpickering pointed out, this breaks `new-repl` if you have
multiple versions of `pretty-show` in your package store.