### PR TITLE
Remove FILE:LANG argument from CLI

### DIFF
--- a/src/Semantic/CLI.hs
+++ b/src/Semantic/CLI.hs
@@ -6,8 +6,7 @@ import           Data.Blob
 import           Data.Blob.IO
 import           Data.Handle
 import qualified Data.Language as Language
-import           Data.List (intercalate, uncons)
-import           Data.List.Split (splitWhen)
+import           Data.List (intercalate)
 import           Data.Project
 import qualified Data.Text as T
 import qualified Data.Flag as Flag
@@ -155,18 +154,20 @@ graphCommand = command "graph" (info graphArgumentsParser (progDesc "Compute a g
               <|> flag'                                   (Task.serialize JSON)              (long "json" <> help "Output JSON graph")
               <|> flag'                                   (Task.serialize Show)              (long "show" <> help "Output using the Show instance (debug only, format subject to change without notice)")
     readProjectFromPaths = makeReadProjectFromPathsTask
-      <$> option auto (long "language" <> help "The language for the analysis.")
-      <*> (   Just <$> some (strArgument (metavar "FILES..."))
+      <$> (   Just <$> some (strArgument (metavar "FILES..."))
           <|> flag' Nothing (long "stdin" <> help "Read a list of newline-separated paths to analyze from stdin."))
-    makeReadProjectFromPathsTask language maybePaths = do
+    makeReadProjectFromPathsTask maybePaths = do
       paths <- maybeM (liftIO (many getLine)) maybePaths
-      blobs <- traverse readBlobFromFile' (flip File language <$> paths)
-      pure $! Project (takeDirectory (maybe "/" fst (uncons paths))) blobs language []
+      blobs <- traverse readBlobFromFile' (fileForPath <$> paths)
+      case paths of
+        (x:_) -> pure $! Project (takeDirectory x) blobs (Language.languageForFilePath x) mempty
+        _     -> pure $! Project "/" mempty Language.Unknown mempty
     readProjectRecursively = makeReadProjectRecursivelyTask
-      <$> optional (strOption (long "root" <> help "Root directory of project. Optional, defaults to entry file/directory." <> metavar "DIR"))
+      <$> option auto (long "language" <> help "The language for the analysis.")
+      <*> optional (strOption (long "root" <> help "Root directory of project. Optional, defaults to entry file/directory." <> metavar "DIR"))
       <*> many (strOption (long "exclude-dir" <> help "Exclude a directory (e.g. vendor)" <> metavar "DIR"))
-      <*> argument filePathReader (metavar "DIR:LANGUAGE | FILE")
-    makeReadProjectRecursivelyTask rootDir excludeDirs File{..} = Task.readProject rootDir filePath fileLanguage excludeDirs
+      <*> argument str (metavar "DIR")
+    makeReadProjectRecursivelyTask language rootDir excludeDirs dir = Task.readProject rootDir dir language excludeDirs
     makeGraphTask graphType includePackages serializer projectTask = projectTask >>= Graph.runGraph graphType includePackages >>= serializer
 
 shaReader :: ReadM Git.OID
@@ -176,27 +177,7 @@ shaReader = eitherReader parseSha
           else Left (arg <> " is not a valid sha1")
 
 filePathReader :: ReadM File
-filePathReader = eitherReader parseFilePath
-  where
-    parseFilePath arg = case splitWhen (== ':') arg of
-        [a, b] | Just lang <- parseLanguage (T.pack b) -> Right (File a lang)
-               | Just lang <- parseLanguage (T.pack a) -> Right (File b lang)
-        [path] -> Right (File path (Language.languageForFilePath path))
-        _ -> Left ("cannot parse `" <> arg <> "`\nexpecting FILE:LANGUAGE or just FILE")
-    parseLanguage :: Text -> Maybe Language.Language
-    parseLanguage l = case T.toLower l of
-      "go"         -> Just Language.Go
-      "haskell"    -> Just Language.Haskell
-      "java"       -> Just Language.Java
-      "javascript" -> Just Language.JavaScript
-      "json"       -> Just Language.JSON
-      "jsx"        -> Just Language.JSX
-      "markdown"   -> Just Language.Markdown
-      "python"     -> Just Language.Python
-      "ruby"       -> Just Language.Ruby
-      "typescript" -> Just Language.TypeScript
-      "php"        -> Just Language.PHP
-      _            -> Nothing
+filePathReader = fileForPath <$> str
 
 options :: Eq a => [(String, a)] -> Mod OptionFields a -> Parser a
 options options fields = option (optionsReader options) (fields <> showDefaultWith (findOption options) <> metavar (intercalate "|" (fmap fst options)))


### PR DESCRIPTION
Fixes https://github.com/github/semantic/issues/19
Fixes https://github.com/github/semantic/issues/20
Fixes https://github.com/github/semantic/issues/194

Removes the funny `FILE:LANG` argument parsing from the CLI, but preserves passing `--language=` for certain commands like `graph` which operate over a directory of files. For commands like `parse` and `graph`, the new https://github.com/tclem/lingo-haskell based language detection (see https://github.com/github/semantic/pull/230) should be sufficient for the languages that semantic currently supports.