### PR TITLE
New version of lingo-haskell

### DIFF
--- a/semantic.cabal
+++ b/semantic.cabal
@@ -73,7 +73,7 @@ common dependencies
                      , unix ^>= 2.7.2.2
                      , proto3-suite
                      , proto3-wire
-                     , lingo >= 0.1.0.1
+                     , lingo >= 0.2.0.0
 
 common executable-flags
   ghc-options:         -threaded -rtsopts "-with-rtsopts=-N -A4m -n2m"


### PR DESCRIPTION
++lingo-haskell to pick up https://github.com/tclem/lingo-haskell/pull/2.