### PR TITLE
Improve performance of Semantic.Git.lsTree.

### DIFF
--- a/semantic.cabal
+++ b/semantic.cabal
@@ -68,6 +68,7 @@ common dependencies
                      , semilattices ^>= 0.0.0.3
                      , shelly >= 1.5 && <2
                      , streaming ^>= 0.2.2.0
+                     , streaming-bytestring ^>= 0.1.6
                      , text ^>= 1.2.3.1
                      , these >= 0.7 && <1
                      , unix ^>= 2.7.2.2
@@ -304,6 +305,8 @@ library
                      , reducers ^>= 3.12.3
                      , semigroupoids ^>= 5.3.2
                      , split ^>= 0.2.3.3
+                     , streaming-process ^>= 0.1
+                     , streaming-utils ^>= 0.2
                      , stm-chans ^>= 3.0.0.4
                      , template-haskell ^>= 2.14
                      , time ^>= 1.8.0.2
@@ -403,7 +406,6 @@ test-suite parse-examples
                      , foldl ^>= 1.4.5
                      , resourcet ^>= 1.2
                      , streaming
-                     , streaming-bytestring ^>= 0.1.6
                      , tasty
                      , tasty-hunit
 

--- a/semantic.cabal
+++ b/semantic.cabal
@@ -305,8 +305,8 @@ library
                      , reducers ^>= 3.12.3
                      , semigroupoids ^>= 5.3.2
                      , split ^>= 0.2.3.3
+                     , streaming-attoparsec ^>= 1.0.0.1
                      , streaming-process ^>= 0.1
-                     , streaming-utils ^>= 0.2
                      , stm-chans ^>= 3.0.0.4
                      , template-haskell ^>= 2.14
                      , time ^>= 1.8.0.2

--- a/src/Data/Blob/IO.hs
+++ b/src/Data/Blob/IO.hs
@@ -20,6 +20,7 @@ import qualified Source.Source as Source
 import qualified Semantic.Git as Git
 import qualified Control.Concurrent.Async as Async
 import qualified Data.ByteString as B
+import qualified Data.Text.Encoding as Text
 import qualified System.Path as Path
 import qualified System.Path.PartClass as Part
 
@@ -61,7 +62,7 @@ readBlobsFromGitRepo path oid excludePaths includePaths = liftIO . fmap catMaybe
       = Just . sourceBlob' path lang oid . Source.fromText <$> Git.catFile gitDir oid
     blobFromTreeEntry _ _ = pure Nothing
 
-    sourceBlob' filepath language (Git.OID oid) source = makeBlob source filepath language oid
+    sourceBlob' filepath language (Git.OID oid) source = makeBlob source filepath language (Text.decodeUtf8 oid)
 
 readFilePair :: MonadIO m => File -> File -> m BlobPair
 readFilePair a b = do

--- a/src/Semantic/CLI.hs
+++ b/src/Semantic/CLI.hs
@@ -6,6 +6,7 @@ import           Data.Blob
 import           Data.Blob.IO
 import           Data.Handle
 import qualified Data.Language as Language
+import qualified Data.ByteString.Char8 as BC
 import           Data.List (intercalate)
 import           Data.Project
 import qualified Data.Text as T
