### PR TITLE
[semantic-python] Correct translation of assignments and function definitions

### DIFF
--- a/semantic-core/src/Data/Core.hs
+++ b/semantic-core/src/Data/Core.hs
@@ -126,6 +126,8 @@ unseqs = go
           Just (l, r) -> go l <> go r
           Nothing     -> t :| []
 
+-- TODO: if the left hand side is only a unit, this should return just the RHS
+-- this is a little fiddly to do
 (>>>=) :: (Eq a, Carrier sig m, Member Core sig) => (Named a :<- m a) -> m a -> m a
 Named u n :<- a >>>= b = send (Named u a :>>= abstract1 n b)
 

--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -174,9 +174,8 @@ instance Compile (Py.ExpressionStatement Span) where
   compile = viaCompileCC
 
 instance Compile (Py.ExpressionList Span) where
-  compile it@Py.ExpressionList { Py.extraChildren = exprs } = do
-    actions <- traverse compile exprs
-    locate it $ do' (fmap (Nothing :<-) actions)
+  compile it@Py.ExpressionList { Py.extraChildren = [child] } = compile child >>= locate it
+  compile Py.ExpressionList { Py.extraChildren = items } = fail ("unimplemented: ExpressionList of length " <> show items)
 
 
 instance Compile (Py.False Span) where compile it = locate it $ bool False

--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ConstraintKinds, DataKinds, DefaultSignatures, DeriveAnyClass, DeriveGeneric, DerivingStrategies,
              DerivingVia, DisambiguateRecordFields, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving,
              NamedFieldPuns, OverloadedLists, OverloadedStrings, ScopedTypeVariables, StandaloneDeriving,
