### PR TITLE
Bump tree-sitter-php to 0.1.0.1.

### DIFF
--- a/semantic.cabal
+++ b/semantic.cabal
@@ -322,7 +322,7 @@ library
                      , tree-sitter-go ^>= 0.1.0.0
                      , tree-sitter-haskell ^>= 0.1.0.0
                      , tree-sitter-json ^>= 0.1.0.0
-                     , tree-sitter-php ^>= 0.1.0.0
+                     , tree-sitter-php ^>= 0.1.0.1
                      , tree-sitter-python ^>= 0.2.0.0
                      , tree-sitter-ruby ^>= 0.1.0.0
                      , tree-sitter-typescript ^>= 0.1.0.0


### PR DESCRIPTION
This fixes associativity bugs in the PHP grammar.