### PR TITLE
Remove special case from Files.readBlobs.

### DIFF
--- a/src/Semantic/Resolution.hs
+++ b/src/Semantic/Resolution.hs
@@ -22,7 +22,7 @@ import qualified Source.Source as Source
 import           System.FilePath.Posix
 
 
-nodeJSResolutionMap :: (Member Files sig, Carrier sig m, MonadIO m) => FilePath -> Text -> [FilePath] -> m (Map FilePath FilePath)
+nodeJSResolutionMap :: (Member Files sig, Carrier sig m) => FilePath -> Text -> [FilePath] -> m (Map FilePath FilePath)
 nodeJSResolutionMap rootDir prop excludeDirs = do
   files <- findFiles rootDir [".json"] excludeDirs
   let packageFiles = fileForPath <$> filter ((==) "package.json" . takeFileName) files

--- a/src/Semantic/Task/Files.hs
+++ b/src/Semantic/Task/Files.hs
@@ -103,13 +103,8 @@ data FilesArg
   | FilesFromGitRepo FilePath Git.OID PathFilter
 
 -- | A task which reads a list of 'Blob's from a 'Handle' or a list of 'FilePath's optionally paired with 'Language's.
-readBlobs :: (Member Files sig, Carrier sig m, MonadIO m) => FilesArg -> m [Blob]
+readBlobs :: (Member Files sig, Carrier sig m) => FilesArg -> m [Blob]
 readBlobs (FilesFromHandle handle) = send (Read (FromHandle handle) pure)
-readBlobs (FilesFromPaths [path]) = do
-  isDir <- isDirectory (filePath path)
-  if isDir
-    then send (Read (FromDir (filePath path)) pure)
-    else pure <$> send (Read (FromPath path) pure)
 readBlobs (FilesFromPaths paths) = traverse (send . flip Read pure . FromPath) paths
 readBlobs (FilesFromGitRepo path sha filter) = send (Read (FromGitRepo path sha filter) pure)
 


### PR DESCRIPTION
I’ve been investigating how much effort it would take us to switch over to `pathtype` in the semantic repository proper. I got quite far, all things considered, but ran into one of these issues: here’s some code, in the `Files` DSL, that seems to assume that there are cases where we would pass a directory as one of the arguments to the `FilesFromPaths` specifier. This seems wrong to me: if you want to pass a directory, you should use `FromDir`, or we should add a new constructor to `FilesArg`.

I checked the commit that added the `isDirectory` check, but it didn’t elucidate the choice; additionally, turning this off hasn’t broken any unit tests yet.