### PR TITLE
Use pathtype for typed paths inside the test suites.

### DIFF
--- a/semantic.cabal
+++ b/semantic.cabal
@@ -61,6 +61,7 @@ common dependencies
                      , tree-sitter == 0.3.0.0
                      , mtl ^>= 2.2.2
                      , network ^>= 2.8.0.0
+                     , pathtype ^>= 0.8.1
                      , process ^>= 1.6.3.0
                      , recursion-schemes ^>= 5.1
                      , scientific ^>= 0.3.6.2

--- a/semantic.cabal
+++ b/semantic.cabal
@@ -53,7 +53,6 @@ common dependencies
                      , containers ^>= 0.6.0.1
                      , directory ^>= 1.3.3.0
                      , fastsum ^>= 0.1.1.0
-                     , filepath ^>= 1.4.2.1
                      , free ^>= 5.1
                      , fused-effects ^>= 0.5.0.0
                      , fused-effects-exceptions ^>= 0.2.0.0
@@ -290,6 +289,7 @@ library
                      , cryptohash ^>= 0.11.9
                      , deepseq ^>= 1.4.4.0
                      , directory-tree ^>= 0.12.1
+                     , filepath ^>= 1.4.2.1
                      , generic-monoid ^>= 0.1.0.0
                      , ghc-prim ^>= 0.5.3
                      , gitrev ^>= 1.3.1

--- a/src/Data/Blob.hs
+++ b/src/Data/Blob.hs
@@ -2,6 +2,7 @@
 module Data.Blob
 ( File(..)
 , fileForPath
+, fileForRelPath
 , Blob(..)
 , Blobs(..)
 , blobLanguage
@@ -32,6 +33,7 @@ import qualified Data.ByteString.Lazy as BL
 import           Data.JSON.Fields
 import           Data.Language
 import           Data.Source as Source
+import qualified System.Path as Path
 
 -- | A 'FilePath' paired with its corresponding 'Language'.
 -- Unpacked to have the same size overhead as (FilePath, Language).
@@ -40,8 +42,12 @@ data File = File
   , fileLanguage :: Language
   } deriving (Show, Eq, Generic)
 
+-- | Prefer 'fileForRelPath' if at all possible.
 fileForPath :: FilePath  -> File
 fileForPath p = File p (languageForFilePath p)
+
+fileForRelPath :: Path.RelFile -> File
+fileForRelPath = fileForPath . Path.toString
 
 -- | The source, path information, and language of a file read from disk.
 data Blob = Blob

--- a/src/Data/Blob/IO.hs
+++ b/src/Data/Blob/IO.hs
@@ -36,12 +36,12 @@ readBlobFromFile' file = do
   maybeFile <- readBlobFromFile file
   maybeM (Prelude.fail ("cannot read '" <> show file <> "', file not found or language not supported.")) maybeFile
 
--- | Read all blobs in the directory with Language.supportedExts
+-- | Read all blobs in the directory with Language.supportedExts.
 readBlobsFromDir :: MonadIO m => FilePath -> m [Blob]
 readBlobsFromDir path = liftIO . fmap catMaybes $
   findFilesInDir path supportedExts mempty >>= Async.mapConcurrently (readBlobFromFile . fileForPath)
 
-  readBlobsFromGitRepoPath :: (Part.AbsRel ar, MonadIO m) => Path.Dir ar -> Git.OID -> [Path.RelFile] -> [Path.RelFile] -> m [Blob]
+readBlobsFromGitRepoPath :: (Part.AbsRel ar, MonadIO m) => Path.Dir ar -> Git.OID -> [Path.RelFile] -> [Path.RelFile] -> m [Blob]
 readBlobsFromGitRepoPath path oid excludePaths includePaths
   = readBlobsFromGitRepo (Path.toString path) oid (fmap Path.toString excludePaths) (fmap Path.toString includePaths)
 

--- a/src/Data/Blob/IO.hs
+++ b/src/Data/Blob/IO.hs
@@ -7,6 +7,7 @@ module Data.Blob.IO
   , readBlobFromFile'
   , readBlobsFromDir
   , readBlobsFromGitRepo
+  , readBlobsFromGitRepoPath
   , readFilePair
   ) where
 
@@ -19,6 +20,8 @@ import Data.Source
 import qualified Semantic.Git as Git
 import qualified Control.Concurrent.Async as Async
 import qualified Data.ByteString as B
+import qualified System.Path as Path
+import qualified System.Path.PartClass as Part
 
 -- | Read a utf8-encoded file to a 'Blob'.
 readBlobFromFile :: forall m. MonadIO m => File -> m (Maybe Blob)
@@ -38,7 +41,11 @@ readBlobsFromDir :: MonadIO m => FilePath -> m [Blob]
 readBlobsFromDir path = liftIO . fmap catMaybes $
   findFilesInDir path supportedExts mempty >>= Async.mapConcurrently (readBlobFromFile . fileForPath)
 
--- | Read all blobs from a git repo
+  readBlobsFromGitRepoPath :: (Part.AbsRel ar, MonadIO m) => Path.Dir ar -> Git.OID -> [Path.RelFile] -> [Path.RelFile] -> m [Blob]
+readBlobsFromGitRepoPath path oid excludePaths includePaths
+  = readBlobsFromGitRepo (Path.toString path) oid (fmap Path.toString excludePaths) (fmap Path.toString includePaths)
+
+-- | Read all blobs from a git repo. Prefer readBlobsFromGitRepoPath, which is typed.
 readBlobsFromGitRepo :: MonadIO m => FilePath -> Git.OID -> [FilePath] -> [FilePath] -> m [Blob]
 readBlobsFromGitRepo path oid excludePaths includePaths = liftIO . fmap catMaybes $
   Git.lsTree path oid >>= Async.mapConcurrently (blobFromTreeEntry path)

