### PR TITLE
Fix a JavaScript import syntax error in comments

### DIFF
--- a/src/Language/TSX/Assignment.hs
+++ b/src/Language/TSX/Assignment.hs
@@ -726,7 +726,7 @@ importStatement :: Assignment Term
 importStatement =   makeImportTerm <$> symbol Grammar.ImportStatement <*> children ((,) <$> importClause <*> fromClause)
                 <|> makeTerm' <$> symbol Grammar.ImportStatement <*> children (requireImport <|> sideEffectImport)
   where
-    -- `import foo = require "./foo"`
+    -- `import foo = require("./foo")`
     requireImport = inject <$> (symbol Grammar.ImportRequireClause *> children (TSX.Syntax.QualifiedAliasedImport <$> term identifier <*> fromClause))
     -- `import "./foo"`
     sideEffectImport = inject <$> (TSX.Syntax.SideEffectImport <$> fromClause)

--- a/src/Language/TypeScript/Assignment.hs
+++ b/src/Language/TypeScript/Assignment.hs
@@ -679,7 +679,7 @@ importStatement :: Assignment Term
 importStatement =   makeImportTerm <$> symbol Grammar.ImportStatement <*> children ((,) <$> importClause <*> fromClause)
                 <|> makeTerm' <$> symbol Grammar.ImportStatement <*> children (requireImport <|> sideEffectImport)
   where
-    -- `import foo = require "./foo"`
+    -- `import foo = require("./foo")`
     requireImport = inject <$> (symbol Grammar.ImportRequireClause *> children (TypeScript.Syntax.QualifiedAliasedImport <$> term identifier <*> fromClause))
     -- `import "./foo"`
     sideEffectImport = inject <$> (TypeScript.Syntax.SideEffectImport <$> fromClause)


### PR DESCRIPTION
The `require` is a function that should be followed by parentheses.