### PR TITLE
Fixed Range Ord instance

### DIFF
--- a/src/Data/Range.hs
+++ b/src/Data/Range.hs
@@ -15,7 +15,7 @@ import Data.JSON.Fields
 
 -- | A half-open interval of integers, defined by start & end indices.
 data Range = Range { start :: {-# UNPACK #-} !Int, end :: {-# UNPACK #-} !Int }
-  deriving (Eq, Generic, NFData)
+  deriving (Eq, Generic, NFData, Ord)
 
 emptyRange :: Range
 emptyRange = Range 0 0
@@ -41,9 +41,6 @@ subtractRange range1 range2 = Range (start range1) (end range1 - rangeLength (Ra
 -- | The associativity of this instance is specced in @Data.Range.Spec@.
 instance Semigroup Range where
   Range start1 end1 <> Range start2 end2 = Range (min start1 start2) (max end1 end2)
-
-instance Ord Range where
-  a <= b = start a <= start b
 
 instance Show Range where
   showsPrec _ Range{..} = showChar '[' . shows start . showString " .. " . shows end . showChar ']'

--- a/src/Data/Range.hs
+++ b/src/Data/Range.hs
@@ -3,7 +3,6 @@ module Data.Range
 ( Range(..)
 , emptyRange
 , rangeLength
-, offsetRange
 , intersectsRange
 , subtractRange
 ) where
@@ -23,10 +22,6 @@ emptyRange = Range 0 0
 -- | Return the length of the range.
 rangeLength :: Range -> Int
 rangeLength range = end range - start range
-
--- | Offset a range by a constant delta.
-offsetRange :: Range -> Int -> Range
-offsetRange a b = Range (start a + b) (end a + b)
 
 -- | Test two ranges for intersection.
 intersectsRange :: Range -> Range -> Bool

--- a/src/Data/Range.hs
+++ b/src/Data/Range.hs
@@ -3,7 +3,6 @@ module Data.Range
 ( Range(..)
 , emptyRange
 , rangeLength
-, intersectsRange
 , subtractRange
 ) where
 
@@ -22,10 +21,6 @@ emptyRange = Range 0 0
 -- | Return the length of the range.
 rangeLength :: Range -> Int
 rangeLength range = end range - start range
-
--- | Test two ranges for intersection.
-intersectsRange :: Range -> Range -> Bool
-intersectsRange range1 range2 = start range1 < end range2 && start range2 < end range1
 
 subtractRange :: Range -> Range -> Range
 subtractRange range1 range2 = Range (start range1) (end range1 - rangeLength (Range (start range2) (max (end range1) (end range2))))


### PR DESCRIPTION
I recently discovered [a long-standing bug](https://github.com/github/semantic/commit/44747394271d7e504b1391e6d11329d0b19bf79c): `Range`’s `Ord` instance doesn’t consider the `end`, only the `start`, which means that `Range 0 10` and `Range 0 0` are ordered as `EQ`, which is both lawless and a bad idea.

This behaviour has existed for just shy of four years, so I have some concern that it might be a load-bearing bug (i.e. that we might have other behaviour dependent on this misbehaviour). However, I believe the `Ord` instance is unused except for caching analyses (which should probably be ignoring the annotations anyway), so 🤞

I’ve also taken the opportunity to remove some unused functions.