### PR TITLE
semantic-python: compile early and terminating return statements

### DIFF
--- a/semantic-python/semantic-python.cabal
+++ b/semantic-python/semantic-python.cabal
@@ -64,6 +64,7 @@ test-suite test
                , directory ^>= 1.3.3
                , exceptions ^>= 0.10.2
                , filepath ^>= 1.4.2.1
+               , pretty-show ^>= 1.9.5
                , process ^>= 1.6.5
                , streaming ^>= 0.2.2
                , streaming-process ^>= 0.1

--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -1,10 +1,6 @@
-<<<<<<< HEAD
 {-# LANGUAGE DefaultSignatures, DeriveAnyClass, DerivingStrategies, DerivingVia, DisambiguateRecordFields,
              FlexibleContexts, FlexibleInstances, NamedFieldPuns, OverloadedStrings, ScopedTypeVariables,
              StandaloneDeriving, TypeOperators, UndecidableInstances, DeriveGeneric #-}
-=======
-{-# LANGUAGE DefaultSignatures, DisambiguateRecordFields, FlexibleContexts, FlexibleInstances, OverloadedStrings, OverloadedLists, ScopedTypeVariables, NamedFieldPuns, TypeOperators #-}
->>>>>>> bump-to-tree-sitter-0.2.1
 module Language.Python.Core
 ( compile
 ) where

--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DefaultSignatures, DeriveAnyClass, DerivingStrategies, DerivingVia, DisambiguateRecordFields,
-             FlexibleContexts, FlexibleInstances, NamedFieldPuns, OverloadedStrings, ScopedTypeVariables,
+             FlexibleContexts, FlexibleInstances, NamedFieldPuns, OverloadedStrings, OverloadedLists, ScopedTypeVariables,
              StandaloneDeriving, TypeOperators, UndecidableInstances, DeriveGeneric #-}
 module Language.Python.Core
 ( compile
@@ -63,12 +63,10 @@ instance Compile (Py.AugmentedAssignment Span)
 instance Compile (Py.Await Span)
 instance Compile (Py.BinaryOperator Span)
 
-instance Compile (Py.Block Span)
-
 instance Compile (Py.Block Span) where
   compile t = compileCC t (pure none)
 
-  compileCC (Py.Block body) cc = foldr compileCC cc body
+  compileCC Py.Block{ Py.extraChildren = body} cc = foldr compileCC cc body
 
 instance Compile (Py.BooleanOperator Span)
 instance Compile (Py.BreakStatement Span)
@@ -76,7 +74,7 @@ instance Compile (Py.Call Span)
 instance Compile (Py.ClassDefinition Span)
 instance Compile (Py.ComparisonOperator Span)
 
-deriving via CompileSum (Py.CompoundStatement Span) instance Compile Py.CompoundStatement
+deriving via CompileSum (Py.CompoundStatement Span) instance Compile (Py.CompoundStatement Span)
 
 instance Compile (Py.ConcatenatedString Span)
 instance Compile (Py.ConditionalExpression Span)
@@ -88,7 +86,7 @@ instance Compile (Py.DictionaryComprehension Span)
 instance Compile (Py.Ellipsis Span)
 instance Compile (Py.ExecStatement Span)
 
-instance Compile (Py.Expression Span) where compile = compileSum
+deriving via CompileSum (Py.Expression Span) instance Compile (Py.Expression Span)
 
 instance Compile (Py.ExpressionStatement Span) where
   compile Py.ExpressionStatement { Py.extraChildren = children } = do

--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -131,7 +131,7 @@ instance Compile (Py.Identifier Span) where
   compile Py.Identifier { bytes } = pure (pure bytes)
 
 instance Compile (Py.IfStatement Span) where
-  compile stmt = compileCC stmt none
+  compile stmt = compileCC stmt (pure none)
 
   compileCC Py.IfStatement{ condition, consequence, alternative} cc =
     if' <$> compile condition <*> compileCC consequence cc <*> foldr clause cc alternative

--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -59,7 +59,8 @@ instance Compile Py.BinaryOperator
 instance Compile Py.Block where
   compile t = compileCC t (pure none)
 
-  compileCC (Py.Block body) cc = foldr compileCC cc body
+  -- BUG: working around https://github.com/tree-sitter/haskell-tree-sitter/issues/195
+  compileCC (Py.Block body) cc = foldr compileCC cc (reverse body)
 
 instance Compile Py.BooleanOperator
 instance Compile Py.BreakStatement

--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -161,7 +161,16 @@ instance Compile (Py.PassStatement Span) where
 deriving via CompileSum (Py.PrimaryExpression Span) instance Compile (Py.PrimaryExpression Span)
 
 instance Compile (Py.PrintStatement Span)
-instance Compile (Py.ReturnStatement Span)
+
+instance Compile (Py.ReturnStatement Span) where
+  compile Py.ReturnStatement { Py.extraChildren = vals } = case vals of
+    Nothing -> pure none
+    Just Py.ExpressionList { extraChildren = [val] } -> compile val
+    Just Py.ExpressionList { extraChildren = vals  } -> fail ("unimplemented: return statement returning " <> show (length vals) <> " values")
+
+  compileCC r _ = compile r
+
+
 instance Compile (Py.RaiseStatement Span)
 instance Compile (Py.Set Span)
 instance Compile (Py.SetComprehension Span)

--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -65,7 +65,8 @@ instance Compile Py.BinaryOperator
 instance Compile Py.Block where
   compile t = compileCC t (pure none)
 
-  -- BUG: working around https://github.com/tree-sitter/haskell-tree-sitter/issues/195
+  -- The call to 'reverse' works around https://github.com/tree-sitter/haskell-tree-sitter/issues/195
+  -- This will be obviated when we upgrade to tree-sitter-python 0.3
   compileCC (Py.Block body) cc = foldr compileCC cc (reverse body)
 
 instance Compile Py.BooleanOperator

--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -68,7 +68,9 @@ instance Compile Py.Call
 instance Compile Py.ClassDefinition
 instance Compile Py.ComparisonOperator
 
-instance Compile Py.CompoundStatement where compile = compileSum
+instance Compile Py.CompoundStatement where
+  compile = compileSum
+  compileCC = compileCCSum
 
 instance Compile Py.ConcatenatedString
 instance Compile Py.ConditionalExpression
@@ -127,6 +129,12 @@ instance Compile Py.IfStatement where
     where clause (Right Py.ElseClause{ body }) _ = compile body
           clause (Left  Py.ElifClause{ condition, consequence }) rest  =
             if' <$> compile condition <*> compile consequence <*> rest
+
+  compileCC Py.IfStatement{ condition, consequence, alternative} cc =
+    if' <$> compile condition <*> compileCC consequence cc <*> foldr clause cc alternative
+    where clause (Right Py.ElseClause{ body }) _ = compileCC body cc
+          clause (Left  Py.ElifClause{ condition, consequence }) rest  =
+            if' <$> compile condition <*> compileCC consequence cc <*> rest
 
 
 instance Compile Py.ImportFromStatement

--- a/semantic-python/test/Test.hs
+++ b/semantic-python/test/Test.hs
@@ -34,6 +34,7 @@ import           System.FilePath
 import qualified TreeSitter.Python as TSP
 import qualified TreeSitter.Python.AST as TSP
 import qualified TreeSitter.Unmarshal as TS
+import           Text.Show.Pretty (ppShow)
 
 import qualified Test.Tasty as Tasty
 import qualified Test.Tasty.HUnit as HUnit
@@ -42,8 +43,8 @@ import           Analysis.ScopeGraph
 import qualified Directive
 import           Instances ()
 
-assertJQExpressionSucceeds :: Directive.Directive -> Term (Ann :+: Core) Name -> HUnit.Assertion
-assertJQExpressionSucceeds directive core = do
+assertJQExpressionSucceeds :: Show a => Directive.Directive -> a -> Term (Ann :+: Core) Name -> HUnit.Assertion
+assertJQExpressionSucceeds directive tree core = do
   bod <- case scopeGraph Eval.eval [File interactive core] of
     (heap, [File _ (Right result)]) -> pure $ Aeson.object
       [ "scope" Aeson..= heap
@@ -58,10 +59,13 @@ assertJQExpressionSucceeds directive core = do
       errorMsg = "jq(1) returned non-zero exit code"
       dirMsg    = "jq expression: " <> show directive
       jsonMsg   = "JSON value: " <> ByteString.Lazy.unpack (Aeson.encodePretty bod)
-      treeMsg   = "Core expr: " <> showCore (stripAnnotations core)
+      astMsg    = "AST (pretty): " <> ppShow tree
+      treeMsg   = "Core expr (pretty): " <> showCore (stripAnnotations core)
+      treeMsg'  = "Core expr (Show): " <> ppShow (stripAnnotations core)
+
 
   catch @_ @Streaming.Process.ProcessExitedUnsuccessfully jqPipeline $ \err -> do
-    HUnit.assertFailure (unlines [errorMsg, dirMsg, jsonMsg, treeMsg, show err])
+    HUnit.assertFailure (unlines [errorMsg, dirMsg, jsonMsg, astMsg, treeMsg, treeMsg', show err])
 
 fixtureTestTreeForFile :: HasCallStack => FilePath -> Tasty.TestTree
 fixtureTestTreeForFile fp = HUnit.testCaseSteps fp $ \step -> withFrozenCallStack $ do
@@ -78,7 +82,7 @@ fixtureTestTreeForFile fp = HUnit.testCaseSteps fp $ \step -> withFrozenCallStac
       Left err           -> HUnit.assertFailure ("Parsing failed: " <> err)
       Right (Left _)     | directive == Directive.Fails -> pure ()
       Right (Right _)    | directive == Directive.Fails -> HUnit.assertFailure ("Expected translation to fail")
-      Right (Right item) -> assertJQExpressionSucceeds directive item
+      Right (Right item) -> assertJQExpressionSucceeds directive result item
       Right (Left err)   -> HUnit.assertFailure ("Compilation failed: " <> err)
 
 

--- a/semantic-python/test/fixtures/2-01-return-statement.py
+++ b/semantic-python/test/fixtures/2-01-return-statement.py
@@ -1,0 +1,3 @@
+# CHECK-JQ: .tree.contents[0][1].contents[1].contents.value == []
+def foo(a):
+    return a

--- a/semantic-python/test/fixtures/2-02-return-doesnt-translate.py
+++ b/semantic-python/test/fixtures/2-02-return-doesnt-translate.py
@@ -1,0 +1,6 @@
+# CHECK-JQ: .tree.contents[0][1].contents[1].contents.value == []
+
+def foo(a):
+    return a
+    a
+    ()

--- a/semantic-python/test/fixtures/2-03-return-in-if-statement.py
+++ b/semantic-python/test/fixtures/2-03-return-in-if-statement.py
@@ -1,0 +1,7 @@
+# CHECK-JQ: .tree.contents[0][1].contents[1] | .tag == "Lam" and .contents.value.tag == "If"
+# CHECK-JQ: .tree.contents[0][1].contents[1].contents.value | .contents == [[], [], { "tag": "Unit" }]
+
+def foo(a):
+    if a: return a
+    return ()
+    ()


### PR DESCRIPTION
Because Python, unlike Ruby, has no implicit returns, it’s important for testing purposes to provide some sort of support for `return` statements. This patch augments the `Compile` typeclass to allow this.

Huge, huge 🎩 to @robrix, whose guidance as to how to implement early returns was really essential.