### PR TITLE
++tree-sitter-typescript/tsx

### DIFF
--- a/semantic.cabal
+++ b/semantic.cabal
@@ -324,8 +324,8 @@ library
                      , tree-sitter-php == 0.2.0.0
                      , tree-sitter-python == 0.4.0.0
                      , tree-sitter-ruby == 0.2.0.0
-                     , tree-sitter-typescript == 0.2.0.0
-                     , tree-sitter-tsx == 0.2.0.0
+                     , tree-sitter-typescript == 0.2.1.0
+                     , tree-sitter-tsx == 0.2.1.0
                      , tree-sitter-java == 0.2.0.0
   if flag(release)
     cpp-options:       -DCOMPUTE_GIT_SHA

--- a/src/Language/TSX/Assignment.hs
+++ b/src/Language/TSX/Assignment.hs
@@ -503,7 +503,7 @@ callSignatureParts = contextualize' <$> Assignment.manyThrough comment (postCont
       Nothing -> (typeParams, formalParams, annotation)
 
 callSignature :: Assignment Term
-callSignature =  makeTerm <$> location <*> (TSX.Syntax.CallSignature <$> (fromMaybe <$> emptyTerm <*> optional (term typeParameters)) <*> formalParameters <*> (fromMaybe <$> emptyTerm <*> optional (term typeAnnotation')))
+callSignature =  makeTerm <$> symbol Grammar.CallSignature <*> children (TSX.Syntax.CallSignature <$> (fromMaybe <$> emptyTerm <*> optional (term typeParameters)) <*> formalParameters <*> (fromMaybe <$> emptyTerm <*> optional (term typeAnnotation')))
 
 constructSignature :: Assignment Term
 constructSignature = makeTerm <$> symbol Grammar.ConstructSignature <*> children (TSX.Syntax.ConstructSignature <$> (fromMaybe <$> emptyTerm <*> optional (term typeParameters)) <*> formalParameters <*> (fromMaybe <$> emptyTerm <*> optional (term typeAnnotation')))

--- a/src/Language/TypeScript/Assignment.hs
+++ b/src/Language/TypeScript/Assignment.hs
@@ -456,7 +456,7 @@ callSignatureParts = contextualize' <$> Assignment.manyThrough comment (postCont
       Nothing -> (typeParams, formalParams, annotation)
 
 callSignature :: Assignment Term
-callSignature =  makeTerm <$> location <*> (TypeScript.Syntax.CallSignature <$> (fromMaybe <$> emptyTerm <*> optional (term typeParameters)) <*> formalParameters <*> (fromMaybe <$> emptyTerm <*> optional (term typeAnnotation')))
+callSignature =  makeTerm <$> symbol Grammar.CallSignature <*> children (TypeScript.Syntax.CallSignature <$> (fromMaybe <$> emptyTerm <*> optional (term typeParameters)) <*> formalParameters <*> (fromMaybe <$> emptyTerm <*> optional (term typeAnnotation')))
 
 constructSignature :: Assignment Term
 constructSignature = makeTerm <$> symbol Grammar.ConstructSignature <*> children (TypeScript.Syntax.ConstructSignature <$> (fromMaybe <$> emptyTerm <*> optional (term typeParameters)) <*> formalParameters <*> (fromMaybe <$> emptyTerm <*> optional (term typeAnnotation')))


### PR DESCRIPTION
Minor version bumps of tsx and typescript parsers to pick up a parser generator fix where the state merging pass was overly eager.