### PR TITLE
Add a CHECK-TREE directive and simplify esoteric jq tests.

### DIFF
--- a/semantic-core/src/Data/Core/Parser.hs
+++ b/semantic-core/src/Data/Core/Parser.hs
@@ -4,6 +4,8 @@ module Data.Core.Parser
   , core
   , lit
   , expr
+  , record
+  , comp
   , lvalue
   ) where
 

--- a/semantic-python/test/Test.hs
+++ b/semantic-python/test/Test.hs
@@ -44,6 +44,7 @@ import           Analysis.ScopeGraph
 import qualified Directive
 import           Instances ()
 
+
 assertJQExpressionSucceeds :: Show a => Directive.Directive -> a -> Term (Ann :+: Core) Name -> HUnit.Assertion
 assertJQExpressionSucceeds directive tree core = do
   bod <- case scopeGraph Eval.eval [File interactive core] of
@@ -79,13 +80,15 @@ fixtureTestTreeForFile fp = HUnit.testCaseSteps fp $ \step -> withFrozenCallStac
   let coreResult = fmap (Control.Effect.run . runFail . Py.compile @(TSP.Module TS.Span) @_ @(Term (Ann :+: Core))) result
   for_ directives $ \directive -> do
     step (Directive.describe directive)
-    case coreResult of
-      Left err           -> HUnit.assertFailure ("Parsing failed: " <> err)
-      Right (Left _)     | directive == Directive.Fails -> pure ()
-      Right (Right _)    | directive == Directive.Fails -> HUnit.assertFailure ("Expected translation to fail")
-      Right (Right item) -> assertJQExpressionSucceeds directive result item
-      Right (Left err)   -> HUnit.assertFailure ("Compilation failed: " <> err)
-
+    case (coreResult, directive) of
+      (Right (Left _), Directive.Fails)      -> pure ()
+      (Left err, _)                          -> HUnit.assertFailure ("Parsing failed: " <> err)
+      (Right (Left err), _)                  -> HUnit.assertFailure ("Compilation failed: " <> err)
+      (Right (Right _), Directive.Fails)     -> HUnit.assertFailure ("Expected translation to fail")
+      (Right (Right item), Directive.JQ _)   -> assertJQExpressionSucceeds directive result item
+      (Right (Right item), Directive.Tree t) -> let msg = "lhs = " <> showCore t <> "\n rhs " <> showCore item'
+                                                    item' = stripAnnotations item
+                                                in HUnit.assertEqual msg t item' where
 
 milestoneFixtures :: IO Tasty.TestTree
 milestoneFixtures = do

--- a/semantic-python/test/fixtures/1-03-empty-tuple.py
+++ b/semantic-python/test/fixtures/1-03-empty-tuple.py
@@ -1,2 +1,3 @@
-# CHECK-JQ: .scope == {} and .tree.contents == []
+# CHECK-JQ: .scope == {}
+# CHECK-TREE: #record {}
 ()

--- a/semantic-python/test/fixtures/2-01-return-statement.py
+++ b/semantic-python/test/fixtures/2-01-return-statement.py
@@ -1,3 +1,3 @@
-# CHECK-JQ: .tree.contents[0][1].contents[1].contents.value.value == []
+# CHECK-TREE: #record { foo : foo = (\a -> a) }
 def foo(a):
     return a

--- a/semantic-python/test/fixtures/2-02-return-doesnt-translate.py
+++ b/semantic-python/test/fixtures/2-02-return-doesnt-translate.py
@@ -1,4 +1,4 @@
-# CHECK-JQ: .tree.contents[0][1].contents[1].contents.value.value == []
+# CHECK-TREE: #record { foo : foo = (\a -> a) }
 
 def foo(a):
     return a


### PR DESCRIPTION
Due to the problems outlined in #245, the tests for return statements
were complicated and not testing useful properties. This patch adds a
new `CHECK-TREE` directive which lets you embed a Core expression
as a string, which is parsed and then compared against the result of
compiling the containing module.