### PR TITLE
Log source paths and more error details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ stack.yaml.lock
 profiles
 /tags
 
-cabal.project.local
+cabal.project.local*
 dist
 dist-newstyle
 .ghc.environment.*

--- a/src/Semantic/CLI.hs
+++ b/src/Semantic/CLI.hs
@@ -57,7 +57,7 @@ main = do
   (options, task) <- customExecParser (prefs showHelpOnEmpty) arguments
   config <- defaultConfig options
   res <- withTelemetry config $ \ (TelemetryQueues logger statter _) ->
-    Task.runTask (Task.TaskSession config "-" False logger statter) task
+    Task.runTask (Task.TaskSession config "-" (optionsLogPathsOnError options) logger statter) task
   either (die . displayException) pure res
 
 -- | A parser for the application's command-line arguments.
@@ -76,7 +76,8 @@ optionsParser = do
                       (long "log-level" <> value (Just Log.Warning) <> help "Log messages at or above this level, or disable logging entirely.")
   failOnWarning <- switch (long "fail-on-warning" <> help "Fail on assignment warnings.")
   failOnParseError <- switch (long "fail-on-parse-error" <> help "Fail on tree-sitter parse errors.")
-  pure $ Options logLevel (Flag.flag FailOnWarning failOnWarning) (Flag.flag FailOnParseError failOnParseError)
+  logPathsOnError <- switch (long "log-paths" <> help "Log source paths on parse and assignment error.")
+  pure $ Options logLevel logPathsOnError (Flag.flag FailOnWarning failOnWarning) (Flag.flag FailOnParseError failOnParseError)
 
 argumentsParser :: Parser (Task.TaskEff ())
 argumentsParser = do

--- a/src/Semantic/Config.hs
+++ b/src/Semantic/Config.hs
@@ -61,12 +61,13 @@ data Config
 data Options
   = Options
   { optionsLogLevel         :: Maybe Level           -- ^ What level of messages to log. 'Nothing' disables logging.
+  , optionsLogPathsOnError  :: Bool                  -- ^ Should semantic log source path on parse or assignment errors (default: False).
   , optionsFailOnWarning    :: Flag FailOnWarning    -- ^ Should semantic fail fast on assignment warnings (for testing)
   , optionsFailOnParseError :: Flag FailOnParseError -- ^ Should semantic fail fast on tree-sitter parser errors (for testing)
   }
 
 defaultOptions :: Options
-defaultOptions = Options (Just Warning) (flag FailOnWarning False) (flag FailOnParseError False)
+defaultOptions = Options (Just Warning) False (flag FailOnWarning False) (flag FailOnParseError False)
 
 debugOptions :: Options
 debugOptions = defaultOptions { optionsLogLevel = Just Debug }


### PR DESCRIPTION
Adds a new CLI switch, `--log-paths`, to log more information on parse or assignment error. This was hardcoded to false as part of protecting us from logging details about private source code and the default is still false, but now there's an option to turn on this logging as it is helpful for debugging.