### PR TITLE
A few more dockerignores

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,10 @@
 Dockerfile
-.licenses
+/.licenses
 .ghc.environment.x86_64-darwin-8.6.5
 
 /bin
+/dist
 /dist-newstyle
 /notices
 /docs
+/tmp


### PR DESCRIPTION
Used these as part of speeding up the release process in #266. Also learned that keeping around .git is important so that the build in docker can `rev-parse` the right sha which gets included in the version.