--- a/test/Examples.hs
+++ b/test/Examples.hs
@@ -9,7 +9,7 @@ import qualified Data.ByteString as B
 import           Data.ByteString.Builder
 import qualified Data.ByteString.Char8 as BC
 import           Data.Either
-import           Data.Blob (fileForPath)
+import           Data.Blob (fileForRelPath)
 import           Data.Flag
 import           Data.Foldable
 import           Data.List
@@ -49,7 +49,7 @@ main = withOptions opts $ \ config logger statter -> hspec . parallel $ do
       files <- runIO $ globDir1 (compile ("**/*" <> languageExtension)) (Path.toString (tsDir </> languageExampleDir))
       let paths = Path.relFile <$> files
       for_ paths $ \file -> it (Path.toString file) $ do
-        res <- runTask session (parseFilePath (Path.toString file))
+        res <- runTask session (parseFilePath file)
         case res of
           Left (SomeException e) -> case cast e of
             -- We have a number of known assignment timeouts, consider these pending specs instead of failing the build.
@@ -105,8 +105,8 @@ languages =
   -- , ("php", ".php") -- TODO: No parse-examples in tree-sitter yet
   ] where examples = Path.relDir "examples"
 
-parseFilePath :: (Member (Error SomeException) sig, Member Distribute sig, Member Task sig, Member Files sig, Carrier sig m, MonadIO m) => FilePath -> m Bool
-parseFilePath path = readBlob (fileForPath path) >>= parseTermBuilder @[] TermShow . pure >>= const (pure True)
+parseFilePath :: (Member (Error SomeException) sig, Member Distribute sig, Member Task sig, Member Files sig, Carrier sig m, MonadIO m) => Path.RelFile -> m Bool
+parseFilePath path = readBlob (fileForRelPath path) >>= parseTermBuilder @[] TermShow . pure >>= const (pure True)
 
 languagesDir :: Path.RelDir
 languagesDir = Path.relDir "tmp/haskell-tree-sitter"

--- a/test/Examples.hs
+++ b/test/Examples.hs
@@ -26,7 +26,8 @@ import           Semantic.Task.Files
 import           System.Directory
 import           System.Exit (die)
 import           System.FilePath.Glob
-import           System.FilePath.Posix
+import qualified System.Path as Path
+import           System.Path ((</>))
 import           System.Process
 import           Test.Hspec
 
@@ -38,16 +39,17 @@ main = withOptions opts $ \ config logger statter -> hspec . parallel $ do
   runIO setupExampleRepos
 
   for_ languages $ \ lang@LanguageExample{..} -> do
-    let tsLang = "tree-sitter-" <> languageName
-        tsDir = languagesDir </> tsLang </> "vendor" </> tsLang
+    let tsLang = Path.relDir ("tree-sitter-" <> languageName)
+        tsDir = languagesDir </> tsLang </> Path.relDir "vendor" </> tsLang
     parallel . describe languageName $ parseExamples args lang tsDir
 
   where
     parseExamples session LanguageExample{..} tsDir = do
       knownFailures <- runIO $ knownFailuresForPath tsDir languageKnownFailuresTxt
-      files <- runIO $ globDir1 (compile ("**/*" <> languageExtension)) (tsDir </> languageExampleDir)
-      for_ files $ \file -> it file $ do
-        res <- runTask session (parseFilePath file)
+      files <- runIO $ globDir1 (compile ("**/*" <> languageExtension)) (Path.toString (tsDir </> languageExampleDir))
+      let paths = Path.relFile <$> files
+      for_ paths $ \file -> it (Path.toString file) $ do
+        res <- runTask session (parseFilePath (Path.toString file))
         case res of
           Left (SomeException e) -> case cast e of
             -- We have a number of known assignment timeouts, consider these pending specs instead of failing the build.
@@ -62,32 +64,33 @@ main = withOptions opts $ \ config logger statter -> hspec . parallel $ do
     setupExampleRepos = readProcess "script/clone-example-repos" mempty mempty >>= print
     opts = defaultOptions { optionsFailOnWarning = flag FailOnWarning True, optionsLogLevel = Nothing }
 
-    knownFailuresForPath :: FilePath -> Maybe FilePath -> IO [FilePath]
+    knownFailuresForPath :: Path.RelDir -> Maybe Path.RelFile -> IO [Path.RelFile]
     knownFailuresForPath _     Nothing     = pure []
     knownFailuresForPath tsDir (Just path) = do
-      known <- BC.lines <$> B.readFile (tsDir </> path)
-      pure $ (tsDir </>) . BC.unpack <$> stripComments known
-      where stripComments = filter (\line -> not (BC.null line) && BC.head line == '#')
+      known <- BC.lines <$> B.readFile (Path.toString (tsDir </> path))
+      let stripComments = filter (\line -> not (BC.null line) && BC.head line == '#')
+      let failures = Path.relFile . BC.unpack <$> stripComments known
+      pure ((tsDir </>) <$> failures)
 
 data LanguageExample
   = LanguageExample