-             TupleSections, TypeApplications, TypeOperators, UndecidableInstances #-}
+             TypeApplications, TypeOperators, UndecidableInstances #-}
 
 module Language.Python.Core
 ( compile
@@ -171,7 +171,7 @@ instance Compile (Py.ExpressionStatement Span) where
     { Py.extraChildren = children
     } cc = do
     foldr compileCC cc children >>= locate it
-  compile stmt = compileCC stmt (pure none)
+  compile = viaCompileCC
 
 instance Compile (Py.ExpressionList Span) where
   compile it@Py.ExpressionList { Py.extraChildren = exprs } = do

--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -54,6 +54,9 @@ type CoreSyntax sig t = ( Member Core sig
 
 class Compile py where
   -- Should this go away, and should compileCC be the main function to call?
+
+  -- FIXME: rather than failing the compilation process entirely
+  -- with MonadFail, we should emit core that represents failure
   compile :: ( CoreSyntax syn t
              , Member (Reader SourcePath) sig
              , Member (Reader Bindings) sig

--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -118,7 +118,8 @@ instance Compile (Py.Assignment Span) where
     , Py.right = Just rhs
     } cc = do
     value  <- compile rhs
-    locate it =<< ((Name.named' name :<- value) >>>=) <$> local (def name) cc
+    let assigning n = (Name.named' name :<- value) >>>= n
+    locate it =<< assigning <$> local (def name) cc
   compileCC other _ = fail ("Unhandled assignment case: " <> show other)
   compile t = compileCC t (pure none)
 

--- a/semantic-python/test/Test.hs
+++ b/semantic-python/test/Test.hs
@@ -86,6 +86,7 @@ fixtureTestTreeForFile fp = HUnit.testCaseSteps (Path.toString fp) $ \step -> wi
   let coreResult = Control.Effect.run
                    . runFail
                    . runReader (fromString @Py.SourcePath . Path.toString $ fp)
+                   . runReader @Py.Bindings mempty
                    . Py.compile @(TSP.Module TS.Span) @_ @(Term (Ann :+: Core))
                    <$> result
 

--- a/semantic-python/test/Test.hs
+++ b/semantic-python/test/Test.hs
@@ -98,7 +98,7 @@ fixtureTestTreeForFile fp = HUnit.testCaseSteps (Path.toString fp) $ \step -> wi
       (Right (Left err), _)                  -> HUnit.assertFailure ("Compilation failed: " <> err)
       (Right (Right _), Directive.Fails)     -> HUnit.assertFailure ("Expected translation to fail")
       (Right (Right item), Directive.JQ _)   -> assertJQExpressionSucceeds directive result item
-      (Right (Right item), Directive.Tree t) -> let msg = "expected (pretty): " <> showCore item'
+      (Right (Right item), Directive.Tree t) -> let msg = "got (pretty): " <> showCore item'
                                                     item' = stripAnnotations item
                                                 in HUnit.assertEqual msg t item' where
 

--- a/semantic-python/test/Test.hs
+++ b/semantic-python/test/Test.hs
@@ -98,7 +98,7 @@ fixtureTestTreeForFile fp = HUnit.testCaseSteps (Path.toString fp) $ \step -> wi
       (Right (Left err), _)                  -> HUnit.assertFailure ("Compilation failed: " <> err)
       (Right (Right _), Directive.Fails)     -> HUnit.assertFailure ("Expected translation to fail")
       (Right (Right item), Directive.JQ _)   -> assertJQExpressionSucceeds directive result item
-      (Right (Right item), Directive.Tree t) -> let msg = "lhs = " <> showCore t <> "\n rhs " <> showCore item'
+      (Right (Right item), Directive.Tree t) -> let msg = "expected (pretty): " <> showCore item'
                                                     item' = stripAnnotations item
                                                 in HUnit.assertEqual msg t item' where
 

--- a/semantic-python/test/fixtures/1-03-empty-tuple.py
+++ b/semantic-python/test/fixtures/1-03-empty-tuple.py
@@ -1,3 +1,3 @@
 # CHECK-JQ: .scope == {}
-# CHECK-TREE: #record {}
+# CHECK-TREE: { #unit; #record {} }
 ()

--- a/semantic-python/test/fixtures/1-04-toplevel-assignment.py
+++ b/semantic-python/test/fixtures/1-04-toplevel-assignment.py
@@ -1,5 +1,4 @@
 # CHECK-JQ: .scope | has("hello") and has("goodbye")
-# CHECK-JQ: .tree.location.span | [.start.line, .start.column] == [0, 0]
-# CHECK-JQ: .tree.location.span | [.end.line, .end.column] == [5, 0]
+# CHECK-TREE: { hello <- #unit; goodbye <- #unit; #record { hello: hello, goodbye: goodbye }}
 hello = ()
 goodbye = ()

--- a/semantic-python/test/fixtures/2-01-return-statement.py
+++ b/semantic-python/test/fixtures/2-01-return-statement.py
@@ -1,3 +1,3 @@
-# CHECK-TREE: #record { foo : foo = (\a -> a) }
+# CHECK-TREE: { foo <- (\a -> a); #record { foo: foo } }
 def foo(a):
     return a

--- a/semantic-python/test/fixtures/2-02-return-doesnt-translate.py
+++ b/semantic-python/test/fixtures/2-02-return-doesnt-translate.py
@@ -1,4 +1,4 @@
-# CHECK-TREE: #record { foo : foo = (\a -> a) }
+# CHECK-TREE: { foo <- (\a -> a); #record { foo: foo } }
 
 def foo(a):
     return a

--- a/semantic-python/test/fixtures/2-03-return-in-if-statement.py
+++ b/semantic-python/test/fixtures/2-03-return-in-if-statement.py
@@ -1,5 +1,4 @@
-# CHECK-JQ: .tree.contents[0][1].contents[1] | .tag == "Lam" and .contents.value.tag == "If"
-# CHECK-JQ: .tree.contents[0][1].contents[1].contents.value | .contents[2].tag == "Unit"
+# CHECK-TREE: { foo <- \a -> if a then a else #unit; #record { foo: foo } }
 
 def foo(a):
     if a: return a


### PR DESCRIPTION
Given this code:
```python
def foo(a):
    return a
```

We currently emit:
```
#record { foo : foo = (\a -> a) }
```

This is wrong; it should be:
```
foo = (\a -> a)

#record { foo: foo }
```

This patch augments `compileCC` to take care of building these records in toplevel-ish situations like `Module.`