@@ -173,7 +174,7 @@ graphCommand = command "graph" (info graphArgumentsParser (progDesc "Compute a g
 shaReader :: ReadM Git.OID
 shaReader = eitherReader parseSha
   where parseSha arg = if length arg == 40 || arg == "HEAD"
-          then Right (Git.OID (T.pack arg))
+          then Right (Git.OID (BC.pack arg))
           else Left (arg <> " is not a valid sha1")
 
 filePathReader :: ReadM File

--- a/src/Semantic/CLI.hs
+++ b/src/Semantic/CLI.hs
@@ -9,7 +9,6 @@ import qualified Data.Language as Language
 import qualified Data.ByteString.Char8 as BC
 import           Data.List (intercalate)
 import           Data.Project
-import qualified Data.Text as T
 import qualified Data.Flag as Flag
 import           Options.Applicative hiding (style)
 import           Prologue

--- a/src/Semantic/Git.hs
+++ b/src/Semantic/Git.hs
@@ -13,13 +13,11 @@ module Semantic.Git
   , OID(..)
 
   -- Testing Purposes
-  , parseEntries
   , parseEntry
   ) where
 
 import Prologue
 
-import           Control.Monad.IO.Class
 import           Data.Attoparsec.ByteString.Char8 (Parser)
 import           Data.Attoparsec.ByteString.Char8 as AP
 import qualified Data.Attoparsec.ByteString.Streaming as AP.Stream
@@ -53,10 +51,6 @@ lsTree gitDir (OID sha) = Streaming.Process.withStreamingOutput lsproc go
 
 sh :: MonadIO m => Sh a -> m a
 sh = shelly . silently . onCommandHandles (initOutputHandles (`hSetBinaryMode` True))
-
--- | Parses an list of entries separated by \NUL, and on failure return []
-parseEntries :: BC.ByteString -> [TreeEntry]
-parseEntries = fromRight [] . AP.parseOnly everything
 
 everything :: Parser [TreeEntry]
 everything = AP.sepBy entryParser "\NUL" <* optional "\NUL" <* AP.endOfInput

--- a/src/Semantic/Git.hs
+++ b/src/Semantic/Git.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# OPTIONS_GHC -O1 #-}
+
 module Semantic.Git
   ( -- Primary (partial) API for cmd line git
     clone
@@ -15,14 +18,22 @@ module Semantic.Git
   , parseEntry
   ) where
 
-import Control.Monad.IO.Class
-import Data.Attoparsec.Text   (Parser)
-import Data.Attoparsec.Text   as AP
-import Data.Char
-import Data.Either            (fromRight)
-import Data.Text              as Text
-import Shelly                 hiding (FilePath)
-import System.IO              (hSetBinaryMode)
+import Prologue
+
+import           Control.Monad.IO.Class
+import qualified Data.ByteString.Char8 as BC
+import           Data.Attoparsec.ByteString.Char8 (Parser)
+import           Data.Attoparsec.ByteString.Char8 as AP
+import qualified Data.Attoparsec.ByteString.Streaming as AP.Stream
+import qualified Data.ByteString.Streaming.Char8 as ByteStream
+import qualified Streaming.Process
+import           Data.Char
+import           Data.Either (fromLeft, fromRight)
+import           Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import           Shelly hiding (FilePath)
+import qualified Streaming.Prelude as Stream
+import           System.IO (hSetBinaryMode)
 
 -- | git clone --bare
 clone :: Text -> FilePath -> IO ()
@@ -32,24 +43,31 @@ clone url path = sh $ do
 -- | git cat-file -p
 catFile :: FilePath -> OID -> IO Text
 catFile gitDir (OID oid) = sh $ do
-  run "git" ["-C", pack gitDir, "cat-file", "-p", oid]
+  run "git" ["-C", pack gitDir, "cat-file", "-p", Text.decodeUtf8 oid]
 
 -- | git ls-tree -rz
 lsTree :: FilePath -> OID -> IO [TreeEntry]
-lsTree gitDir (OID sha) = sh $ parseEntries <$> run "git" ["-C", pack gitDir, "ls-tree", "-rz", sha]
+lsTree gitDir (OID sha) = Streaming.Process.withStreamingOutput lsproc go
+  where
+    lsproc = Streaming.Process.proc "git" ["-C", gitDir, "cat-file", "-p", BC.unpack sha]
+    go :: ByteStream.ByteString IO () -> IO [TreeEntry]
+    go
+      = fmap (fromLeft [] . fst)
+      . AP.Stream.parse everything
 
 sh :: MonadIO m => Sh a -> m a
 sh = shelly . silently . onCommandHandles (initOutputHandles (`hSetBinaryMode` True))
 
 -- | Parses an list of entries separated by \NUL, and on failure return []
-parseEntries :: Text -> [TreeEntry]
+parseEntries :: BC.ByteString -> [TreeEntry]
 parseEntries = fromRight [] . AP.parseOnly everything
-  where
-    everything = AP.sepBy entryParser "\NUL" <* "\NUL\n" <* AP.endOfInput
+
+everything :: Parser [TreeEntry]
+everything = AP.sepBy entryParser "\NUL" <* "\NUL\n" <* AP.endOfInput
 
 -- | Parse the entire input with entryParser, and on failure return a default
 -- For testing purposes only
-parseEntry :: Text -> Either String TreeEntry
+parseEntry :: BC.ByteString -> Either String TreeEntry
 parseEntry = AP.parseOnly (entryParser <* AP.endOfInput)
 
 -- | Parses a TreeEntry
@@ -58,14 +76,14 @@ entryParser = TreeEntry
   <$> modeParser <* AP.char ' '
   <*> typeParser <* AP.char ' '
   <*> oidParser <* AP.char '\t'
-  <*> (unpack <$> AP.takeWhile (/= '\NUL'))
+  <*> (BC.unpack <$> AP.takeWhile (/= '\NUL'))
     where
       typeParser = AP.choice [BlobObject <$ "blob", TreeObject <$ "tree", OtherObjectType <$ AP.takeWhile isAlphaNum]
       modeParser = AP.choice [NormalMode <$ "100644", ExecutableMode <$ "100755", SymlinkMode <$ "120000", TreeMode <$ "040000", OtherMode <$ AP.takeWhile isAlphaNum]
       oidParser = OID <$> AP.takeWhile isHexDigit
 
-newtype OID = OID Text
-  deriving (Eq, Show, Ord)
+newtype OID = OID BC.ByteString
+  deriving (Eq, Show, Ord, Generic, NFData)
 
 data ObjectMode
   = NormalMode
@@ -73,13 +91,13 @@ data ObjectMode
   | SymlinkMode
   | TreeMode
   | OtherMode
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic, NFData)
 
 data ObjectType
   = BlobObject
   | TreeObject
   | OtherObjectType
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic, NFData)
 
 data TreeEntry
   = TreeEntry
