### PR TITLE
Avoid repeated recompilation on CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_cache:
   - rm -fv $HOME/.cabal/packages/hackage.haskell.org/01-index.tar.idx
 
   - rm -rfv $HOME/.cabal/packages/head.hackage
+  - cabal new-configure --enable-tests --disable-optimization --write-ghc-environment-files=always --jobs=2
 
 matrix:
   include:
@@ -30,7 +31,6 @@ before_install:
 
 install:
 - cabal new-update -v
-- cabal new-configure --enable-tests --disable-optimization --write-ghc-environment-files=always --jobs=2
 - cabal new-build --only-dependencies
 
 script:


### PR DESCRIPTION
If we call `cabal new-configure` before every build, GHC throws out all the cached artifacts from previous runs, which isn’t ideal. We can do so in `before-cache` and things will turn out the same… I think.