### PR TITLE
[semantic-python] Implement chained assignment (a = b = c)

### DIFF
--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -31,14 +31,14 @@ import qualified TreeSitter.Python.AST as Py
 import           TreeSitter.Span (Span)
 import qualified TreeSitter.Span as TreeSitter
 
--- Access to the current filename as Text to stick into location annotations.
+-- | Access to the current filename as Text to stick into location annotations.
 newtype SourcePath = SourcePath { rawPath :: Text }
   deriving stock (Eq, Show)
   deriving newtype IsString
 
--- Keeps track of the current scope's bindings (so that we can, when
--- compiling a class or module, return the list of bound variables
--- as a Core record so that all immediate definitions are exposed)
+-- | Keeps track of the current scope's bindings (so that we can, when
+-- compiling a class or module, return the list of bound variables as
+-- a Core record so that all immediate definitions are exposed)
 newtype Bindings = Bindings { unBindings :: Stack Name }
   deriving stock (Eq, Show)
   deriving newtype (Semigroup, Monoid)

--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -127,7 +127,7 @@ instance Compile (Py.Attribute Span)
 -- (since they appear to have values, i.e. `a = b = c`) and statements (because
 -- they introduce bindings. For that reason, they deserve special attention.
 --
--- The correct desugaring for the expression above looks like, given a continuation @cc@:
+-- The correct desugaring for the expression above looks like, given a continuation @cont@:
 -- @
 --  (b :<- c) >>>= (a :<- b) >>>= cont
 -- @

--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -82,8 +82,6 @@ class Compile py where
   default compileCC :: (MonadFail m, Show py) => py -> m (t Name) -> m (t Name)
   compileCC a _ = defaultCompile a
 
-
-
 -- | TODO: This is not right, it should be a reference to a Preluded
 -- NoneType instance, but it will do for now.
 none :: (Member Core sig, Carrier sig t) => t Name

--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -161,7 +161,7 @@ desugar acc = \case
   Right (Right any) -> pure (acc, any)
   other -> fail ("desugar: couldn't desugar RHS " <> show other)
 
--- This is a fold function that is invoked from a left fold but that
+-- This is an algebra that is invoked from a left fold but that
 -- returns a function (the 'difference' pattern) so that we can pass
 -- information about what RHS we need down the chain: unlike most fold
 -- functions, it has four parameters, not three (since our fold

--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -173,7 +173,7 @@ collapseDesugared :: (CoreSyntax syn t, Member (Reader Bindings) sig, Carrier si
                   -> t Name                 -- The current RHS to which to assign, yielded from an outer continuation
                   -> m (t Name)             -- The properly-sequenced resolut
 collapseDesugared cont (Located loc n) rem =
-  let assigning = fmap (Core.annAt loc) . fmap ((Name.named' n :<- rem) >>>=)
+  let assigning = fmap (Core.annAt loc . ((Name.named' n :<- rem) >>>=))
   in assigning (local (def n) (cont (pure n))) -- gotta call local here to record this assignment
 
 instance Compile (Py.Assignment Span) where

--- a/semantic-python/test/fixtures/2-04-multiple-assign.py
+++ b/semantic-python/test/fixtures/2-04-multiple-assign.py
@@ -1,0 +1,2 @@
+# CHECK-TREE: { z <- #true; y <- z; x <- y; #record { z : z, y : y, x : x }}
+x = y = z = True


### PR DESCRIPTION
While @robrix and I were figuring out the correct semantics of Python assignment with respect to `compileCC`, we discovered that a coherent treatment of assignment has to account for the fact that Python assignments are changed: the RHS of an assignment can contain further assignments. This was a sufficient sticking-point such that it was worth figuring out now.