@@ -87,4 +105,4 @@ data TreeEntry
   , treeEntryType :: ObjectType
   , treeEntryOid  :: OID
   , treeEntryPath :: FilePath
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic, NFData)

--- a/src/Semantic/Git.hs
+++ b/src/Semantic/Git.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveAnyClass #-}
-{-# OPTIONS_GHC -O1 #-}
 
 module Semantic.Git
   ( -- Primary (partial) API for cmd line git
@@ -16,24 +15,22 @@ module Semantic.Git
   -- Testing Purposes
   , parseEntries
   , parseEntry
-  , everything
   ) where
 
 import Prologue
 
 import           Control.Monad.IO.Class
-import qualified Data.ByteString.Char8 as BC
 import           Data.Attoparsec.ByteString.Char8 (Parser)
 import           Data.Attoparsec.ByteString.Char8 as AP
 import qualified Data.Attoparsec.ByteString.Streaming as AP.Stream
+import qualified Data.ByteString.Char8 as BC
 import qualified Data.ByteString.Streaming.Char8 as ByteStream
-import qualified Streaming.Process
 import           Data.Char
-import           Data.Either (fromLeft, fromRight)
+import           Data.Either (fromRight)
 import           Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import           Shelly hiding (FilePath)
-import qualified Streaming.Prelude as Stream
+import qualified Streaming.Process
 import           System.IO (hSetBinaryMode)
 
 -- | git clone --bare
@@ -52,9 +49,7 @@ lsTree gitDir (OID sha) = Streaming.Process.withStreamingOutput lsproc go
   where
     lsproc = Streaming.Process.proc "git" ["-C", gitDir, "ls-tree", "-zr", BC.unpack sha]
     go :: ByteStream.ByteString IO () -> IO [TreeEntry]
-    go
-      = fmap (fromLeft [] . fst)
-      . AP.Stream.parse everything
+    go = fmap (fromRight [] . fst) . AP.Stream.parse everything
 
 sh :: MonadIO m => Sh a -> m a
 sh = shelly . silently . onCommandHandles (initOutputHandles (`hSetBinaryMode` True))

--- a/src/Semantic/Git.hs
+++ b/src/Semantic/Git.hs
@@ -13,11 +13,13 @@ module Semantic.Git
   , OID(..)
 
   -- Testing Purposes
+  , parseEntries
   , parseEntry
   ) where
 
 import Prologue
 
+import           Control.Monad.IO.Class
 import           Data.Attoparsec.ByteString.Char8 (Parser)
 import           Data.Attoparsec.ByteString.Char8 as AP
 import qualified Data.Attoparsec.ByteString.Streaming as AP.Stream
@@ -51,6 +53,10 @@ lsTree gitDir (OID sha) = Streaming.Process.withStreamingOutput lsproc go
 
 sh :: MonadIO m => Sh a -> m a
 sh = shelly . silently . onCommandHandles (initOutputHandles (`hSetBinaryMode` True))
+
+-- | Parses an list of entries separated by \NUL, and on failure return []
+parseEntries :: BC.ByteString -> [TreeEntry]
+parseEntries = fromRight [] . AP.parseOnly everything
 
 everything :: Parser [TreeEntry]
 everything = AP.sepBy entryParser "\NUL" <* optional "\NUL" <* AP.endOfInput

--- a/src/Semantic/Git.hs
+++ b/src/Semantic/Git.hs
@@ -16,6 +16,7 @@ module Semantic.Git
   -- Testing Purposes
   , parseEntries
   , parseEntry
+  , everything
   ) where
 
 import Prologue
