### PR TITLE
Assignment error in Java try/catch blocks (#235)

### DIFF
--- a/src/Language/Java/Assignment.hs
+++ b/src/Language/Java/Assignment.hs
@@ -452,7 +452,7 @@ throw :: Assignment Term
 throw = makeTerm <$> symbol ThrowStatement <*> children (Statement.Throw <$> term expression)
 
 try :: Assignment Term
-try = (symbol TryStatement *> children tryWithResources) <|> standardTry
+try = symbol TryStatement *> children tryWithResources <|> standardTry
 
 standardTry :: Assignment Term
 standardTry = makeTerm <$> symbol TryStatement <*> children (Statement.Try <$> term expression <*> (append <$> optional catches <*> optional finally))

--- a/src/Language/Java/Assignment.hs
+++ b/src/Language/Java/Assignment.hs
@@ -452,16 +452,19 @@ throw :: Assignment Term
 throw = makeTerm <$> symbol ThrowStatement <*> children (Statement.Throw <$> term expression)
 
 try :: Assignment Term
-try = symbol TryStatement *> children tryWithResources <|> makeTerm <$> symbol TryStatement <*> children (Statement.Try <$> term expression <*> (append <$> optional catches <*> optional finally))
+try = (symbol TryStatement *> children tryWithResources) <|> standardTry
+
+standardTry :: Assignment Term
+standardTry = makeTerm <$> symbol TryStatement <*> children (Statement.Try <$> term expression <*> (append <$> optional catches <*> optional finally))
 
 catches :: Assignment [Term]
 catches = symbol Catches *> children (manyTerm catch)
   where
-    catch = makeTerm <$> symbol CatchClause <*> children (Statement.Catch <$> catchFormalParameter <*> term expression)
+    catch = makeTerm <$> symbol CatchClause <*> children (Statement.Catch <$> catchFormalParameter <*> block)
     catchFormalParameter = makeTerm <$> symbol CatchFormalParameter <*> children (flip Type.Annotation <$> catchType <* symbol VariableDeclaratorId <*> children identifier)
 
 catchType :: Assignment Term
-catchType = makeTerm <$> symbol CatchType <*> (Java.Syntax.CatchType <$> many type')
+catchType = makeTerm <$> symbol CatchType <*> children (Java.Syntax.CatchType <$> many type')
 
 finally :: Assignment Term
 finally = makeTerm <$> symbol Finally <*> children (Statement.Finally <$> term expression)

--- a/test/fixtures/java/corpus/try.java
+++ b/test/fixtures/java/corpus/try.java
@@ -1,0 +1,9 @@
+public class Bar {
+  public void foo() {
+    try {
+      System.out.println(1/0);
+    } catch (Exception e) {
+      e.printStackTrace(System.out);
+    }
+  }
+}

--- a/test/fixtures/java/corpus/try_with_resources.java
+++ b/test/fixtures/java/corpus/try_with_resources.java
@@ -1,0 +1,9 @@
+public class Bar {
+  public void foo() {
+   try (BufferedReader br = new BufferedReader()) {
+      System.out.println(1/0);
+    } catch (Exception e) {
+      e.printStackTrace(System.out);
+    }
+  }
+}


### PR DESCRIPTION
As @tclem pointed out, the TryStatement token was being consumed too
early. We also ran into errors within the `catches` clause where we
required a block but were asking for an expression.