-  { languageName :: FilePath
-  , languageExtension :: FilePath
-  , languageExampleDir :: FilePath
-  , languageKnownFailuresTxt :: Maybe FilePath
+  { languageName :: String
+  , languageExtension :: String
+  , languageExampleDir :: Path.RelDir
+  , languageKnownFailuresTxt :: Maybe Path.RelFile
   } deriving (Eq, Show)
 
-le :: FilePath -> FilePath -> FilePath -> Maybe FilePath -> LanguageExample
+le :: String -> String -> Path.RelDir -> Maybe Path.RelFile -> LanguageExample
 le = LanguageExample
 
 languages :: [LanguageExample]
 languages =
-  [ le "python" ".py" "examples" (Just "script/known_failures.txt")
-  , le "ruby" ".rb" "examples" (Just "script/known_failures.txt")
-  , le "typescript" ".ts" "examples" (Just "typescript/script/known_failures.txt")
-  , le "typescript" ".tsx" "examples" (Just "typescript/script/known_failures.txt")
-  , le "typescript" ".js" "examples" Nothing -- parse JavaScript with TypeScript parser.
-  , le "go" ".go" "examples" (Just "script/known-failures.txt")
+  [ le "python" ".py" examples (Just $ Path.relFile "script/known_failures.txt")
+  , le "ruby" ".rb" examples (Just $ Path.relFile "script/known_failures.txt")
+  , le "typescript" ".ts" examples (Just $ Path.relFile "typescript/script/known_failures.txt")
+  , le "typescript" ".tsx" examples (Just $ Path.relFile "typescript/script/known_failures.txt")
+  , le "typescript" ".js" examples Nothing -- parse JavaScript with TypeScript parser.
+  , le "go" ".go" examples (Just $ Path.relFile "script/known-failures.txt")
 
   -- TODO: Java assignment errors need to be investigated
   -- , le "java" ".java" "examples/guava" (Just "script/known_failures_guava.txt")
@@ -100,10 +103,10 @@ languages =
   -- , le "haskell" ".hs" "examples/ivory" (Just "script/known-failures-ivory.txt")
 
   -- , ("php", ".php") -- TODO: No parse-examples in tree-sitter yet
-  ]
+  ] where examples = Path.relDir "examples"
 
 parseFilePath :: (Member (Error SomeException) sig, Member Distribute sig, Member Task sig, Member Files sig, Carrier sig m, MonadIO m) => FilePath -> m Bool
 parseFilePath path = readBlob (fileForPath path) >>= parseTermBuilder @[] TermShow . pure >>= const (pure True)
 
-languagesDir :: FilePath
-languagesDir = "tmp/haskell-tree-sitter"
+languagesDir :: Path.RelDir
+languagesDir = Path.relDir "tmp/haskell-tree-sitter"

--- a/test/Graphing/Calls/Spec.hs
+++ b/test/Graphing/Calls/Spec.hs
@@ -6,19 +6,19 @@ import Prelude hiding (readFile)
 import SpecHelpers hiding (readFile)
 
 import Algebra.Graph
-import Data.List (uncons)
 
 import           "semantic" Data.Graph (Graph (..), topologicalSort)
 import           Data.Graph.ControlFlowVertex
 import qualified Data.Language as Language
 import           Semantic.Graph
+import qualified System.Path as Path
 
-callGraphPythonProject :: [FilePath] -> IO (Semantic.Graph.Graph ControlFlowVertex)
-callGraphPythonProject paths = runTaskOrDie $ do
+callGraphPythonProject :: Path.RelFile -> IO (Semantic.Graph.Graph ControlFlowVertex)
+callGraphPythonProject path = runTaskOrDie $ do
   let proxy = Proxy @'Language.Python
   let lang = Language.Python
-  blobs <- catMaybes <$> traverse readBlobFromFile (flip File lang <$> paths)
-  package <- fmap snd <$> parsePackage pythonParser (Project (takeDirectory (maybe "/" fst (uncons paths))) blobs lang [])
+  blobs <- catMaybes <$> traverse readBlobFromFile (flip File lang <$> [Path.toString path])
+  package <- fmap snd <$> parsePackage pythonParser (Project (Path.toString (Path.takeDirectory path)) blobs lang [])
   modules <- topologicalSort <$> runImportGraphToModules proxy package
   runCallGraph proxy False modules package
 
@@ -28,18 +28,18 @@ spec = describe "call graphing" $ do
   let needs r v = unGraph r `shouldSatisfy` hasVertex v
 
   it "should work for a simple example" $ do
-    res <- callGraphPythonProject ["test/fixtures/python/graphing/simple/simple.py"]
+    res <- callGraphPythonProject (Path.relFile "test/fixtures/python/graphing/simple/simple.py")
     res `needs` Variable "magnus" "simple.py" (Span (Pos 4 1) (Pos 4 7))
 
   it "should evaluate both sides of an if-statement" $ do
-    res <- callGraphPythonProject ["test/fixtures/python/graphing/conditional/conditional.py"]
+    res <- callGraphPythonProject (Path.relFile "test/fixtures/python/graphing/conditional/conditional.py")
     res `needs` Variable "merle" "conditional.py" (Span (Pos 5 5) (Pos 5 10))
     res `needs` Variable "taako" "conditional.py" (Span (Pos 8 5) (Pos 8 10))
 
   it "should continue even when a type error is encountered" $ do
-    res <- callGraphPythonProject ["test/fixtures/python/graphing/typeerror/typeerror.py"]
+    res <- callGraphPythonProject (Path.relFile "test/fixtures/python/graphing/typeerror/typeerror.py")
     res `needs` Variable "lup" "typeerror.py" (Span (Pos 5 1) (Pos 5 4))
 
   it "should continue when an unbound variable is encountered" $ do
-    res <- callGraphPythonProject ["test/fixtures/python/graphing/unbound/unbound.py"]
+    res <- callGraphPythonProject (Path.relFile "test/fixtures/python/graphing/unbound/unbound.py")
     res `needs` Variable "lucretia" "unbound.py" (Span (Pos 5 1) (Pos 5 9))

--- a/test/Graphing/Calls/Spec.hs
+++ b/test/Graphing/Calls/Spec.hs
@@ -17,8 +17,8 @@ callGraphPythonProject :: Path.RelFile -> IO (Semantic.Graph.Graph ControlFlowVe
 callGraphPythonProject path = runTaskOrDie $ do
   let proxy = Proxy @'Language.Python
   let lang = Language.Python
-  blobs <- catMaybes <$> traverse readBlobFromFile (flip File lang <$> [Path.toString path])
-  package <- fmap snd <$> parsePackage pythonParser (Project (Path.toString (Path.takeDirectory path)) blobs lang [])
+  blob <- readBlobFromFile' (fileForRelPath path)
+  package <- fmap snd <$> parsePackage pythonParser (Project (Path.toString (Path.takeDirectory path)) [blob] lang [])
   modules <- topologicalSort <$> runImportGraphToModules proxy package
   runCallGraph proxy False modules package
 

--- a/test/Integration/Spec.hs
+++ b/test/Integration/Spec.hs
@@ -45,7 +45,7 @@ testForExample = \case
       ("parses " <> Path.toString parseOutput)
       (\ref new -> ["git", "diff", ref, new])
       (Path.toString parseOutput)
-      (parseFilePath ?session (Path.toString file) >>= either throw (pure . BL.fromStrict))
+      (parseFilePath ?session file >>= either throw (pure . BL.fromStrict))
 
 
 -- | Return all the examples from the given directory. Examples are expected to

--- a/test/Integration/Spec.hs
+++ b/test/Integration/Spec.hs
@@ -39,7 +39,7 @@ testForExample = \case
       ("diffs " <> Path.toString diffOutput)
       (\ref new -> ["git", "diff", ref, new])
       (Path.toString diffOutput)
-      (BL.fromStrict <$> diffFilePaths ?session (Both (Path.toString fileA) (Path.toString fileB)))
+      (BL.fromStrict <$> diffFilePaths ?session (Both fileA fileB))
   ParseExample{file, parseOutput} ->
     goldenVsStringDiff
       ("parses " <> Path.toString parseOutput)

--- a/test/Integration/Spec.hs
+++ b/test/Integration/Spec.hs
@@ -6,45 +6,46 @@ import Data.Foldable (find)
 import Data.List (union, concat, transpose)
 import qualified Data.ByteString.Lazy as BL
 import System.FilePath.Glob
-import System.FilePath.Posix
 import System.IO.Unsafe
 
-import SpecHelpers
+import SpecHelpers hiding ((</>))
+import qualified System.Path as Path
+import System.Path ((</>))
 
 import Test.Tasty
 import Test.Tasty.Golden
 
-languages :: [FilePath]
-languages = ["go", "javascript", "json", "python", "ruby", "typescript", "tsx"]
+languages :: [Path.RelDir]
+languages = fmap Path.relDir ["go", "javascript", "json", "python", "ruby", "typescript", "tsx"]
 
 testTree :: (?session :: TaskSession) => TestTree
 testTree = testGroup "Integration (golden tests)" $ fmap testsForLanguage languages
 
-testsForLanguage :: (?session :: TaskSession) => FilePath -> TestTree
+testsForLanguage :: (?session :: TaskSession) => Path.RelDir -> TestTree
 testsForLanguage language = do
-  let dir = "test/fixtures" </> language </> "corpus"
+  let dir = Path.relDir "test/fixtures" </> language </> Path.relDir "corpus"
   let items = unsafePerformIO (examples dir)
-  localOption (mkTimeout 3000000) $ testGroup language $ fmap testForExample items
+  localOption (mkTimeout 3000000) $ testGroup (Path.toString language) $ fmap testForExample items
 {-# NOINLINE testsForLanguage #-}
 
-data Example = DiffExample { fileA :: FilePath, fileB :: FilePath, diffOutput :: FilePath }
-             | ParseExample { file :: FilePath, parseOutput :: FilePath }
+data Example = DiffExample { fileA :: Path.RelFile, fileB :: Path.RelFile, diffOutput :: Path.RelFile }
+             | ParseExample { file :: Path.RelFile, parseOutput :: Path.RelFile }
              deriving (Eq, Show)
 
 testForExample :: (?session :: TaskSession) => Example -> TestTree
 testForExample = \case
   DiffExample{fileA, fileB, diffOutput} ->
     goldenVsStringDiff
-      ("diffs " <> diffOutput)
+      ("diffs " <> Path.toString diffOutput)
       (\ref new -> ["git", "diff", ref, new])
-      diffOutput
-      (BL.fromStrict <$> diffFilePaths ?session (Both fileA fileB))
+      (Path.toString diffOutput)
+      (BL.fromStrict <$> diffFilePaths ?session (Both (Path.toString fileA) (Path.toString fileB)))
   ParseExample{file, parseOutput} ->
     goldenVsStringDiff
-      ("parses " <> parseOutput)
+      ("parses " <> Path.toString parseOutput)
       (\ref new -> ["git", "diff", ref, new])
-      parseOutput
-      (parseFilePath ?session file >>= either throw (pure . BL.fromStrict))
+      (Path.toString parseOutput)
+      (parseFilePath ?session (Path.toString file) >>= either throw (pure . BL.fromStrict))
 
 
 -- | Return all the examples from the given directory. Examples are expected to
@@ -58,7 +59,7 @@ testForExample = \case
 -- |
 -- | example-name.parseA.txt - The expected sexpression parse tree for example-name.A.rb
 -- | example-name.parseB.txt - The expected sexpression parse tree for example-name.B.rb
-examples :: FilePath -> IO [Example]
+examples :: Path.RelDir -> IO [Example]
 examples directory = do
   as <- globFor "*.A.*"
   bs <- globFor "*.B.*"
@@ -83,17 +84,17 @@ examples directory = do
               Just out -> f out name : acc
               Nothing -> acc
 
-    lookupNormalized :: FilePath -> [FilePath] -> FilePath
+    lookupNormalized :: Path.RelFile -> [Path.RelFile] -> Path.RelFile
     lookupNormalized name xs = fromMaybe
-      (error ("cannot find " <> name <> " make sure .A, .B and exist."))
+      (error ("cannot find " <> Path.toString name <> " make sure .A, .B and exist."))
       (lookupNormalized' name xs)
 
-    lookupNormalized' :: FilePath -> [FilePath] -> Maybe FilePath
+    lookupNormalized' :: Path.RelFile -> [Path.RelFile] -> Maybe Path.RelFile
     lookupNormalized' name = find ((== name) . normalizeName)
 
-    globFor :: FilePath -> IO [FilePath]
-    globFor p = globDir1 (compile p) directory
+    globFor :: String -> IO [Path.RelFile]
+    globFor p = fmap Path.relFile <$> globDir1 (compile p) (Path.toString directory)
 
 -- | Given a test name like "foo.A.js", return "foo".
-normalizeName :: FilePath -> FilePath
-normalizeName path = dropExtension $ dropExtension path
+normalizeName :: Path.RelFile -> Path.RelFile
+normalizeName = Path.dropExtension . Path.dropExtension

--- a/test/Integration/Spec.hs
+++ b/test/Integration/Spec.hs
@@ -8,7 +8,7 @@ import qualified Data.ByteString.Lazy as BL
 import System.FilePath.Glob
 import System.IO.Unsafe
 
-import SpecHelpers hiding ((</>))
+import SpecHelpers
 import qualified System.Path as Path
 import System.Path ((</>))
 

--- a/test/Rendering/TOC/Spec.hs
+++ b/test/Rendering/TOC/Spec.hs
@@ -26,7 +26,7 @@ import Serializing.Format as Format
 import qualified System.Path as Path
 import           System.Path ((</>))
 
-import SpecHelpers hiding ((</>))
+import SpecHelpers
 
 
 spec :: Spec

--- a/test/Rendering/TOC/Spec.hs
+++ b/test/Rendering/TOC/Spec.hs
@@ -220,7 +220,7 @@ isMethodOrFunction a
   | otherwise                                          = False
 
 blobsForPaths :: Both Path.RelFile -> IO BlobPair
-blobsForPaths = readFilePathPair . fmap Path.toString . fmap (Path.relDir "test/fixtures" </>)
+blobsForPaths = readFilePathPair . fmap (Path.relDir "test/fixtures" </>)
 
 blankDiff :: Diff'
 blankDiff = merge (Nothing, Nothing) (inject [ inserting (termIn Nothing (inject (Syntax.Identifier (name "\"a\"")))) ])

--- a/test/Semantic/CLI/Spec.hs
+++ b/test/Semantic/CLI/Spec.hs
@@ -9,7 +9,7 @@ import qualified System.Path as Path
 import           System.Path ((</>))
 import qualified System.Path.Directory as Path
 
-import SpecHelpers hiding ((</>))
+import SpecHelpers
 import Test.Tasty
 import Test.Tasty.Golden
 

--- a/test/Semantic/CLI/Spec.hs
+++ b/test/Semantic/CLI/Spec.hs
@@ -4,10 +4,12 @@ import           Data.ByteString.Builder
 import           Semantic.Api hiding (Blob, BlobPair, File)
 import           Semantic.Task
 import           Serializing.Format
-import           System.Directory
 import           System.IO.Unsafe
+import qualified System.Path as Path
+import           System.Path ((</>))
+import qualified System.Path.Directory as Path
 
-import SpecHelpers
+import SpecHelpers hiding ((</>))
 import Test.Tasty
 import Test.Tasty.Golden
 
@@ -24,48 +26,48 @@ testTree = testGroup "Semantic.CLI"
 -- summary of the differences between these JSON files.
 renderDiff :: String -> String -> [String]
 renderDiff ref new = unsafePerformIO $ do
-  useJD <- (isExtensionOf ".json" ref &&) <$> fmap isJust (findExecutable "jd")
+  useJD <- (Path.hasExtension ".json" (Path.relPath ref) &&) <$> fmap isJust (Path.findExecutable "jd")
   pure $ if useJD
     then ["jd", "-set", ref, new]
     else ["git", "diff", ref, new]
 {-# NOINLINE renderDiff #-}
 
-testForDiffFixture :: (String, [BlobPair] -> TaskEff Builder, [Both File], FilePath) -> TestTree
+testForDiffFixture :: (String, [BlobPair] -> TaskEff Builder, [Both File], Path.RelFile) -> TestTree
 testForDiffFixture (diffRenderer, runDiff, files, expected) =
   goldenVsStringDiff
     ("diff fixture renders to " <> diffRenderer <> " " <> show files)
     renderDiff
-    expected
+    (Path.toString expected)
     (fmap toLazyByteString . runTaskOrDie $ readBlobPairs (Right files) >>= runDiff)
 
-testForParseFixture :: (String, [Blob] -> TaskEff Builder, [File], FilePath) -> TestTree
+testForParseFixture :: (String, [Blob] -> TaskEff Builder, [File], Path.RelFile) -> TestTree
 testForParseFixture (format, runParse, files, expected) =
   goldenVsStringDiff
     ("diff fixture renders to " <> format)
     renderDiff
-    expected
+    (Path.toString expected)
     (fmap toLazyByteString . runTaskOrDie $ readBlobs (FilesFromPaths files) >>= runParse)
 
-parseFixtures :: [(String, [Blob] -> TaskEff Builder, [File], FilePath)]
+parseFixtures :: [(String, [Blob] -> TaskEff Builder, [File], Path.RelFile)]
 parseFixtures =
-  [ ("s-expression", parseTermBuilder TermSExpression, path, "test/fixtures/ruby/corpus/and-or.parseA.txt")
-  , ("json", parseTermBuilder TermJSONTree, path, prefix </> "parse-tree.json")
-  , ("json", parseTermBuilder TermJSONTree, path', prefix </> "parse-trees.json")
-  , ("json", parseTermBuilder TermJSONTree, [], prefix </> "parse-tree-empty.json")
-  , ("symbols", parseSymbolsBuilder Serializing.Format.JSON, path'', prefix </> "parse-tree.symbols.json")
-  , ("protobuf symbols", parseSymbolsBuilder Serializing.Format.Proto, path'', prefix </> "parse-tree.symbols.protobuf.bin")
+  [ ("s-expression", parseTermBuilder TermSExpression, path, Path.relFile "test/fixtures/ruby/corpus/and-or.parseA.txt")
+  , ("json", parseTermBuilder TermJSONTree, path, prefix </> Path.file "parse-tree.json")
+  , ("json", parseTermBuilder TermJSONTree, path', prefix </> Path.file "parse-trees.json")
+  , ("json", parseTermBuilder TermJSONTree, [], prefix </> Path.file "parse-tree-empty.json")
+  , ("symbols", parseSymbolsBuilder Serializing.Format.JSON, path'', prefix </> Path.file "parse-tree.symbols.json")
+  , ("protobuf symbols", parseSymbolsBuilder Serializing.Format.Proto, path'', prefix </> Path.file "parse-tree.symbols.protobuf.bin")
   ]
   where path = [File "test/fixtures/ruby/corpus/and-or.A.rb" Ruby]
         path' = [File "test/fixtures/ruby/corpus/and-or.A.rb" Ruby, File "test/fixtures/ruby/corpus/and-or.B.rb" Ruby]
         path'' = [File "test/fixtures/ruby/corpus/method-declaration.A.rb" Ruby]
-        prefix = "test/fixtures/cli"
+        prefix = Path.relDir "test/fixtures/cli"
 
-diffFixtures :: [(String, [BlobPair] -> TaskEff Builder, [Both File], FilePath)]
+diffFixtures :: [(String, [BlobPair] -> TaskEff Builder, [Both File], Path.RelFile)]
 diffFixtures =
-  [ ("json diff", parseDiffBuilder DiffJSONTree, pathMode, prefix </> "diff-tree.json")
-  , ("s-expression diff", parseDiffBuilder DiffSExpression, pathMode, "test/fixtures/ruby/corpus/method-declaration.diffA-B.txt")
-  , ("toc summaries diff", diffSummaryBuilder Serializing.Format.JSON, pathMode, prefix </> "diff-tree.toc.json")
-  , ("protobuf diff", diffSummaryBuilder Serializing.Format.Proto, pathMode, prefix </> "diff-tree.toc.protobuf.bin")
+  [ ("json diff", parseDiffBuilder DiffJSONTree, pathMode, prefix </> Path.file "diff-tree.json")
+  , ("s-expression diff", parseDiffBuilder DiffSExpression, pathMode, Path.relFile "test/fixtures/ruby/corpus/method-declaration.diffA-B.txt")
+  , ("toc summaries diff", diffSummaryBuilder Serializing.Format.JSON, pathMode, prefix </> Path.file "diff-tree.toc.json")
+  , ("protobuf diff", diffSummaryBuilder Serializing.Format.Proto, pathMode, prefix </> Path.file "diff-tree.toc.protobuf.bin")
   ]
   where pathMode = [Both (File "test/fixtures/ruby/corpus/method-declaration.A.rb" Ruby) (File "test/fixtures/ruby/corpus/method-declaration.B.rb"  Ruby)]
-        prefix = "test/fixtures/cli"
+        prefix = Path.relDir "test/fixtures/cli"

--- a/test/SpecHelpers.hs
+++ b/test/SpecHelpers.hs
@@ -55,7 +55,6 @@ import Parsing.Parser as X
 import Semantic.Task as X
 import Semantic.Util as X
 import Semantic.Graph (runHeap, runScopeGraph)
-import System.FilePath as X
 import Debug.Trace as X (traceShowM, traceM)
 
 import Data.ByteString as X (ByteString)

--- a/test/SpecHelpers.hs
+++ b/test/SpecHelpers.hs
@@ -75,6 +75,8 @@ import Semantic.Telemetry (LogQueue, StatQueue)
 import Semantic.Api hiding (File, Blob, BlobPair)
 import System.Exit (die)
 import Control.Exception (displayException)
+import qualified System.Path as Path
+import qualified System.Path.PartClass as Part
 
 runBuilder :: Builder -> ByteString
 runBuilder = toStrict . toLazyByteString
@@ -100,9 +102,9 @@ readFilePathPair :: Both FilePath -> IO BlobPair
 readFilePathPair paths = let paths' = fmap fileForPath paths in
                      runBothWith readFilePair paths'
 
-parseTestFile :: Parser term -> FilePath -> IO (Blob, term)
+parseTestFile :: Part.AbsRel ar => Parser term -> Path.File ar -> IO (Blob, term)
 parseTestFile parser path = runTaskOrDie $ do
-  blob <- readBlob (fileForPath path)
+  blob <- readBlob (fileForPath (Path.toString path))
   term <- parse parser blob
   pure (blob, term)
 

--- a/test/SpecHelpers.hs
+++ b/test/SpecHelpers.hs
@@ -86,8 +86,11 @@ instance IsString Name where
   fromString = X.name . fromString
 
 -- | Returns an s-expression formatted diff for the specified FilePath pair.
-diffFilePaths :: TaskSession -> Both FilePath -> IO ByteString
-diffFilePaths session paths = readFilePathPair paths >>= runTask session . parseDiffBuilder @[] DiffSExpression . pure >>= either (die . displayException) (pure . runBuilder)
+diffFilePaths :: TaskSession -> Both Path.RelFile -> IO ByteString
+diffFilePaths session paths
+  = readFilePathPair (fmap Path.toString paths)
+    >>= runTask session . parseDiffBuilder @[] DiffSExpression . pure
+    >>= either (die . displayException) (pure . runBuilder)
 
 -- | Returns an s-expression parse tree for the specified path.
 parseFilePath :: TaskSession -> Path.RelFile -> IO (Either SomeException ByteString)

--- a/test/SpecHelpers.hs
+++ b/test/SpecHelpers.hs
@@ -88,20 +88,20 @@ instance IsString Name where
 -- | Returns an s-expression formatted diff for the specified FilePath pair.
 diffFilePaths :: TaskSession -> Both Path.RelFile -> IO ByteString
 diffFilePaths session paths
-  = readFilePathPair (fmap Path.toString paths)
+  = readFilePathPair paths
     >>= runTask session . parseDiffBuilder @[] DiffSExpression . pure
     >>= either (die . displayException) (pure . runBuilder)
 
 -- | Returns an s-expression parse tree for the specified path.
 parseFilePath :: TaskSession -> Path.RelFile -> IO (Either SomeException ByteString)
 parseFilePath session path = do
-  blob <- readBlobFromFile (fileForPath (Path.toString path))
+  blob <- readBlobFromFile (fileForRelPath path)
   res <- runTask session $ parseTermBuilder TermSExpression (toList blob)
   pure (runBuilder <$> res)
 
 -- | Read two files to a BlobPair.
-readFilePathPair :: Both FilePath -> IO BlobPair
-readFilePathPair paths = let paths' = fmap fileForPath paths in
+readFilePathPair :: Both Path.RelFile -> IO BlobPair
+readFilePathPair paths = let paths' = fmap fileForRelPath paths in
                      runBothWith readFilePair paths'
 
 parseTestFile :: Parser term -> Path.RelFile -> IO (Blob, term)

--- a/test/Tags/Spec.hs
+++ b/test/Tags/Spec.hs
@@ -3,46 +3,46 @@ module Tags.Spec (spec) where
 import Data.Text (Text)
 import SpecHelpers
 import Tags.Tagging
-
+import qualified System.Path as Path
 
 spec :: Spec
 spec = do
   describe "go" $ do
     it "produces tags for functions with docs" $ do
-      (blob, tree) <- parseTestFile goParser "test/fixtures/go/tags/simple_functions.go"
+      (blob, tree) <- parseTestFile goParser (Path.relFile "test/fixtures/go/tags/simple_functions.go")
       runTagging blob symbolsToSummarize tree `shouldBe`
         [ Tag "TestFromBits" "Function" (Span (Pos 6 1) (Pos 8 2)) ["Statements"] (Just "func TestFromBits(t *testing.T) {") (Just "// TestFromBits ...")
         , Tag "Hi" "Function" (Span (Pos 10 1) (Pos 11 2)) ["Statements"] (Just "func Hi()") Nothing ]
 
     it "produces tags for methods" $ do
-      (blob, tree) <- parseTestFile goParser "test/fixtures/go/tags/method.go"
+      (blob, tree) <- parseTestFile goParser (Path.relFile "test/fixtures/go/tags/method.go")
       runTagging blob symbolsToSummarize tree `shouldBe`
         [ Tag "CheckAuth" "Method" (Span (Pos 3 1) (Pos 3 100)) ["Statements"] (Just "func (c *apiClient) CheckAuth(req *http.Request, user, repo string) (*authenticatedActor, error)") Nothing]
 
     it "produces tags for calls" $ do
-      (blob, tree) <- parseTestFile goParser "test/fixtures/go/tags/simple_functions.go"
+      (blob, tree) <- parseTestFile goParser (Path.relFile "test/fixtures/go/tags/simple_functions.go")
       runTagging blob ["Call"] tree `shouldBe`
         [ Tag "Hi" "Call" (Span (Pos 7 2) (Pos 7 6)) ["Function", "Context", "Statements"] (Just "Hi()") Nothing]
 
   describe "javascript and typescript" $ do
     it "produces tags for functions with docs" $ do
-      (blob, tree) <- parseTestFile typescriptParser "test/fixtures/javascript/tags/simple_function_with_docs.js"
+      (blob, tree) <- parseTestFile typescriptParser (Path.relFile "test/fixtures/javascript/tags/simple_function_with_docs.js")
       runTagging blob symbolsToSummarize tree `shouldBe`
         [ Tag "myFunction" "Function" (Span (Pos 2 1) (Pos 4 2)) ["Statements"] (Just "function myFunction()") (Just "// This is myFunction") ]
 
     it "produces tags for classes" $ do
-      (blob, tree) <- parseTestFile typescriptParser "test/fixtures/typescript/tags/class.ts"
+      (blob, tree) <- parseTestFile typescriptParser (Path.relFile "test/fixtures/typescript/tags/class.ts")
       runTagging blob symbolsToSummarize tree `shouldBe`
         [ Tag "FooBar" "Class" (Span (Pos 1 1) (Pos 1 16)) ["Statements"] (Just "class FooBar") Nothing ]
 
     it "produces tags for modules" $ do
-      (blob, tree) <- parseTestFile typescriptParser "test/fixtures/typescript/tags/module.ts"
+      (blob, tree) <- parseTestFile typescriptParser (Path.relFile "test/fixtures/typescript/tags/module.ts")
       runTagging blob symbolsToSummarize tree `shouldBe`
         [ Tag "APromise" "Module" (Span (Pos 1 1) (Pos 1 20)) ["Statements"] (Just "module APromise { }") Nothing ]
 
   describe "python" $ do
     it "produces tags for functions" $ do
-      (blob, tree) <- parseTestFile pythonParser "test/fixtures/python/tags/simple_functions.py"
+      (blob, tree) <- parseTestFile pythonParser (Path.relFile "test/fixtures/python/tags/simple_functions.py")
       runTagging blob symbolsToSummarize tree `shouldBe`
         [ Tag "Foo" "Function" (Span (Pos 1 1) (Pos 5 17)) ["Statements"] (Just "def Foo(x):") Nothing
         , Tag "Bar" "Function" (Span (Pos 7 1) (Pos 11 13)) ["Statements"] (Just "def Bar():") Nothing
@@ -50,30 +50,30 @@ spec = do
         ]
 
     it "produces tags for functions with docs" $ do
-      (blob, tree) <- parseTestFile pythonParser "test/fixtures/python/tags/simple_function_with_docs.py"
+      (blob, tree) <- parseTestFile pythonParser (Path.relFile "test/fixtures/python/tags/simple_function_with_docs.py")
       runTagging blob symbolsToSummarize tree `shouldBe`
         [ Tag "Foo" "Function" (Span (Pos 1 1) (Pos 3 13)) ["Statements"] (Just "def Foo(x):") (Just "\"\"\"This is the foo function\"\"\"") ]
 
     it "produces tags for classes" $ do
-      (blob, tree) <- parseTestFile pythonParser "test/fixtures/python/tags/class.py"
+      (blob, tree) <- parseTestFile pythonParser (Path.relFile "test/fixtures/python/tags/class.py")
       runTagging blob symbolsToSummarize tree `shouldBe`
         [ Tag "Foo" "Class" (Span (Pos 1 1) (Pos 5 17)) ["Statements"] (Just "class Foo:") (Just "\"\"\"The Foo class\"\"\"")
         , Tag "f" "Function" (Span (Pos 3 5) (Pos 5 17)) ["Statements", "Class", "Statements"] (Just "def f(self):") (Just "\"\"\"The f method\"\"\"")
         ]
 
     it "produces tags for multi-line functions" $ do
-      (blob, tree) <- parseTestFile pythonParser "test/fixtures/python/tags/multiline.py"
+      (blob, tree) <- parseTestFile pythonParser (Path.relFile "test/fixtures/python/tags/multiline.py")
       runTagging blob symbolsToSummarize tree `shouldBe`
         [ Tag "Foo" "Function" (Span (Pos 1 1) (Pos 3 13)) ["Statements"] (Just "def Foo(x,") Nothing ]
 
   describe "ruby" $ do
     it "produces tags for methods" $ do
-      (blob, tree) <- parseTestFile rubyParser "test/fixtures/ruby/tags/simple_method.rb"
+      (blob, tree) <- parseTestFile rubyParser (Path.relFile "test/fixtures/ruby/tags/simple_method.rb")
       runTagging blob symbolsToSummarize tree `shouldBe`
         [ Tag "foo" "Method" (Span (Pos 1 1) (Pos 4 4)) ["Statements"] (Just "def foo") Nothing ]
 
     it "produces tags for sends" $ do
-      (blob, tree) <- parseTestFile rubyParser "test/fixtures/ruby/tags/simple_method.rb"
+      (blob, tree) <- parseTestFile rubyParser (Path.relFile "test/fixtures/ruby/tags/simple_method.rb")
       runTagging blob ["Send"] tree `shouldBe`
         [ Tag "puts" "Send" (Span (Pos 2 3) (Pos 2 12)) ["Statements", "Method", "Statements"] (Just "puts \"hi\"") Nothing
         , Tag "bar" "Send" (Span (Pos 3 3) (Pos 3 8)) ["Statements", "Method", "Statements"] (Just "a.bar") Nothing
@@ -81,12 +81,12 @@ spec = do
         ]
 
     it "produces tags for methods with docs" $ do
-      (blob, tree) <- parseTestFile rubyParser "test/fixtures/ruby/tags/simple_method_with_docs.rb"
+      (blob, tree) <- parseTestFile rubyParser (Path.relFile "test/fixtures/ruby/tags/simple_method_with_docs.rb")
       runTagging blob symbolsToSummarize tree `shouldBe`
         [ Tag "foo" "Method" (Span (Pos 2 1) (Pos 3 4)) ["Statements"] (Just "def foo") (Just "# Public: foo") ]
 
     it "produces tags for methods and classes with docs" $ do
-      (blob, tree) <- parseTestFile rubyParser "test/fixtures/ruby/tags/class_module.rb"
+      (blob, tree) <- parseTestFile rubyParser (Path.relFile "test/fixtures/ruby/tags/class_module.rb")
       runTagging blob symbolsToSummarize tree `shouldBe`
         [ Tag "Foo" "Module" (Span (Pos 2 1 ) (Pos 12 4)) ["Statements"] (Just "module Foo") (Just "# Public: Foo")
         , Tag "Bar" "Class"  (Span (Pos 5 3 ) (Pos 11 6)) ["Module", "Context", "Statements"] (Just "class Bar") (Just "# Public: Bar")


### PR DESCRIPTION
It’s my ultimate goal to change `Data.Project` and `Data.File` and friends to use `pathtype`, but doing such a change from the outside-in (i.e. modifying those types' consumers before the types themselves) has proven easier than doing it from the inside-out.