@@ -49,7 +50,7 @@ catFile gitDir (OID oid) = sh $ do
 lsTree :: FilePath -> OID -> IO [TreeEntry]
 lsTree gitDir (OID sha) = Streaming.Process.withStreamingOutput lsproc go
   where
-    lsproc = Streaming.Process.proc "git" ["-C", gitDir, "cat-file", "-p", BC.unpack sha]
+    lsproc = Streaming.Process.proc "git" ["-C", gitDir, "ls-tree", "-zr", BC.unpack sha]
     go :: ByteStream.ByteString IO () -> IO [TreeEntry]
     go
       = fmap (fromLeft [] . fst)
@@ -63,7 +64,7 @@ parseEntries :: BC.ByteString -> [TreeEntry]
 parseEntries = fromRight [] . AP.parseOnly everything
 
 everything :: Parser [TreeEntry]
-everything = AP.sepBy entryParser "\NUL" <* "\NUL\n" <* AP.endOfInput
+everything = AP.sepBy entryParser "\NUL"
 
 -- | Parse the entire input with entryParser, and on failure return a default
 -- For testing purposes only

--- a/src/Semantic/Git.hs
+++ b/src/Semantic/Git.hs
@@ -59,7 +59,7 @@ parseEntries :: BC.ByteString -> [TreeEntry]
 parseEntries = fromRight [] . AP.parseOnly everything
 
 everything :: Parser [TreeEntry]
-everything = AP.sepBy entryParser "\NUL"
+everything = AP.sepBy entryParser "\NUL" <* optional "\NUL" <* AP.endOfInput
 
 -- | Parse the entire input with entryParser, and on failure return a default
 -- For testing purposes only

--- a/src/Semantic/Git.hs
+++ b/src/Semantic/Git.hs
@@ -47,7 +47,7 @@ catFile gitDir (OID oid) = sh $ do
 lsTree :: FilePath -> OID -> IO [TreeEntry]
 lsTree gitDir (OID sha) = Streaming.Process.withStreamingOutput lsproc go
   where
-    lsproc = Streaming.Process.proc "git" ["-C", gitDir, "ls-tree", "-zr", BC.unpack sha]
+    lsproc = Streaming.Process.proc "git" ["-C", gitDir, "ls-tree", "-rz", BC.unpack sha]
     go :: ByteStream.ByteString IO () -> IO [TreeEntry]
     go = fmap (fromRight [] . fst) . AP.Stream.parse everything
 

--- a/src/Semantic/Git.hs
+++ b/src/Semantic/Git.hs
@@ -59,7 +59,7 @@ parseEntries :: BC.ByteString -> [TreeEntry]
 parseEntries = fromRight [] . AP.parseOnly everything
 
 everything :: Parser [TreeEntry]
-everything = AP.sepBy entryParser "\NUL" <* optional "\NUL" <* AP.endOfInput
+everything = AP.sepBy entryParser "\NUL" <* "\NUL\n" <* AP.endOfInput
 
 -- | Parse the entire input with entryParser, and on failure return a default
 -- For testing purposes only


### PR DESCRIPTION
- [x] Depends on #286.

As currently implemented, `lsTree` calls out to `shelly` to invoke `git ls-tree`, which loads the entire response into memory as a strict `Text` before yielding a final result. That response is immediately deconstructed by being fed into an Attoparsec parser. While this works, it’s not as efficient as it could be given large repos (for example, Kubernetes yields 18000 results for this invocation).

A better solution is to use `streaming-process` and `streaming-attoparsec` to stream the output of this process directly into the Attoparsec parser. This also avoids the overhead of converting from the system-level `ByteString` to the `Text` in which `shelly` operates, and (I believe) makes the parser slightly more efficient, as `ByteString`s are easier to traverse than `Text`.

My testing over `kubernetes` yielded a ~25% speedup. Before:
```
benchmarked without-streaming
time                 161.6 ms   (158.9 ms .. 164.3 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 160.9 ms   (159.9 ms .. 162.6 ms)
std dev              2.165 ms   (1.285 ms .. 3.131 ms)

```

After:
```
benchmarked with streaming
time                 123.8 ms   (117.5 ms .. 127.7 ms)
                     0.997 R²   (0.988 R² .. 1.000 R²)
mean                 131.8 ms   (129.0 ms .. 135.8 ms)
std dev              5.846 ms   (4.254 ms .. 7.176 ms)
```

This lies on a hot path for other services, so it’s important that we get this right, but I feel confident that we have enough unit tests to catch any bugs that might occur (see #286).