### PR TITLE
Parse effect

### DIFF
--- a/semantic.cabal
+++ b/semantic.cabal
@@ -253,6 +253,7 @@ library
                      , Semantic.Git
                      , Semantic.Graph
                      , Semantic.IO
+                     , Semantic.Parse
                      , Semantic.REPL
                      , Semantic.Resolution
                      , Semantic.Task

--- a/semantic.cabal
+++ b/semantic.cabal
@@ -116,6 +116,7 @@ library
                      , Control.Abstract.Value
                      -- Effects
                      , Control.Effect.Interpose
+                     , Control.Effect.Parse
                      , Control.Effect.REPL
                      , Control.Rewriting
                      -- Datatypes for abstract interpretation

--- a/semantic.cabal
+++ b/semantic.cabal
@@ -114,6 +114,8 @@ library
                      , Control.Abstract.Roots
                      , Control.Abstract.ScopeGraph
                      , Control.Abstract.Value
+                     -- Carriers
+                     , Control.Carrier.Parse.Measured
                      -- Effects
                      , Control.Effect.Interpose
                      , Control.Effect.Parse
@@ -254,7 +256,6 @@ library
                      , Semantic.Git
                      , Semantic.Graph
                      , Semantic.IO
-                     , Semantic.Parse
                      , Semantic.REPL
                      , Semantic.Resolution
                      , Semantic.Task

--- a/semantic.cabal
+++ b/semantic.cabal
@@ -116,6 +116,7 @@ library
                      , Control.Abstract.Value
                      -- Carriers
                      , Control.Carrier.Parse.Measured
+                     , Control.Carrier.Parse.Simple
                      -- Effects
                      , Control.Effect.Interpose
                      , Control.Effect.Parse

--- a/src/Control/Carrier/Parse/Measured.hs
+++ b/src/Control/Carrier/Parse/Measured.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE GADTs, GeneralizedNewtypeDeriving, TypeOperators, UndecidableInstances #-}
-module Semantic.Parse
+module Control.Carrier.Parse.Measured
 ( -- * Parse effect
   module Control.Effect.Parse
   -- * Parse carrier

--- a/src/Control/Carrier/Parse/Measured.hs
+++ b/src/Control/Carrier/Parse/Measured.hs
@@ -59,13 +59,13 @@ runParser blob@Blob{..} parser = case parser of
     time "parse.tree_sitter_ast_parse" languageTag $ do
       config <- asks config
       parseToAST (configTreeSitterParseTimeout config) language blob
-        >>= maybeM (throwError (SomeException ParserTimedOut))
+        >>= either (trace >=> const (throwError (SomeException ParserTimedOut))) pure
 
   UnmarshalParser language ->
     time "parse.tree_sitter_ast_parse" languageTag $ do
       config <- asks config
       parseToPreciseAST (configTreeSitterParseTimeout config) language blob
-        >>= maybeM (throwError (SomeException ParserTimedOut))
+        >>= either (trace >=> const (throwError (SomeException ParserTimedOut))) pure
 
   AssignmentParser    parser assignment -> runAssignment Assignment.assign    parser blob assignment
   DeterministicParser parser assignment -> runAssignment Deterministic.assign parser blob assignment

--- a/src/Control/Carrier/Parse/Measured.hs
+++ b/src/Control/Carrier/Parse/Measured.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs, GeneralizedNewtypeDeriving, TypeOperators, UndecidableInstances #-}
+-- | A carrier for 'Parse' effects suitable for use in production.
 module Control.Carrier.Parse.Measured
 ( -- * Parse effect
   module Control.Effect.Parse

--- a/src/Control/Carrier/Parse/Simple.hs
+++ b/src/Control/Carrier/Parse/Simple.hs
@@ -4,6 +4,7 @@ module Control.Carrier.Parse.Simple
   module Control.Effect.Parse
   -- * Parse carrier
 , ParseC(..)
+, runParse
   -- * Exceptions
 , ParserCancelled(..)
 ) where
@@ -19,8 +20,6 @@ import           Control.Exception
 import           Control.Monad.IO.Class
 import           Data.Blob
 import qualified Data.Error as Error
-import qualified Data.Flag as Flag
-import qualified Data.Syntax as Syntax
 import           Data.Sum
 import           Data.Term
 import           Data.Typeable
@@ -28,128 +27,69 @@ import           Parsing.CMark
 import           Parsing.Parser
 import           Parsing.TreeSitter
 import           Prologue hiding (project)
-import           Semantic.Config
-import           Semantic.Task (TaskSession(..))
-import           Semantic.Telemetry
-import           Semantic.Timeout
 import           Source.Source (Source)
 
-newtype ParseC m a = ParseC { runParse :: m a }
+runParse :: Duration -> ParseC m a -> m a
+runParse timeout = runReader timeout . runParseC
+
+newtype ParseC m a = ParseC { runParseC :: ReaderC Duration m a }
   deriving (Applicative, Functor, Monad, MonadIO)
 
 instance ( Carrier sig m
          , Member (Error SomeException) sig
-         , Member (Reader TaskSession) sig
-         , Member Telemetry sig
-         , Member Timeout sig
          , Member Trace sig
          , MonadIO m
          )
       => Carrier (Parse :+: sig) (ParseC m) where
-  eff (L (Parse parser blob k)) = runParser blob parser >>= k
-  eff (R other) = ParseC (eff (handleCoercible other))
+  eff (L (Parse parser blob k)) = ParseC ask >>= \ timeout -> runParser timeout blob parser >>= k
+  eff (R other) = ParseC (send (handleCoercible other))
 
 -- | Parse a 'Blob' in 'IO'.
-runParser :: (Member (Error SomeException) sig, Member (Reader TaskSession) sig, Member Telemetry sig, Member Timeout sig, Member Trace sig, Carrier sig m, MonadIO m)
-          => Blob
-          -> Parser term
-          -> m term
-runParser blob@Blob{..} parser = case parser of
-  ASTParser language -> do
-    config <- asks config
-    parseToAST (configTreeSitterParseTimeout config) language blob
+runParser
+  :: ( Carrier sig m
+     , Member (Error SomeException) sig
+     , Member Trace sig
+     , MonadIO m
+     )
+  => Duration
+  -> Blob
+  -> Parser term
+  -> m term
+runParser timeout blob@Blob{..} parser = case parser of
+  ASTParser language ->
+    parseToAST timeout language blob
       >>= maybeM (throwError (SomeException ParserTimedOut))
 
-  UnmarshalParser language -> do
-    config <- asks config
-    parseToPreciseAST (configTreeSitterParseTimeout config) language blob
+  UnmarshalParser language ->
+    parseToPreciseAST timeout language blob
       >>= maybeM (throwError (SomeException ParserTimedOut))
 
-  AssignmentParser    parser assignment -> runAssignment Assignment.assign    parser blob assignment
-  DeterministicParser parser assignment -> runAssignment Deterministic.assign parser blob assignment
+  AssignmentParser    parser assignment -> runAssignment Assignment.assign    parser timeout blob assignment
+  DeterministicParser parser assignment -> runAssignment Deterministic.assign parser timeout blob assignment
 
   MarkdownParser ->
     let term = cmarkParser blobSource
     in length term `seq` pure term
-  SomeParser parser -> SomeTerm <$> runParser blob parser
+  SomeParser parser -> SomeTerm <$> runParser timeout blob parser
 
 data ParserCancelled = ParserTimedOut | AssignmentTimedOut
   deriving (Show, Typeable)
 
 instance Exception ParserCancelled
 
-errors :: (Syntax.Error :< fs, Apply Foldable fs, Apply Functor fs) => Term (Sum fs) Assignment.Loc -> [Error.Error String]
-errors = cata $ \ (In Assignment.Loc{..} syntax) ->
-  maybe (fold syntax) (pure . Syntax.unError span) (project syntax)
 
 runAssignment
-  :: ( Apply Foldable syntaxes
-     , Apply Functor syntaxes
-     , Element Syntax.Error syntaxes
-     , Member (Error SomeException) sig
-     , Member (Reader TaskSession) sig
-     , Member Telemetry sig
-     , Member Timeout sig
+  :: ( Member (Error SomeException) sig
      , Member Trace sig
      , Carrier sig m
      , MonadIO m
      )
   => (Source -> assignment (Term (Sum syntaxes) Assignment.Loc) -> ast -> Either (Error.Error String) (Term (Sum syntaxes) Assignment.Loc))
   -> Parser ast
+  -> Duration
   -> Blob
   -> assignment (Term (Sum syntaxes) Assignment.Loc)
   -> m (Term (Sum syntaxes) Assignment.Loc)
-runAssignment assign parser blob@Blob{..} assignment = do
-  taskSession <- ask
-  let requestID' = ("github_request_id", requestID taskSession)
-  let isPublic'  = ("github_is_public", show (isPublic taskSession))
-  let logPrintFlag = configLogPrintSource . config $ taskSession
-  let blobFields = ("path", if isPublic taskSession || Flag.toBool LogPrintSource logPrintFlag then blobPath blob else "<filtered>")
-  let logFields = requestID' : isPublic' : blobFields : languageTag
-  let shouldFailForTesting = configFailParsingForTesting $ config taskSession
-  let shouldFailOnParsing = optionsFailOnParseError . configOptions $ config taskSession
-  let shouldFailOnWarning = optionsFailOnWarning . configOptions $ config taskSession
-
-  ast <- runParser blob parser `catchError` \ (SomeException err) -> do
-    writeStat (increment "parse.parse_failures" languageTag)
-    writeLog Error "failed parsing" (("task", "parse") : logFields)
-    throwError (toException err)
-
-  res <- timeout (configAssignmentTimeout (config taskSession)) . time "parse.assign" languageTag $
-    case assign blobSource assignment ast of
-      Left err -> do
-        writeStat (increment "parse.assign_errors" languageTag)
-        logError taskSession Error blob err (("task", "assign") : logFields)
-        throwError (toException err)
-      Right term -> do
-        for_ (zip (errors term) [(0::Integer)..]) $ \ (err, i) -> case Error.errorActual err of
-          Just "ParseError" -> do
-            when (i == 0) $ writeStat (increment "parse.parse_errors" languageTag)
-            logError taskSession Warning blob err (("task", "parse") : logFields)
-            when (Flag.toBool FailOnParseError shouldFailOnParsing) (throwError (toException err))
-          _ -> do
-            when (i == 0) $ writeStat (increment "parse.assign_warnings" languageTag)
-            logError taskSession Warning blob err (("task", "assign") : logFields)
-            when (Flag.toBool FailOnWarning shouldFailOnWarning) (throwError (toException err))
-        term <$ writeStat (count "parse.nodes" (length term) languageTag)
-  case res of
-    Just r | not (Flag.toBool FailTestParsing shouldFailForTesting) -> pure r
-    _ -> do
-      writeStat (increment "assign.assign_timeouts" languageTag)
-      writeLog Error "assignment timeout" (("task", "assign") : logFields)
-      throwError (SomeException AssignmentTimedOut)
-  where languageTag = [("language", show (blobLanguage blob))]
-
-
--- | Log an 'Error.Error' at the specified 'Level'.
-logError :: (Member Telemetry sig, Carrier sig m)
-         => TaskSession
-         -> Level
-         -> Blob
-         -> Error.Error String
-         -> [(String, String)]
-         -> m ()
-logError TaskSession{..} level blob err =
-  let shouldLogSource = configLogPrintSource config
-      shouldColorize = Flag.switch IsTerminal Error.Colourize $ configIsTerminal config
-  in writeLog level (Error.formatError shouldLogSource shouldColorize blob err)
+runAssignment assign parser timeout blob@Blob{..} assignment = do
+  ast <- runParser timeout blob parser
+  either (throwError . toException) pure (assign blobSource assignment ast)

--- a/src/Control/Carrier/Parse/Simple.hs
+++ b/src/Control/Carrier/Parse/Simple.hs
@@ -72,7 +72,7 @@ runParser timeout blob@Blob{..} parser = case parser of
     in length term `seq` pure term
   SomeParser parser -> SomeTerm <$> runParser timeout blob parser
 
-data ParserCancelled = ParserTimedOut | AssignmentTimedOut
+data ParserCancelled = ParserTimedOut
   deriving (Show, Typeable)
 
 instance Exception ParserCancelled

--- a/src/Control/Carrier/Parse/Simple.hs
+++ b/src/Control/Carrier/Parse/Simple.hs
@@ -1,0 +1,159 @@
+{-# LANGUAGE GADTs, GeneralizedNewtypeDeriving, TypeOperators, UndecidableInstances #-}
+module Control.Carrier.Parse.Simple
+( -- * Parse effect
+  module Control.Effect.Parse
+  -- * Parse carrier
+, ParseC(..)
+  -- * Exceptions
+, ParserCancelled(..)
+) where
+
+import qualified Assigning.Assignment as Assignment
+import qualified Assigning.Assignment.Deterministic as Deterministic
+import           Control.Effect.Error
+import           Control.Effect.Carrier
+import           Control.Effect.Parse
+import           Control.Effect.Reader
+import           Control.Effect.Trace
+import           Control.Exception
+import           Control.Monad.IO.Class
+import           Data.Blob
+import qualified Data.Error as Error
+import qualified Data.Flag as Flag
+import qualified Data.Syntax as Syntax
+import           Data.Sum
+import           Data.Term
+import           Data.Typeable
+import           Parsing.CMark
+import           Parsing.Parser
+import           Parsing.TreeSitter
+import           Prologue hiding (project)
+import           Semantic.Config
+import           Semantic.Task (TaskSession(..))
+import           Semantic.Telemetry
+import           Semantic.Timeout
+import           Source.Source (Source)
+
+newtype ParseC m a = ParseC { runParse :: m a }
+  deriving (Applicative, Functor, Monad, MonadIO)
+
+instance ( Carrier sig m
+         , Member (Error SomeException) sig
+         , Member (Reader TaskSession) sig
+         , Member Telemetry sig
+         , Member Timeout sig
+         , Member Trace sig
+         , MonadIO m
+         )
+      => Carrier (Parse :+: sig) (ParseC m) where
+  eff (L (Parse parser blob k)) = runParser blob parser >>= k
+  eff (R other) = ParseC (eff (handleCoercible other))
+
+-- | Parse a 'Blob' in 'IO'.
+runParser :: (Member (Error SomeException) sig, Member (Reader TaskSession) sig, Member Telemetry sig, Member Timeout sig, Member Trace sig, Carrier sig m, MonadIO m)
+          => Blob
+          -> Parser term
+          -> m term
+runParser blob@Blob{..} parser = case parser of
+  ASTParser language ->
+    time "parse.tree_sitter_ast_parse" languageTag $ do
+      config <- asks config
+      parseToAST (configTreeSitterParseTimeout config) language blob
+        >>= maybeM (throwError (SomeException ParserTimedOut))
+
+  UnmarshalParser language ->
+    time "parse.tree_sitter_ast_parse" languageTag $ do
+      config <- asks config
+      parseToPreciseAST (configTreeSitterParseTimeout config) language blob
+        >>= maybeM (throwError (SomeException ParserTimedOut))
+
+  AssignmentParser    parser assignment -> runAssignment Assignment.assign    parser blob assignment
+  DeterministicParser parser assignment -> runAssignment Deterministic.assign parser blob assignment
+
+  MarkdownParser ->
+    time "parse.cmark_parse" languageTag $
+      let term = cmarkParser blobSource
+      in length term `seq` pure term
+  SomeParser parser -> SomeTerm <$> runParser blob parser
+  where languageTag = [("language" :: String, show (blobLanguage blob))]
+
+data ParserCancelled = ParserTimedOut | AssignmentTimedOut
+  deriving (Show, Typeable)
+
+instance Exception ParserCancelled
+
+errors :: (Syntax.Error :< fs, Apply Foldable fs, Apply Functor fs) => Term (Sum fs) Assignment.Loc -> [Error.Error String]
+errors = cata $ \ (In Assignment.Loc{..} syntax) ->
+  maybe (fold syntax) (pure . Syntax.unError span) (project syntax)
+
+runAssignment
+  :: ( Apply Foldable syntaxes
+     , Apply Functor syntaxes
+     , Element Syntax.Error syntaxes
+     , Member (Error SomeException) sig
+     , Member (Reader TaskSession) sig
+     , Member Telemetry sig
+     , Member Timeout sig
+     , Member Trace sig
+     , Carrier sig m
+     , MonadIO m
+     )
+  => (Source -> assignment (Term (Sum syntaxes) Assignment.Loc) -> ast -> Either (Error.Error String) (Term (Sum syntaxes) Assignment.Loc))
+  -> Parser ast
+  -> Blob
+  -> assignment (Term (Sum syntaxes) Assignment.Loc)
+  -> m (Term (Sum syntaxes) Assignment.Loc)
+runAssignment assign parser blob@Blob{..} assignment = do
+  taskSession <- ask
+  let requestID' = ("github_request_id", requestID taskSession)
+  let isPublic'  = ("github_is_public", show (isPublic taskSession))
+  let logPrintFlag = configLogPrintSource . config $ taskSession
+  let blobFields = ("path", if isPublic taskSession || Flag.toBool LogPrintSource logPrintFlag then blobPath blob else "<filtered>")
+  let logFields = requestID' : isPublic' : blobFields : languageTag
+  let shouldFailForTesting = configFailParsingForTesting $ config taskSession
+  let shouldFailOnParsing = optionsFailOnParseError . configOptions $ config taskSession
+  let shouldFailOnWarning = optionsFailOnWarning . configOptions $ config taskSession
+
+  ast <- runParser blob parser `catchError` \ (SomeException err) -> do
+    writeStat (increment "parse.parse_failures" languageTag)
+    writeLog Error "failed parsing" (("task", "parse") : logFields)
+    throwError (toException err)
+
+  res <- timeout (configAssignmentTimeout (config taskSession)) . time "parse.assign" languageTag $
+    case assign blobSource assignment ast of
+      Left err -> do
+        writeStat (increment "parse.assign_errors" languageTag)
+        logError taskSession Error blob err (("task", "assign") : logFields)
+        throwError (toException err)
+      Right term -> do
+        for_ (zip (errors term) [(0::Integer)..]) $ \ (err, i) -> case Error.errorActual err of
+          Just "ParseError" -> do
+            when (i == 0) $ writeStat (increment "parse.parse_errors" languageTag)
+            logError taskSession Warning blob err (("task", "parse") : logFields)
+            when (Flag.toBool FailOnParseError shouldFailOnParsing) (throwError (toException err))
+          _ -> do
+            when (i == 0) $ writeStat (increment "parse.assign_warnings" languageTag)
+            logError taskSession Warning blob err (("task", "assign") : logFields)
+            when (Flag.toBool FailOnWarning shouldFailOnWarning) (throwError (toException err))
+        term <$ writeStat (count "parse.nodes" (length term) languageTag)
+  case res of
+    Just r | not (Flag.toBool FailTestParsing shouldFailForTesting) -> pure r
+    _ -> do
+      writeStat (increment "assign.assign_timeouts" languageTag)
+      writeLog Error "assignment timeout" (("task", "assign") : logFields)
+      throwError (SomeException AssignmentTimedOut)
+  where languageTag = [("language", show (blobLanguage blob))]
+
+
+-- | Log an 'Error.Error' at the specified 'Level'.
+logError :: (Member Telemetry sig, Carrier sig m)
+         => TaskSession
+         -> Level
+         -> Blob
+         -> Error.Error String
+         -> [(String, String)]
+         -> m ()
+logError TaskSession{..} level blob err =
+  let shouldLogSource = configLogPrintSource config
+      shouldColorize = Flag.switch IsTerminal Error.Colourize $ configIsTerminal config
+  in writeLog level (Error.formatError shouldLogSource shouldColorize blob err)

--- a/src/Control/Carrier/Parse/Simple.hs
+++ b/src/Control/Carrier/Parse/Simple.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs, GeneralizedNewtypeDeriving, TypeOperators, UndecidableInstances #-}
+-- | A carrier for 'Parse' effects suitable for use in the repl, tests, etc.
 module Control.Carrier.Parse.Simple
 ( -- * Parse effect
   module Control.Effect.Parse

--- a/src/Control/Carrier/Parse/Simple.hs
+++ b/src/Control/Carrier/Parse/Simple.hs
@@ -54,11 +54,11 @@ runParser
 runParser timeout blob@Blob{..} parser = case parser of
   ASTParser language ->
     parseToAST timeout language blob
-      >>= maybeM (throwError (SomeException ParserTimedOut))
+      >>= either (trace >=> const (throwError (SomeException ParserTimedOut))) pure
 
   UnmarshalParser language ->
     parseToPreciseAST timeout language blob
-      >>= maybeM (throwError (SomeException ParserTimedOut))
+      >>= either (trace >=> const (throwError (SomeException ParserTimedOut))) pure
 
   AssignmentParser    parser assignment ->
     runParser timeout blob parser >>= either (throwError . toException) pure . Assignment.assign    blobSource assignment

--- a/src/Control/Effect/Parse.hs
+++ b/src/Control/Effect/Parse.hs
@@ -1,2 +1,29 @@
+{-# LANGUAGE ExistentialQuantification #-}
 module Control.Effect.Parse
-() where
+( -- * Parse effect
+  Parse(..)
+, parse
+) where
+
+import Control.Effect.Carrier
+import Data.Blob
+import Parsing.Parser
+
+data Parse m k
+  = forall term . Parse (Parser term) Blob (term -> m k)
+
+deriving instance Functor m => Functor (Parse m)
+
+instance HFunctor Parse where
+  hmap f (Parse parser blob k) = Parse parser blob (f . k)
+
+instance Effect Parse where
+  handle state handler (Parse parser blob k) = Parse parser blob (handler . (<$ state) . k)
+
+
+-- | Parse a 'Blob' with the given 'Parser'.
+parse :: (Member Parse sig, Carrier sig m)
+      => Parser term
+      -> Blob
+      -> m term
+parse parser blob = send (Parse parser blob pure)

--- a/src/Control/Effect/Parse.hs
+++ b/src/Control/Effect/Parse.hs
@@ -1,0 +1,2 @@
+module Control.Effect.Parse
+() where

--- a/src/Semantic/AST.hs
+++ b/src/Semantic/AST.hs
@@ -18,6 +18,7 @@ import           Data.AST
 import           Data.Blob
 import           Parsing.Parser
 import           Rendering.JSON (renderJSONAST)
+import           Semantic.Config
 import           Semantic.Task
 import qualified Serializing.Format as F
 
@@ -36,7 +37,7 @@ astParseBlob blob@Blob{..}
 data ASTFormat = SExpression | JSON | Show | Quiet
   deriving (Show)
 
-runASTParse :: (Member Distribute sig, Member (Error SomeException) sig, Member Parse sig, Member (Reader TaskSession) sig, Carrier sig m, MonadIO m) => ASTFormat -> [Blob] -> m F.Builder
+runASTParse :: (Member Distribute sig, Member (Error SomeException) sig, Member Parse sig, Member (Reader Config) sig, Carrier sig m, MonadIO m) => ASTFormat -> [Blob] -> m F.Builder
 runASTParse SExpression = distributeFoldMap (astParseBlob >=> withSomeAST (serialize (F.SExpression F.ByShow)))
 runASTParse Show        = distributeFoldMap (astParseBlob >=> withSomeAST (serialize F.Show . fmap nodeSymbol))
 runASTParse JSON        = distributeFoldMap (\ blob -> withSomeAST (renderJSONAST blob) <$> astParseBlob blob) >=> serialize F.JSON

--- a/src/Semantic/AST.hs
+++ b/src/Semantic/AST.hs
@@ -19,6 +19,7 @@ import           Data.Blob
 import           Parsing.Parser
 import           Rendering.JSON (renderJSONAST)
 import           Semantic.Config
+import           Semantic.Parse
 import           Semantic.Task
 import qualified Serializing.Format as F
 

--- a/src/Semantic/AST.hs
+++ b/src/Semantic/AST.hs
@@ -13,13 +13,13 @@ import Data.ByteString.Builder
 import Data.List (intersperse)
 
 import           Control.Effect.Error
+import           Control.Effect.Parse
 import           Control.Effect.Reader
 import           Data.AST
 import           Data.Blob
 import           Parsing.Parser
 import           Rendering.JSON (renderJSONAST)
 import           Semantic.Config
-import           Semantic.Parse
 import           Semantic.Task
 import qualified Serializing.Format as F
 

--- a/src/Semantic/AST.hs
+++ b/src/Semantic/AST.hs
@@ -13,6 +13,7 @@ import Data.ByteString.Builder
 import Data.List (intersperse)
 
 import           Control.Effect.Error
+import           Control.Effect.Reader
 import           Data.AST
 import           Data.Blob
 import           Parsing.Parser
@@ -35,7 +36,7 @@ astParseBlob blob@Blob{..}
 data ASTFormat = SExpression | JSON | Show | Quiet
   deriving (Show)
 
-runASTParse :: (Member Distribute sig, Member (Error SomeException) sig, Member Parse sig, Member Task sig, Carrier sig m, MonadIO m) => ASTFormat -> [Blob] -> m F.Builder
+runASTParse :: (Member Distribute sig, Member (Error SomeException) sig, Member Parse sig, Member (Reader TaskSession) sig, Carrier sig m, MonadIO m) => ASTFormat -> [Blob] -> m F.Builder
 runASTParse SExpression = distributeFoldMap (astParseBlob >=> withSomeAST (serialize (F.SExpression F.ByShow)))
 runASTParse Show        = distributeFoldMap (astParseBlob >=> withSomeAST (serialize F.Show . fmap nodeSymbol))
 runASTParse JSON        = distributeFoldMap (\ blob -> withSomeAST (renderJSONAST blob) <$> astParseBlob blob) >=> serialize F.JSON

--- a/src/Semantic/AST.hs
+++ b/src/Semantic/AST.hs
@@ -38,7 +38,7 @@ data ASTFormat = SExpression | JSON | Show | Quiet
 runASTParse :: (Member Distribute sig, Member (Error SomeException) sig, Member Parse sig, Member Task sig, Carrier sig m, MonadIO m) => ASTFormat -> [Blob] -> m F.Builder
 runASTParse SExpression = distributeFoldMap (astParseBlob >=> withSomeAST (serialize (F.SExpression F.ByShow)))
 runASTParse Show        = distributeFoldMap (astParseBlob >=> withSomeAST (serialize F.Show . fmap nodeSymbol))
-runASTParse JSON        = distributeFoldMap (\ blob -> astParseBlob blob >>= withSomeAST (render (renderJSONAST blob))) >=> serialize F.JSON
+runASTParse JSON        = distributeFoldMap (\ blob -> withSomeAST (renderJSONAST blob) <$> astParseBlob blob) >=> serialize F.JSON
 runASTParse Quiet       = distributeFoldMap $ \blob -> do
   result <- time' ((Right <$> astParseBlob blob) `catchError` (pure . Left @SomeException))
   pure . mconcat . intersperse "\t" $ [ either (const "ERR") (const "OK") (fst result)

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -98,7 +98,7 @@ dotGraphDiff :: (DiffEffects sig m) => BlobPair -> m Builder
 dotGraphDiff blobPair = doDiff blobPair (const id) render
   where render _ = serialize (DOT (diffStyle "diffs")) . renderTreeGraph
 
-type DiffEffects sig m = (Member (Error SomeException) sig, Member (Reader Config) sig, Member (Reader TaskSession) sig, Member Telemetry sig, Member Distribute sig, Member Parse sig, Carrier sig m, MonadIO m)
+type DiffEffects sig m = (Member (Error SomeException) sig, Member (Reader Config) sig, Member Telemetry sig, Member Distribute sig, Member Parse sig, Carrier sig m, MonadIO m)
 
 type CanDiff syntax = (ConstructorName syntax, Diffable syntax, Eq1 syntax, HasDeclaration syntax, Hashable1 syntax, Show1 syntax, ToJSONFields1 syntax, Traversable syntax)
 type Decorate a b = forall syntax . CanDiff syntax => Blob -> Term syntax a -> Term syntax b

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -94,7 +94,7 @@ dotGraphDiff :: (DiffEffects sig m) => BlobPair -> m Builder
 dotGraphDiff blobPair = doDiff blobPair (const pure) render
   where render _ = serialize (DOT (diffStyle "diffs")) . renderTreeGraph
 
-type DiffEffects sig m = (Member (Error SomeException) sig, Member Telemetry sig, Member Distribute sig, Member Task sig, Carrier sig m, MonadIO m)
+type DiffEffects sig m = (Member (Error SomeException) sig, Member Telemetry sig, Member Distribute sig, Member Parse sig, Member Task sig, Carrier sig m, MonadIO m)
 
 type CanDiff syntax = (ConstructorName syntax, Diffable syntax, Eq1 syntax, HasDeclaration syntax, Hashable1 syntax, Show1 syntax, ToJSONFields1 syntax, Traversable syntax)
 type Decorate m a b = forall syntax . CanDiff syntax => Blob -> Term syntax a -> m (Term syntax b)
@@ -124,7 +124,7 @@ diffTerms blobs terms = time "diff" languageTag $ do
   diff <$ writeStat (Stat.count "diff.nodes" (bilength diff) languageTag)
   where languageTag = languageTagForBlobPair blobs
 
-doParse :: (Member (Error SomeException) sig, Member Distribute sig, Member Task sig, Carrier sig m)
+doParse :: (Member (Error SomeException) sig, Member Distribute sig, Member Parse sig, Carrier sig m)
   => BlobPair -> Decorate m Loc ann -> m (SomeTermPair TermPairConstraints ann)
 doParse blobPair decorate = case languageForBlobPair blobPair of
   Go         -> SomeTermPair <$> distributeFor blobPair (\ blob -> parse goParser blob >>= decorate blob)

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -14,6 +14,7 @@ module Semantic.Api.Diffs
 import           Analysis.ConstructorName (ConstructorName)
 import           Analysis.TOCSummary (HasDeclaration)
 import           Control.Effect.Error
+import           Control.Effect.Parse
 import           Control.Effect.Reader
 import           Control.Exception
 import           Control.Lens
@@ -36,7 +37,6 @@ import           Rendering.JSON hiding (JSON)
 import qualified Rendering.JSON
 import           Semantic.Api.Bridge
 import           Semantic.Config
-import           Semantic.Parse
 import           Semantic.Proto.SemanticPB hiding (Blob, BlobPair)
 import           Semantic.Task as Task
 import           Semantic.Telemetry as Stat

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -58,7 +58,7 @@ parseDiffBuilder DiffDotGraph    = distributeFoldMap dotGraphDiff
 type RenderJSON m syntax = forall syntax . CanDiff syntax => BlobPair -> Diff syntax Loc Loc -> m (Rendering.JSON.JSON "diffs" SomeJSON)
 
 jsonDiff :: (DiffEffects sig m) => RenderJSON m syntax -> BlobPair -> m (Rendering.JSON.JSON "diffs" SomeJSON)
-jsonDiff f blobPair = doDiff blobPair (const pure) f `catchError` jsonError blobPair
+jsonDiff f blobPair = doDiff blobPair (const id) f `catchError` jsonError blobPair
 
 jsonError :: Applicative m => BlobPair -> SomeException -> m (Rendering.JSON.JSON "diffs" SomeJSON)
 jsonError blobPair (SomeException e) = pure $ renderJSONDiffError blobPair (show e)
@@ -70,7 +70,7 @@ diffGraph :: (Traversable t, DiffEffects sig m) => t BlobPair -> m DiffTreeGraph
 diffGraph blobs = DiffTreeGraphResponse . V.fromList . toList <$> distributeFor blobs go
   where
     go :: (DiffEffects sig m) => BlobPair -> m DiffTreeFileGraph
-    go blobPair = doDiff blobPair (const pure) render
+    go blobPair = doDiff blobPair (const id) render
       `catchError` \(SomeException e) ->
         pure (DiffTreeFileGraph path lang mempty mempty (V.fromList [ParseError (T.pack (show e))]))
       where
@@ -85,19 +85,19 @@ diffGraph blobs = DiffTreeGraphResponse . V.fromList . toList <$> distributeFor 
 
 
 sexpDiff :: (DiffEffects sig m) => BlobPair -> m Builder
-sexpDiff blobPair = doDiff blobPair (const pure) (const (serialize (SExpression ByConstructorName)))
+sexpDiff blobPair = doDiff blobPair (const id) (const (serialize (SExpression ByConstructorName)))
 
 showDiff :: (DiffEffects sig m) => BlobPair -> m Builder
-showDiff blobPair = doDiff blobPair (const pure) (const (serialize Show))
+showDiff blobPair = doDiff blobPair (const id) (const (serialize Show))
 
 dotGraphDiff :: (DiffEffects sig m) => BlobPair -> m Builder
-dotGraphDiff blobPair = doDiff blobPair (const pure) render
+dotGraphDiff blobPair = doDiff blobPair (const id) render
   where render _ = serialize (DOT (diffStyle "diffs")) . renderTreeGraph
 
 type DiffEffects sig m = (Member (Error SomeException) sig, Member Telemetry sig, Member Distribute sig, Member Parse sig, Member Task sig, Carrier sig m, MonadIO m)
 
 type CanDiff syntax = (ConstructorName syntax, Diffable syntax, Eq1 syntax, HasDeclaration syntax, Hashable1 syntax, Show1 syntax, ToJSONFields1 syntax, Traversable syntax)
-type Decorate m a b = forall syntax . CanDiff syntax => Blob -> Term syntax a -> m (Term syntax b)
+type Decorate a b = forall syntax . CanDiff syntax => Blob -> Term syntax a -> Term syntax b
 
 type TermPairConstraints =
  '[ ConstructorName
@@ -111,7 +111,7 @@ type TermPairConstraints =
   ]
 
 doDiff :: (DiffEffects sig m)
-  => BlobPair -> Decorate m Loc ann -> (forall syntax . CanDiff syntax => BlobPair -> Diff syntax ann ann -> m output) -> m output
+  => BlobPair -> Decorate Loc ann -> (forall syntax . CanDiff syntax => BlobPair -> Diff syntax ann ann -> m output) -> m output
 doDiff blobPair decorate render = do
   SomeTermPair terms <- doParse blobPair decorate
   diff <- diffTerms blobPair terms
@@ -125,19 +125,19 @@ diffTerms blobs terms = time "diff" languageTag $ do
   where languageTag = languageTagForBlobPair blobs
 
 doParse :: (Member (Error SomeException) sig, Member Distribute sig, Member Parse sig, Carrier sig m)
-  => BlobPair -> Decorate m Loc ann -> m (SomeTermPair TermPairConstraints ann)
+  => BlobPair -> Decorate Loc ann -> m (SomeTermPair TermPairConstraints ann)
 doParse blobPair decorate = case languageForBlobPair blobPair of
-  Go         -> SomeTermPair <$> distributeFor blobPair (\ blob -> parse goParser blob >>= decorate blob)
-  Haskell    -> SomeTermPair <$> distributeFor blobPair (\ blob -> parse haskellParser blob >>= decorate blob)
-  JavaScript -> SomeTermPair <$> distributeFor blobPair (\ blob -> parse tsxParser blob >>= decorate blob)
-  JSON       -> SomeTermPair <$> distributeFor blobPair (\ blob -> parse jsonParser blob >>= decorate blob)
-  JSX        -> SomeTermPair <$> distributeFor blobPair (\ blob -> parse tsxParser blob >>= decorate blob)
-  Markdown   -> SomeTermPair <$> distributeFor blobPair (\ blob -> parse markdownParser blob >>= decorate blob)
-  Python     -> SomeTermPair <$> distributeFor blobPair (\ blob -> parse pythonParser blob >>= decorate blob)
-  Ruby       -> SomeTermPair <$> distributeFor blobPair (\ blob -> parse rubyParser blob >>= decorate blob)
-  TypeScript -> SomeTermPair <$> distributeFor blobPair (\ blob -> parse typescriptParser blob >>= decorate blob)
-  TSX        -> SomeTermPair <$> distributeFor blobPair (\ blob -> parse tsxParser blob >>= decorate blob)
-  PHP        -> SomeTermPair <$> distributeFor blobPair (\ blob -> parse phpParser blob >>= decorate blob)
+  Go         -> SomeTermPair <$> distributeFor blobPair (\ blob -> decorate blob <$> parse goParser blob)
+  Haskell    -> SomeTermPair <$> distributeFor blobPair (\ blob -> decorate blob <$> parse haskellParser blob)
+  JavaScript -> SomeTermPair <$> distributeFor blobPair (\ blob -> decorate blob <$> parse tsxParser blob)
+  JSON       -> SomeTermPair <$> distributeFor blobPair (\ blob -> decorate blob <$> parse jsonParser blob)
+  JSX        -> SomeTermPair <$> distributeFor blobPair (\ blob -> decorate blob <$> parse tsxParser blob)
+  Markdown   -> SomeTermPair <$> distributeFor blobPair (\ blob -> decorate blob <$> parse markdownParser blob)
+  Python     -> SomeTermPair <$> distributeFor blobPair (\ blob -> decorate blob <$> parse pythonParser blob)
+  Ruby       -> SomeTermPair <$> distributeFor blobPair (\ blob -> decorate blob <$> parse rubyParser blob)
+  TypeScript -> SomeTermPair <$> distributeFor blobPair (\ blob -> decorate blob <$> parse typescriptParser blob)
+  TSX        -> SomeTermPair <$> distributeFor blobPair (\ blob -> decorate blob <$> parse tsxParser blob)
+  PHP        -> SomeTermPair <$> distributeFor blobPair (\ blob -> decorate blob <$> parse phpParser blob)
   _          -> noLanguageForBlob (pathForBlobPair blobPair)
 
 data SomeTermPair typeclasses ann where

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -14,6 +14,7 @@ module Semantic.Api.Diffs
 import           Analysis.ConstructorName (ConstructorName)
 import           Analysis.TOCSummary (HasDeclaration)
 import           Control.Effect.Error
+import           Control.Effect.Reader
 import           Control.Exception
 import           Control.Lens
 import           Control.Monad.IO.Class
@@ -94,7 +95,7 @@ dotGraphDiff :: (DiffEffects sig m) => BlobPair -> m Builder
 dotGraphDiff blobPair = doDiff blobPair (const id) render
   where render _ = serialize (DOT (diffStyle "diffs")) . renderTreeGraph
 
-type DiffEffects sig m = (Member (Error SomeException) sig, Member Telemetry sig, Member Distribute sig, Member Parse sig, Member Task sig, Carrier sig m, MonadIO m)
+type DiffEffects sig m = (Member (Error SomeException) sig, Member (Reader TaskSession) sig, Member Telemetry sig, Member Distribute sig, Member Parse sig, Member Task sig, Carrier sig m, MonadIO m)
 
 type CanDiff syntax = (ConstructorName syntax, Diffable syntax, Eq1 syntax, HasDeclaration syntax, Hashable1 syntax, Show1 syntax, ToJSONFields1 syntax, Traversable syntax)
 type Decorate a b = forall syntax . CanDiff syntax => Blob -> Term syntax a -> Term syntax b

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -36,6 +36,7 @@ import           Rendering.JSON hiding (JSON)
 import qualified Rendering.JSON
 import           Semantic.Api.Bridge
 import           Semantic.Config
+import           Semantic.Parse
 import           Semantic.Proto.SemanticPB hiding (Blob, BlobPair)
 import           Semantic.Task as Task
 import           Semantic.Telemetry as Stat

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -35,6 +35,7 @@ import           Rendering.Graph
 import           Rendering.JSON hiding (JSON)
 import qualified Rendering.JSON
 import           Semantic.Api.Bridge
+import           Semantic.Config
 import           Semantic.Proto.SemanticPB hiding (Blob, BlobPair)
 import           Semantic.Task as Task
 import           Semantic.Telemetry as Stat
@@ -96,7 +97,7 @@ dotGraphDiff :: (DiffEffects sig m) => BlobPair -> m Builder
 dotGraphDiff blobPair = doDiff blobPair (const id) render
   where render _ = serialize (DOT (diffStyle "diffs")) . renderTreeGraph
 
-type DiffEffects sig m = (Member (Error SomeException) sig, Member (Reader TaskSession) sig, Member Telemetry sig, Member Distribute sig, Member Parse sig, Carrier sig m, MonadIO m)
+type DiffEffects sig m = (Member (Error SomeException) sig, Member (Reader Config) sig, Member (Reader TaskSession) sig, Member Telemetry sig, Member Distribute sig, Member Parse sig, Carrier sig m, MonadIO m)
 
 type CanDiff syntax = (ConstructorName syntax, Diffable syntax, Eq1 syntax, HasDeclaration syntax, Hashable1 syntax, Show1 syntax, ToJSONFields1 syntax, Traversable syntax)
 type Decorate a b = forall syntax . CanDiff syntax => Blob -> Term syntax a -> Term syntax b

--- a/src/Semantic/Api/Symbols.hs
+++ b/src/Semantic/Api/Symbols.hs
@@ -22,6 +22,7 @@ import           Prologue
 import           Semantic.Api.Bridge
 import qualified Semantic.Api.LegacyTypes as Legacy
 import           Semantic.Api.Terms (ParseEffects, doParse)
+import           Semantic.Parse
 import           Semantic.Proto.SemanticPB hiding (Blob)
 import           Semantic.Task
 import           Serializing.Format

--- a/src/Semantic/Api/Symbols.hs
+++ b/src/Semantic/Api/Symbols.hs
@@ -6,6 +6,7 @@ module Semantic.Api.Symbols
   ) where
 
 import           Control.Effect.Error
+import           Control.Effect.Parse
 import           Control.Effect.Reader
 import           Control.Exception
 import           Control.Lens
@@ -22,7 +23,6 @@ import           Prologue
 import           Semantic.Api.Bridge
 import qualified Semantic.Api.LegacyTypes as Legacy
 import           Semantic.Api.Terms (ParseEffects, doParse)
-import           Semantic.Parse
 import           Semantic.Proto.SemanticPB hiding (Blob)
 import           Semantic.Task
 import           Serializing.Format

--- a/src/Semantic/Api/TOCSummaries.hs
+++ b/src/Semantic/Api/TOCSummaries.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE GADTs, TypeOperators, DerivingStrategies, LambdaCase #-}
 module Semantic.Api.TOCSummaries (diffSummary, legacyDiffSummary, diffSummaryBuilder) where
 
+import           Analysis.Decorator (decoratorWithAlgebra)
 import           Analysis.TOCSummary (Declaration, declarationAlgebra)
 import           Control.Effect.Error
 import           Control.Lens
@@ -26,7 +27,7 @@ legacyDiffSummary :: (DiffEffects sig m) => [BlobPair] -> m Summaries
 legacyDiffSummary = distributeFoldMap go
   where
     go :: (DiffEffects sig m) => BlobPair -> m Summaries
-    go blobPair = doDiff blobPair (decorate . declarationAlgebra) render
+    go blobPair = doDiff blobPair (\ blob -> decoratorWithAlgebra (declarationAlgebra blob)) render
       `catchError` \(SomeException e) ->
         pure $ Summaries mempty (Map.singleton path [toJSON (ErrorSummary (T.pack (show e)) lowerBound lang)])
       where path = T.pack $ pathKeyForBlobPair blobPair
@@ -39,7 +40,7 @@ diffSummary :: (DiffEffects sig m) => [BlobPair] -> m DiffTreeTOCResponse
 diffSummary blobs = DiffTreeTOCResponse . V.fromList <$> distributeFor blobs go
   where
     go :: (DiffEffects sig m) => BlobPair -> m TOCSummaryFile
-    go blobPair = doDiff blobPair (decorate . declarationAlgebra) render
+    go blobPair = doDiff blobPair (\ blob -> decoratorWithAlgebra (declarationAlgebra blob)) render
       `catchError` \(SomeException e) ->
         pure $ TOCSummaryFile path lang mempty (V.fromList [TOCSummaryError (T.pack (show e)) Nothing])
       where path = T.pack $ pathKeyForBlobPair blobPair

--- a/src/Semantic/Api/Terms.hs
+++ b/src/Semantic/Api/Terms.hs
@@ -38,6 +38,7 @@ import           Rendering.JSON hiding (JSON)
 import qualified Rendering.JSON
 import           Semantic.Api.Bridge
 import           Semantic.Config
+import           Semantic.Parse
 import           Semantic.Proto.SemanticPB hiding (Blob)
 import           Semantic.Task
 import           Serializing.Format hiding (JSON)

--- a/src/Semantic/Api/Terms.hs
+++ b/src/Semantic/Api/Terms.hs
@@ -102,7 +102,7 @@ quietTerm blob = showTiming blob <$> time' ( (doParse blob >>= withSomeTerm (fma
       in stringUtf8 (status <> "\t" <> show (blobLanguage blob) <> "\t" <> blobPath blob <> "\t" <> show duration <> " ms\n")
 
 
-type ParseEffects sig m = (Member (Error SomeException) sig, Member (Reader PerLanguageModes) sig, Member Parse sig, Member Task sig, Carrier sig m)
+type ParseEffects sig m = (Member (Error SomeException) sig, Member (Reader PerLanguageModes) sig, Member Parse sig, Member (Reader TaskSession) sig, Carrier sig m)
 
 type TermConstraints =
  '[ Taggable

--- a/src/Semantic/Api/Terms.hs
+++ b/src/Semantic/Api/Terms.hs
@@ -16,6 +16,7 @@ module Semantic.Api.Terms
 
 import           Analysis.ConstructorName (ConstructorName)
 import           Control.Effect.Error
+import           Control.Effect.Parse
 import           Control.Effect.Reader
 import           Control.Lens
 import           Control.Monad
@@ -38,7 +39,6 @@ import           Rendering.JSON hiding (JSON)
 import qualified Rendering.JSON
 import           Semantic.Api.Bridge
 import           Semantic.Config
-import           Semantic.Parse
 import           Semantic.Proto.SemanticPB hiding (Blob)
 import           Semantic.Task
 import           Serializing.Format hiding (JSON)

--- a/src/Semantic/Api/Terms.hs
+++ b/src/Semantic/Api/Terms.hs
@@ -104,7 +104,7 @@ quietTerm blob = showTiming blob <$> time' ( (doParse blob >>= withSomeTerm (fma
       in stringUtf8 (status <> "\t" <> show (blobLanguage blob) <> "\t" <> blobPath blob <> "\t" <> show duration <> " ms\n")
 
 
-type ParseEffects sig m = (Member (Error SomeException) sig, Member (Reader PerLanguageModes) sig, Member Parse sig, Member (Reader Config) sig, Member (Reader TaskSession) sig, Carrier sig m)
+type ParseEffects sig m = (Member (Error SomeException) sig, Member (Reader PerLanguageModes) sig, Member Parse sig, Member (Reader Config) sig, Carrier sig m)
 
 type TermConstraints =
  '[ Taggable

--- a/src/Semantic/Api/Terms.hs
+++ b/src/Semantic/Api/Terms.hs
@@ -37,6 +37,7 @@ import           Rendering.Graph
 import           Rendering.JSON hiding (JSON)
 import qualified Rendering.JSON
 import           Semantic.Api.Bridge
+import           Semantic.Config
 import           Semantic.Proto.SemanticPB hiding (Blob)
 import           Semantic.Task
 import           Serializing.Format hiding (JSON)
@@ -102,7 +103,7 @@ quietTerm blob = showTiming blob <$> time' ( (doParse blob >>= withSomeTerm (fma
       in stringUtf8 (status <> "\t" <> show (blobLanguage blob) <> "\t" <> blobPath blob <> "\t" <> show duration <> " ms\n")
 
 
-type ParseEffects sig m = (Member (Error SomeException) sig, Member (Reader PerLanguageModes) sig, Member Parse sig, Member (Reader TaskSession) sig, Carrier sig m)
+type ParseEffects sig m = (Member (Error SomeException) sig, Member (Reader PerLanguageModes) sig, Member Parse sig, Member (Reader Config) sig, Member (Reader TaskSession) sig, Carrier sig m)
 
 type TermConstraints =
  '[ Taggable

--- a/src/Semantic/Api/Terms.hs
+++ b/src/Semantic/Api/Terms.hs
@@ -102,7 +102,7 @@ quietTerm blob = showTiming blob <$> time' ( (doParse blob >>= withSomeTerm (fma
       in stringUtf8 (status <> "\t" <> show (blobLanguage blob) <> "\t" <> blobPath blob <> "\t" <> show duration <> " ms\n")
 
 
-type ParseEffects sig m = (Member (Error SomeException) sig, Member (Reader PerLanguageModes) sig, Member Task sig, Carrier sig m)
+type ParseEffects sig m = (Member (Error SomeException) sig, Member (Reader PerLanguageModes) sig, Member Parse sig, Member Task sig, Carrier sig m)
 
 type TermConstraints =
  '[ Taggable

--- a/src/Semantic/CLI.hs
+++ b/src/Semantic/CLI.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ApplicativeDo #-}
 module Semantic.CLI (main) where
 
+import qualified Control.Carrier.Parse.Measured as Parse
 import           Control.Effect.Reader
 import           Control.Exception as Exc (displayException)
 import           Data.Blob
@@ -17,7 +18,6 @@ import           Semantic.Api hiding (File)
 import qualified Semantic.AST as AST
 import           Semantic.Config
 import qualified Semantic.Graph as Graph
-import qualified Semantic.Parse as Parse
 import qualified Semantic.Task as Task
 import qualified Semantic.Git as Git
 import           Semantic.Task.Files

--- a/src/Semantic/Graph.hs
+++ b/src/Semantic/Graph.hs
@@ -35,6 +35,7 @@ import           Analysis.Abstract.Graph as Graph
 import           Control.Abstract hiding (String)
 import           Control.Abstract.PythonPackage as PythonPackage
 import           Control.Effect.Carrier
+import           Control.Effect.Parse
 import           Data.Abstract.Address.Hole as Hole
 import           Data.Abstract.Address.Monovariant as Monovariant
 import           Data.Abstract.Address.Precise as Precise
@@ -62,7 +63,6 @@ import           Language.Haskell.HsColour.Colourise
 import           Parsing.Parser
 import           Prologue hiding (TypeError (..))
 import           Semantic.Analysis
-import           Semantic.Parse
 import           Semantic.Task as Task
 import           Source.Loc as Loc
 import           Source.Span

--- a/src/Semantic/Graph.hs
+++ b/src/Semantic/Graph.hs
@@ -62,6 +62,7 @@ import           Language.Haskell.HsColour.Colourise
 import           Parsing.Parser
 import           Prologue hiding (TypeError (..))
 import           Semantic.Analysis
+import           Semantic.Parse
 import           Semantic.Task as Task
 import           Source.Loc as Loc
 import           Source.Span

--- a/src/Semantic/Graph.hs
+++ b/src/Semantic/Graph.hs
@@ -74,8 +74,8 @@ type AnalysisClasses = '[ Declarations1, Eq1, Evaluatable, FreeVariables1, Acces
 
 runGraph :: ( Member Distribute sig
             , Member (Error SomeException) sig
+            , Member Parse sig
             , Member Resolution sig
-            , Member Task sig
             , Member Trace sig
             , Carrier sig m
             , Effect sig
@@ -230,7 +230,7 @@ runScopeGraph :: Ord address
 runScopeGraph = raiseHandler (runState lowerBound)
 
 -- | Parse a list of files into a 'Package'.
-parsePackage :: (Member Distribute sig, Member (Error SomeException) sig, Member Resolution sig, Member Task sig, Member Trace sig, Carrier sig m)
+parsePackage :: (Member Distribute sig, Member (Error SomeException) sig, Member Resolution sig, Member Parse sig, Member Trace sig, Carrier sig m)
              => Parser term -- ^ A parser.
              -> Project     -- ^ Project to parse into a package.
              -> m (Package (Blob, term))
@@ -244,7 +244,7 @@ parsePackage parser project = do
     n = Data.Abstract.Evaluatable.name (projectName project) -- TODO: Confirm this is the right `name`.
 
 -- | Parse all files in a project into 'Module's.
-parseModules :: (Member Distribute sig, Member (Error SomeException) sig, Member Task sig, Carrier sig m) => Parser term -> Project -> m [Module (Blob, term)]
+parseModules :: (Member Distribute sig, Member (Error SomeException) sig, Member Parse sig, Carrier sig m) => Parser term -> Project -> m [Module (Blob, term)]
 parseModules parser p@Project{..} = distributeFor (projectFiles p) (parseModule p parser)
 
 
@@ -258,9 +258,9 @@ parsePythonPackage :: forall syntax sig m term.
                    , term ~ Term syntax Loc
                    , Member (Error SomeException) sig
                    , Member Distribute sig
+                   , Member Parse sig
                    , Member Resolution sig
                    , Member Trace sig
-                   , Member Task sig
                    , Carrier sig m
                    , Effect sig
                    )
@@ -320,7 +320,7 @@ parsePythonPackage parser project = do
         resMap <- Task.resolutionMap p
         pure (Package.fromModules (Data.Abstract.Evaluatable.name $ projectName p) modules resMap) -- TODO: Confirm this is the right `name`.
 
-parseModule :: (Member (Error SomeException) sig, Member Task sig, Carrier sig m)
+parseModule :: (Member (Error SomeException) sig, Member Parse sig, Carrier sig m)
             => Project
             -> Parser term
             -> File

--- a/src/Semantic/Parse.hs
+++ b/src/Semantic/Parse.hs
@@ -1,0 +1,2 @@
+module Semantic.Parse
+() where

--- a/src/Semantic/Parse.hs
+++ b/src/Semantic/Parse.hs
@@ -8,3 +8,5 @@ import Parsing.Parser
 
 data Parse m k
   = forall term . Parse (Parser term) Blob (term -> m k)
+
+deriving instance Functor m => Functor (Parse m)

--- a/src/Semantic/Parse.hs
+++ b/src/Semantic/Parse.hs
@@ -14,3 +14,6 @@ deriving instance Functor m => Functor (Parse m)
 
 instance HFunctor Parse where
   hmap f (Parse parser blob k) = Parse parser blob (f . k)
+
+instance Effect Parse where
+  handle state handler (Parse parser blob k) = Parse parser blob (handler . (<$ state) . k)

--- a/src/Semantic/Parse.hs
+++ b/src/Semantic/Parse.hs
@@ -1,16 +1,39 @@
-{-# LANGUAGE ExistentialQuantification, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ExistentialQuantification, GADTs, GeneralizedNewtypeDeriving, TypeOperators, UndecidableInstances #-}
 module Semantic.Parse
 ( -- * Parse effect
   Parse(..)
 , parse
   -- * Parse carrier
 , ParseC(..)
+  -- * Exceptions
+, ParserCancelled(..)
 ) where
 
-import Control.Effect.Carrier
-import Control.Monad.IO.Class
-import Data.Blob
-import Parsing.Parser
+import qualified Assigning.Assignment as Assignment
+import qualified Assigning.Assignment.Deterministic as Deterministic
+import           Control.Effect.Error
+import           Control.Effect.Carrier
+import           Control.Effect.Reader
+import           Control.Effect.Resource
+import           Control.Effect.Trace
+import           Control.Exception
+import           Control.Monad.IO.Class
+import           Data.Blob
+import qualified Data.Error as Error
+import qualified Data.Flag as Flag
+import qualified Data.Syntax as Syntax
+import           Data.Sum
+import           Data.Term
+import           Data.Typeable
+import           Parsing.CMark
+import           Parsing.Parser
+import           Parsing.TreeSitter
+import           Prologue hiding (project)
+import           Semantic.Config
+import           Semantic.Task (TaskSession(..))
+import           Semantic.Telemetry
+import           Semantic.Timeout
+import           Source.Source (Source)
 
 data Parse m k
   = forall term . Parse (Parser term) Blob (term -> m k)
@@ -34,3 +57,126 @@ parse parser blob = send (Parse parser blob pure)
 
 newtype ParseC m a = ParseC { runParse :: m a }
   deriving (Applicative, Functor, Monad, MonadIO)
+
+instance ( Carrier sig m
+         , Member (Error SomeException) sig
+         , Member (Reader TaskSession) sig
+         , Member Resource sig
+         , Member Telemetry sig
+         , Member Timeout sig
+         , Member Trace sig
+         , MonadIO m
+         )
+      => Carrier (Parse :+: sig) (ParseC m) where
+  eff (L (Parse parser blob k)) = runParser blob parser >>= k
+  eff (R other) = ParseC (eff (handleCoercible other))
+
+-- | Parse a 'Blob' in 'IO'.
+runParser :: (Member (Error SomeException) sig, Member (Reader TaskSession) sig, Member Resource sig, Member Telemetry sig, Member Timeout sig, Member Trace sig, Carrier sig m, MonadIO m)
+          => Blob
+          -> Parser term
+          -> m term
+runParser blob@Blob{..} parser = case parser of
+  ASTParser language ->
+    time "parse.tree_sitter_ast_parse" languageTag $ do
+      config <- asks config
+      parseToAST (configTreeSitterParseTimeout config) language blob
+        >>= maybeM (throwError (SomeException ParserTimedOut))
+
+  UnmarshalParser language ->
+    time "parse.tree_sitter_ast_parse" languageTag $ do
+      config <- asks config
+      parseToPreciseAST (configTreeSitterParseTimeout config) language blob
+        >>= maybeM (throwError (SomeException ParserTimedOut))
+
+  AssignmentParser    parser assignment -> runAssignment Assignment.assign    parser blob assignment
+  DeterministicParser parser assignment -> runAssignment Deterministic.assign parser blob assignment
+
+  MarkdownParser ->
+    time "parse.cmark_parse" languageTag $
+      let term = cmarkParser blobSource
+      in length term `seq` pure term
+  SomeParser parser -> SomeTerm <$> runParser blob parser
+  where languageTag = [("language" :: String, show (blobLanguage blob))]
+
+data ParserCancelled = ParserTimedOut | AssignmentTimedOut
+  deriving (Show, Typeable)
+
+instance Exception ParserCancelled
+
+errors :: (Syntax.Error :< fs, Apply Foldable fs, Apply Functor fs) => Term (Sum fs) Assignment.Loc -> [Error.Error String]
+errors = cata $ \ (In Assignment.Loc{..} syntax) ->
+  maybe (fold syntax) (pure . Syntax.unError span) (project syntax)
+
+runAssignment
+  :: ( Apply Foldable syntaxes
+     , Apply Functor syntaxes
+     , Element Syntax.Error syntaxes
+     , Member (Error SomeException) sig
+     , Member (Reader TaskSession) sig
+     , Member Resource sig
+     , Member Telemetry sig
+     , Member Timeout sig
+     , Member Trace sig
+     , Carrier sig m
+     , MonadIO m
+     )
+  => (Source -> assignment (Term (Sum syntaxes) Assignment.Loc) -> ast -> Either (Error.Error String) (Term (Sum syntaxes) Assignment.Loc))
+  -> Parser ast
+  -> Blob
+  -> assignment (Term (Sum syntaxes) Assignment.Loc)
+  -> m (Term (Sum syntaxes) Assignment.Loc)
+runAssignment assign parser blob@Blob{..} assignment = do
+  taskSession <- ask
+  let requestID' = ("github_request_id", requestID taskSession)
+  let isPublic'  = ("github_is_public", show (isPublic taskSession))
+  let logPrintFlag = configLogPrintSource . config $ taskSession
+  let blobFields = ("path", if isPublic taskSession || Flag.toBool LogPrintSource logPrintFlag then blobPath blob else "<filtered>")
+  let logFields = requestID' : isPublic' : blobFields : languageTag
+  let shouldFailForTesting = configFailParsingForTesting $ config taskSession
+  let shouldFailOnParsing = optionsFailOnParseError . configOptions $ config taskSession
+  let shouldFailOnWarning = optionsFailOnWarning . configOptions $ config taskSession
+
+  ast <- runParser blob parser `catchError` \ (SomeException err) -> do
+    writeStat (increment "parse.parse_failures" languageTag)
+    writeLog Error "failed parsing" (("task", "parse") : logFields)
+    throwError (toException err)
+
+  res <- timeout (configAssignmentTimeout (config taskSession)) . time "parse.assign" languageTag $
+    case assign blobSource assignment ast of
+      Left err -> do
+        writeStat (increment "parse.assign_errors" languageTag)
+        logError taskSession Error blob err (("task", "assign") : logFields)
+        throwError (toException err)
+      Right term -> do
+        for_ (zip (errors term) [(0::Integer)..]) $ \ (err, i) -> case Error.errorActual err of
+          Just "ParseError" -> do
+            when (i == 0) $ writeStat (increment "parse.parse_errors" languageTag)
+            logError taskSession Warning blob err (("task", "parse") : logFields)
+            when (Flag.toBool FailOnParseError shouldFailOnParsing) (throwError (toException err))
+          _ -> do
+            when (i == 0) $ writeStat (increment "parse.assign_warnings" languageTag)
+            logError taskSession Warning blob err (("task", "assign") : logFields)
+            when (Flag.toBool FailOnWarning shouldFailOnWarning) (throwError (toException err))
+        term <$ writeStat (count "parse.nodes" (length term) languageTag)
+  case res of
+    Just r | not (Flag.toBool FailTestParsing shouldFailForTesting) -> pure r
+    _ -> do
+      writeStat (increment "assign.assign_timeouts" languageTag)
+      writeLog Error "assignment timeout" (("task", "assign") : logFields)
+      throwError (SomeException AssignmentTimedOut)
+  where languageTag = [("language", show (blobLanguage blob))]
+
+
+-- | Log an 'Error.Error' at the specified 'Level'.
+logError :: (Member Telemetry sig, Carrier sig m)
+         => TaskSession
+         -> Level
+         -> Blob
+         -> Error.Error String
+         -> [(String, String)]
+         -> m ()
+logError TaskSession{..} level blob err =
+  let shouldLogSource = configLogPrintSource config
+      shouldColorize = Flag.switch IsTerminal Error.Colourize $ configIsTerminal config
+  in writeLog level (Error.formatError shouldLogSource shouldColorize blob err)

--- a/src/Semantic/Parse.hs
+++ b/src/Semantic/Parse.hs
@@ -1,2 +1,10 @@
+{-# LANGUAGE ExistentialQuantification #-}
 module Semantic.Parse
-() where
+( Parse(..)
+) where
+
+import Data.Blob
+import Parsing.Parser
+
+data Parse m k
+  = forall term . Parse (Parser term) Blob (term -> m k)

--- a/src/Semantic/Parse.hs
+++ b/src/Semantic/Parse.hs
@@ -4,6 +4,7 @@ module Semantic.Parse
   Parse(..)
 , parse
   -- * Parse carrier
+, ParseC(..)
 ) where
 
 import Control.Effect.Carrier

--- a/src/Semantic/Parse.hs
+++ b/src/Semantic/Parse.hs
@@ -1,10 +1,13 @@
-{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE ExistentialQuantification, GeneralizedNewtypeDeriving #-}
 module Semantic.Parse
-( Parse(..)
+( -- * Parse effect
+  Parse(..)
 , parse
+  -- * Parse carrier
 ) where
 
 import Control.Effect.Carrier
+import Control.Monad.IO.Class
 import Data.Blob
 import Parsing.Parser
 
@@ -26,3 +29,7 @@ parse :: (Member Parse sig, Carrier sig m)
       -> Blob
       -> m term
 parse parser blob = send (Parse parser blob pure)
+
+
+newtype ParseC m a = ParseC { runParse :: m a }
+  deriving (Applicative, Functor, Monad, MonadIO)

--- a/src/Semantic/Parse.hs
+++ b/src/Semantic/Parse.hs
@@ -14,7 +14,6 @@ import qualified Assigning.Assignment.Deterministic as Deterministic
 import           Control.Effect.Error
 import           Control.Effect.Carrier
 import           Control.Effect.Reader
-import           Control.Effect.Resource
 import           Control.Effect.Trace
 import           Control.Exception
 import           Control.Monad.IO.Class
@@ -61,7 +60,6 @@ newtype ParseC m a = ParseC { runParse :: m a }
 instance ( Carrier sig m
          , Member (Error SomeException) sig
          , Member (Reader TaskSession) sig
-         , Member Resource sig
          , Member Telemetry sig
          , Member Timeout sig
          , Member Trace sig
@@ -72,7 +70,7 @@ instance ( Carrier sig m
   eff (R other) = ParseC (eff (handleCoercible other))
 
 -- | Parse a 'Blob' in 'IO'.
-runParser :: (Member (Error SomeException) sig, Member (Reader TaskSession) sig, Member Resource sig, Member Telemetry sig, Member Timeout sig, Member Trace sig, Carrier sig m, MonadIO m)
+runParser :: (Member (Error SomeException) sig, Member (Reader TaskSession) sig, Member Telemetry sig, Member Timeout sig, Member Trace sig, Carrier sig m, MonadIO m)
           => Blob
           -> Parser term
           -> m term
@@ -114,7 +112,6 @@ runAssignment
      , Element Syntax.Error syntaxes
      , Member (Error SomeException) sig
      , Member (Reader TaskSession) sig
-     , Member Resource sig
      , Member Telemetry sig
      , Member Timeout sig
      , Member Trace sig

--- a/src/Semantic/Parse.hs
+++ b/src/Semantic/Parse.hs
@@ -3,6 +3,7 @@ module Semantic.Parse
 ( Parse(..)
 ) where
 
+import Control.Effect.Carrier
 import Data.Blob
 import Parsing.Parser
 
@@ -10,3 +11,6 @@ data Parse m k
   = forall term . Parse (Parser term) Blob (term -> m k)
 
 deriving instance Functor m => Functor (Parse m)
+
+instance HFunctor Parse where
+  hmap f (Parse parser blob k) = Parse parser blob (f . k)

--- a/src/Semantic/Parse.hs
+++ b/src/Semantic/Parse.hs
@@ -1,8 +1,7 @@
-{-# LANGUAGE ExistentialQuantification, GADTs, GeneralizedNewtypeDeriving, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE GADTs, GeneralizedNewtypeDeriving, TypeOperators, UndecidableInstances #-}
 module Semantic.Parse
 ( -- * Parse effect
-  Parse(..)
-, parse
+  module Control.Effect.Parse
   -- * Parse carrier
 , ParseC(..)
   -- * Exceptions
@@ -13,6 +12,7 @@ import qualified Assigning.Assignment as Assignment
 import qualified Assigning.Assignment.Deterministic as Deterministic
 import           Control.Effect.Error
 import           Control.Effect.Carrier
+import           Control.Effect.Parse
 import           Control.Effect.Reader
 import           Control.Effect.Trace
 import           Control.Exception
@@ -33,26 +33,6 @@ import           Semantic.Task (TaskSession(..))
 import           Semantic.Telemetry
 import           Semantic.Timeout
 import           Source.Source (Source)
-
-data Parse m k
-  = forall term . Parse (Parser term) Blob (term -> m k)
-
-deriving instance Functor m => Functor (Parse m)
-
-instance HFunctor Parse where
-  hmap f (Parse parser blob k) = Parse parser blob (f . k)
-
-instance Effect Parse where
-  handle state handler (Parse parser blob k) = Parse parser blob (handler . (<$ state) . k)
-
-
--- | Parse a 'Blob' with the given 'Parser'.
-parse :: (Member Parse sig, Carrier sig m)
-      => Parser term
-      -> Blob
-      -> m term
-parse parser blob = send (Parse parser blob pure)
-
 
 newtype ParseC m a = ParseC { runParse :: m a }
   deriving (Applicative, Functor, Monad, MonadIO)

--- a/src/Semantic/Parse.hs
+++ b/src/Semantic/Parse.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ExistentialQuantification #-}
 module Semantic.Parse
 ( Parse(..)
+, parse
 ) where
 
 import Control.Effect.Carrier
@@ -17,3 +18,11 @@ instance HFunctor Parse where
 
 instance Effect Parse where
   handle state handler (Parse parser blob k) = Parse parser blob (handler . (<$ state) . k)
+
+
+-- | Parse a 'Blob' with the given 'Parser'.
+parse :: (Member Parse sig, Carrier sig m)
+      => Parser term
+      -> Blob
+      -> m term
+parse parser blob = send (Parse parser blob pure)

--- a/src/Semantic/REPL.hs
+++ b/src/Semantic/REPL.hs
@@ -69,8 +69,7 @@ repl proxy parser paths =
     . runReader (TaskSession config "-" False logger statter)
     . Files.runFiles
     . runResolution
-    . runParse
-    . runTaskC $ do
+    . runParse $ do
       blobs <- catMaybes <$> traverse readBlobFromFile (flip File (Language.reflect proxy) <$> paths)
       package <- fmap (fmap quieterm) <$> parsePackage parser (Project (takeDirectory (maybe "/" fst (uncons paths))) blobs (Language.reflect proxy) [])
       modules <- topologicalSort <$> runImportGraphToModules proxy (snd <$> package)

--- a/src/Semantic/REPL.hs
+++ b/src/Semantic/REPL.hs
@@ -60,7 +60,7 @@ repl proxy parser paths =
     . runReader (TaskSession config "-" False logger statter)
     . Files.runFiles
     . runResolution
-    $ runParse (configTreeSitterParseTimeout config) $ do
+    . runParse (configTreeSitterParseTimeout config) $ do
       blobs <- catMaybes <$> traverse readBlobFromFile (flip File (Language.reflect proxy) <$> paths)
       package <- fmap (fmap quieterm) <$> parsePackage parser (Project (takeDirectory (maybe "/" fst (uncons paths))) blobs (Language.reflect proxy) [])
       modules <- topologicalSort <$> runImportGraphToModules proxy (snd <$> package)

--- a/src/Semantic/REPL.hs
+++ b/src/Semantic/REPL.hs
@@ -70,7 +70,7 @@ repl proxy parser paths =
     . Files.runFiles
     . runResolution
     . runParse
-    . runTaskF $ do
+    . runTaskC $ do
       blobs <- catMaybes <$> traverse readBlobFromFile (flip File (Language.reflect proxy) <$> paths)
       package <- fmap (fmap quieterm) <$> parsePackage parser (Project (takeDirectory (maybe "/" fst (uncons paths))) blobs (Language.reflect proxy) [])
       modules <- topologicalSort <$> runImportGraphToModules proxy (snd <$> package)

--- a/src/Semantic/REPL.hs
+++ b/src/Semantic/REPL.hs
@@ -7,6 +7,7 @@ module Semantic.REPL
 import Control.Abstract hiding (Continue, List, string)
 import Control.Abstract.ScopeGraph (runScopeError)
 import Control.Abstract.Heap (runHeapError)
+import Control.Carrier.Parse.Measured
 import Control.Effect.Carrier
 import Control.Effect.Catch
 import Control.Effect.Lift
@@ -37,7 +38,6 @@ import Semantic.Analysis
 import Semantic.Config (logOptionsFromConfig)
 import Semantic.Distribute
 import Semantic.Graph
-import Semantic.Parse
 import Semantic.Resolution
 import Semantic.Task hiding (Error)
 import qualified Semantic.Task.Files as Files

--- a/src/Semantic/REPL.hs
+++ b/src/Semantic/REPL.hs
@@ -37,6 +37,7 @@ import Semantic.Analysis
 import Semantic.Config (logOptionsFromConfig)
 import Semantic.Distribute
 import Semantic.Graph
+import Semantic.Parse
 import Semantic.Resolution
 import Semantic.Task hiding (Error)
 import qualified Semantic.Task.Files as Files

--- a/src/Semantic/REPL.hs
+++ b/src/Semantic/REPL.hs
@@ -7,7 +7,7 @@ module Semantic.REPL
 import Control.Abstract hiding (Continue, List, string)
 import Control.Abstract.ScopeGraph (runScopeError)
 import Control.Abstract.Heap (runHeapError)
-import Control.Carrier.Parse.Measured
+import Control.Carrier.Parse.Simple
 import Control.Effect.Carrier
 import Control.Effect.Catch
 import Control.Effect.Lift
@@ -35,7 +35,7 @@ import Numeric (readDec)
 import Parsing.Parser (rubyParser)
 import Prologue
 import Semantic.Analysis
-import Semantic.Config (logOptionsFromConfig)
+import Semantic.Config (configTreeSitterParseTimeout, logOptionsFromConfig)
 import Semantic.Distribute
 import Semantic.Graph
 import Semantic.Resolution
@@ -70,7 +70,7 @@ repl proxy parser paths =
     . runReader (TaskSession config "-" False logger statter)
     . Files.runFiles
     . runResolution
-    . runParse $ do
+    $ runParse (configTreeSitterParseTimeout config) $ do
       blobs <- catMaybes <$> traverse readBlobFromFile (flip File (Language.reflect proxy) <$> paths)
       package <- fmap (fmap quieterm) <$> parsePackage parser (Project (takeDirectory (maybe "/" fst (uncons paths))) blobs (Language.reflect proxy) [])
       modules <- topologicalSort <$> runImportGraphToModules proxy (snd <$> package)

--- a/src/Semantic/REPL.hs
+++ b/src/Semantic/REPL.hs
@@ -51,13 +51,12 @@ instance Exception Quit
 rubyREPL = repl (Proxy @'Language.Ruby) rubyParser
 
 repl proxy parser paths =
-  withOptions debugOptions $ \config logger statter ->
+  withOptions debugOptions $ \config _ _ ->
     runM
     . withDistribute
     . runCatch
     . runError @SomeException
     . runTraceByPrinting
-    . runReader (TaskSession config "-" False logger statter)
     . Files.runFiles
     . runResolution
     . runParse (configTreeSitterParseTimeout config) $ do

--- a/src/Semantic/REPL.hs
+++ b/src/Semantic/REPL.hs
@@ -69,6 +69,7 @@ repl proxy parser paths =
     . runReader (TaskSession config "-" False logger statter)
     . Files.runFiles
     . runResolution
+    . runParse
     . runTaskF $ do
       blobs <- catMaybes <$> traverse readBlobFromFile (flip File (Language.reflect proxy) <$> paths)
       package <- fmap (fmap quieterm) <$> parsePackage parser (Project (takeDirectory (maybe "/" fst (uncons paths))) blobs (Language.reflect proxy) [])

--- a/src/Semantic/Task.hs
+++ b/src/Semantic/Task.hs
@@ -275,71 +275,76 @@ runParser blob@Blob{..} parser = case parser of
       parseToPreciseAST (configTreeSitterParseTimeout config) language blob
         >>= maybeM (throwError (SomeException ParserTimedOut))
 
-  AssignmentParser    parser assignment -> runAssignment Assignment.assign    parser assignment
-  DeterministicParser parser assignment -> runAssignment Deterministic.assign parser assignment
+  AssignmentParser    parser assignment -> runAssignment Assignment.assign    parser blob assignment
+  DeterministicParser parser assignment -> runAssignment Deterministic.assign parser blob assignment
 
   MarkdownParser ->
     time "parse.cmark_parse" languageTag $
       let term = cmarkParser blobSource
       in length term `seq` pure term
   SomeParser parser -> SomeTerm <$> runParser blob parser
-  where languageTag = pure . (,) ("language" :: String) . show $ blobLanguage blob
-        errors :: (Syntax.Error :< fs, Apply Foldable fs, Apply Functor fs) => Term (Sum fs) Assignment.Loc -> [Error.Error String]
-        errors = cata $ \ (In Assignment.Loc{..} syntax) -> case syntax of
-          _ | Just err@Syntax.Error{} <- project syntax -> [Syntax.unError span err]
-          _                                             -> fold syntax
-        runAssignment :: ( Apply Foldable syntaxes
-                         , Apply Functor syntaxes
-                         , Element Syntax.Error syntaxes
-                         , Member (Error SomeException) sig
-                         , Member (Reader TaskSession) sig
-                         , Member Resource sig
-                         , Member Telemetry sig
-                         , Member Timeout sig
-                         , Member Trace sig
-                         , Carrier sig m
-                         , MonadIO m
-                         )
-                      => (Source -> assignment (Term (Sum syntaxes) Assignment.Loc) -> ast -> Either (Error.Error String) (Term (Sum syntaxes) Assignment.Loc))
-                      -> Parser ast
-                      -> assignment (Term (Sum syntaxes) Assignment.Loc)
-                      -> m (Term (Sum syntaxes) Assignment.Loc)
-        runAssignment assign parser assignment = do
-          taskSession <- ask
-          let requestID' = ("github_request_id", requestID taskSession)
-          let isPublic'  = ("github_is_public", show (isPublic taskSession))
-          let logPrintFlag = configLogPrintSource . config $ taskSession
-          let blobFields = ("path", if isPublic taskSession || Flag.toBool LogPrintSource logPrintFlag then blobPath blob else "<filtered>")
-          let logFields = requestID' : isPublic' : blobFields : languageTag
-          let shouldFailForTesting = configFailParsingForTesting $ config taskSession
-          let shouldFailOnParsing = optionsFailOnParseError . configOptions $ config taskSession
-          let shouldFailOnWarning = optionsFailOnWarning . configOptions $ config taskSession
+  where languageTag = [("language" :: String, show (blobLanguage blob))]
 
-          ast <- runParser blob parser `catchError` \ (SomeException err) -> do
-            writeStat (increment "parse.parse_failures" languageTag)
-            writeLog Error "failed parsing" (("task", "parse") : logFields)
-            throwError (toException err)
+errors :: (Syntax.Error :< fs, Apply Foldable fs, Apply Functor fs) => Term (Sum fs) Assignment.Loc -> [Error.Error String]
+errors = cata $ \ (In Assignment.Loc{..} syntax) -> case syntax of
+  _ | Just err@Syntax.Error{} <- project syntax -> [Syntax.unError span err]
+  _                                             -> fold syntax
 
-          res <- timeout (configAssignmentTimeout (config taskSession)) . time "parse.assign" languageTag $
-            case assign blobSource assignment ast of
-              Left err -> do
-                writeStat (increment "parse.assign_errors" languageTag)
-                logError taskSession Error blob err (("task", "assign") : logFields)
-                throwError (toException err)
-              Right term -> do
-                for_ (zip (errors term) [(0::Integer)..]) $ \ (err, i) -> case Error.errorActual err of
-                  Just "ParseError" -> do
-                    when (i == 0) $ writeStat (increment "parse.parse_errors" languageTag)
-                    logError taskSession Warning blob err (("task", "parse") : logFields)
-                    when (Flag.toBool FailOnParseError shouldFailOnParsing) (throwError (toException err))
-                  _ -> do
-                    when (i == 0) $ writeStat (increment "parse.assign_warnings" languageTag)
-                    logError taskSession Warning blob err (("task", "assign") : logFields)
-                    when (Flag.toBool FailOnWarning shouldFailOnWarning) (throwError (toException err))
-                term <$ writeStat (count "parse.nodes" (length term) languageTag)
-          case res of
-            Just r | not (Flag.toBool FailTestParsing shouldFailForTesting) -> pure r
-            _ -> do
-              writeStat (increment "assign.assign_timeouts" languageTag)
-              writeLog Error "assignment timeout" (("task", "assign") : logFields)
-              throwError (SomeException AssignmentTimedOut)
+runAssignment
+  :: ( Apply Foldable syntaxes
+     , Apply Functor syntaxes
+     , Element Syntax.Error syntaxes
+     , Member (Error SomeException) sig
+     , Member (Reader TaskSession) sig
+     , Member Resource sig
+     , Member Telemetry sig
+     , Member Timeout sig
+     , Member Trace sig
+     , Carrier sig m
+     , MonadIO m
+     )
+  => (Source -> assignment (Term (Sum syntaxes) Assignment.Loc) -> ast -> Either (Error.Error String) (Term (Sum syntaxes) Assignment.Loc))
+  -> Parser ast
+  -> Blob
+  -> assignment (Term (Sum syntaxes) Assignment.Loc)
+  -> m (Term (Sum syntaxes) Assignment.Loc)
+runAssignment assign parser blob@Blob{..} assignment = do
+  taskSession <- ask
+  let requestID' = ("github_request_id", requestID taskSession)
+  let isPublic'  = ("github_is_public", show (isPublic taskSession))
+  let logPrintFlag = configLogPrintSource . config $ taskSession
+  let blobFields = ("path", if isPublic taskSession || Flag.toBool LogPrintSource logPrintFlag then blobPath blob else "<filtered>")
+  let logFields = requestID' : isPublic' : blobFields : languageTag
+  let shouldFailForTesting = configFailParsingForTesting $ config taskSession
+  let shouldFailOnParsing = optionsFailOnParseError . configOptions $ config taskSession
+  let shouldFailOnWarning = optionsFailOnWarning . configOptions $ config taskSession
+
+  ast <- runParser blob parser `catchError` \ (SomeException err) -> do
+    writeStat (increment "parse.parse_failures" languageTag)
+    writeLog Error "failed parsing" (("task", "parse") : logFields)
+    throwError (toException err)
+
+  res <- timeout (configAssignmentTimeout (config taskSession)) . time "parse.assign" languageTag $
+    case assign blobSource assignment ast of
+      Left err -> do
+        writeStat (increment "parse.assign_errors" languageTag)
+        logError taskSession Error blob err (("task", "assign") : logFields)
+        throwError (toException err)
+      Right term -> do
+        for_ (zip (errors term) [(0::Integer)..]) $ \ (err, i) -> case Error.errorActual err of
+          Just "ParseError" -> do
+            when (i == 0) $ writeStat (increment "parse.parse_errors" languageTag)
+            logError taskSession Warning blob err (("task", "parse") : logFields)
+            when (Flag.toBool FailOnParseError shouldFailOnParsing) (throwError (toException err))
+          _ -> do
+            when (i == 0) $ writeStat (increment "parse.assign_warnings" languageTag)
+            logError taskSession Warning blob err (("task", "assign") : logFields)
+            when (Flag.toBool FailOnWarning shouldFailOnWarning) (throwError (toException err))
+        term <$ writeStat (count "parse.nodes" (length term) languageTag)
+  case res of
+    Just r | not (Flag.toBool FailTestParsing shouldFailForTesting) -> pure r
+    _ -> do
+      writeStat (increment "assign.assign_timeouts" languageTag)
+      writeLog Error "assignment timeout" (("task", "assign") : logFields)
+      throwError (SomeException AssignmentTimedOut)
+  where languageTag = [("language", show (blobLanguage blob))]

--- a/src/Semantic/Task.hs
+++ b/src/Semantic/Task.hs
@@ -5,8 +5,11 @@ module Semantic.Task
 , TaskEff
 , Level(..)
 , RAlgebra
--- * Parsing
+-- * Parse effect
 , Parse
+, parse
+-- * Parse carrier
+, ParseC
 , runParse
 -- * I/O
 , Files.readBlob
@@ -25,7 +28,6 @@ module Semantic.Task
 , time
 , time'
 -- * High-level flow
-, parse
 , decorate
 , diff
 , render

--- a/src/Semantic/Task.hs
+++ b/src/Semantic/Task.hs
@@ -247,9 +247,8 @@ runParser blob@Blob{..} parser = case parser of
   where languageTag = [("language" :: String, show (blobLanguage blob))]
 
 errors :: (Syntax.Error :< fs, Apply Foldable fs, Apply Functor fs) => Term (Sum fs) Assignment.Loc -> [Error.Error String]
-errors = cata $ \ (In Assignment.Loc{..} syntax) -> case syntax of
-  _ | Just err@Syntax.Error{} <- project syntax -> [Syntax.unError span err]
-  _                                             -> fold syntax
+errors = cata $ \ (In Assignment.Loc{..} syntax) ->
+  maybe (fold syntax) (pure . Syntax.unError span) (project syntax)
 
 runAssignment
   :: ( Apply Foldable syntaxes

--- a/src/Semantic/Task.hs
+++ b/src/Semantic/Task.hs
@@ -3,12 +3,6 @@
 module Semantic.Task
 ( TaskC
 , Level(..)
--- * Parse effect
-, Parse
-, parse
--- * Parse carrier
-, ParseC
-, runParse
 -- * I/O
 , Files.readBlob
 , Files.readBlobs
@@ -43,8 +37,6 @@ module Semantic.Task
 , withOptions
 , TaskSession(..)
 , runTraceInTelemetry
--- * Exceptions
-, ParserCancelled(..)
 -- * Re-exports
 , Distribute
 , Error
@@ -54,8 +46,6 @@ module Semantic.Task
 , Telemetry
 ) where
 
-import qualified Assigning.Assignment as Assignment
-import qualified Assigning.Assignment.Deterministic as Deterministic
 import           Control.Effect.Carrier
 import           Control.Effect.Catch
 import           Control.Effect.Error
@@ -63,18 +53,9 @@ import           Control.Effect.Lift
 import           Control.Effect.Reader
 import           Control.Effect.Resource
 import           Control.Effect.Trace
-import           Control.Monad
 import           Control.Monad.IO.Class
-import           Data.Blob
 import           Data.ByteString.Builder
-import qualified Data.Error as Error
 import qualified Data.Flag as Flag
-import           Data.Sum
-import qualified Data.Syntax as Syntax
-import           Data.Term
-import           Parsing.CMark
-import           Parsing.Parser
-import           Parsing.TreeSitter
 import           Prologue hiding (project)
 import           Semantic.Config
 import           Semantic.Distribute
@@ -83,12 +64,10 @@ import qualified Semantic.Task.Files as Files
 import           Semantic.Telemetry
 import           Semantic.Timeout
 import           Serializing.Format hiding (Options)
-import           Source.Source (Source)
 
 -- | A high-level task producing some result, e.g. parsing, diffing, rendering. 'Task's can also specify explicit concurrency via 'distribute', 'distributeFor', and 'distributeFoldMap'
 type TaskC
-  = ParseC
-  ( ResolutionC
+  = ResolutionC
   ( Files.FilesC
   ( ReaderC Config
   ( ReaderC TaskSession
@@ -99,14 +78,7 @@ type TaskC
   ( ResourceC
   ( CatchC
   ( DistributeC
-  ( LiftC IO))))))))))))
-
--- | A task which parses a 'Blob' with the given 'Parser'.
-parse :: (Member Parse sig, Carrier sig m)
-      => Parser term
-      -> Blob
-      -> m term
-parse parser blob = send (Parse parser blob pure)
+  ( LiftC IO)))))))))))
 
 serialize :: (Member (Reader Config) sig, Carrier sig m)
           => Format input
@@ -143,7 +115,6 @@ runTask taskSession@TaskSession{..} task = do
           . runReader config
           . Files.runFiles
           . runResolution
-          . runParse
     run task
   queueStat statter stat
   pure result
@@ -169,142 +140,3 @@ newtype TraceInTelemetryC m a = TraceInTelemetryC { runTraceInTelemetryC :: m a 
 instance (Member Telemetry sig, Carrier sig m) => Carrier (Trace :+: sig) (TraceInTelemetryC m) where
   eff (R other)         = TraceInTelemetryC . eff . handleCoercible $ other
   eff (L (Trace str k)) = writeLog Debug str [] >> k
-
-
-data Parse m k
-  = forall term . Parse (Parser term) Blob (term -> m k)
-
-deriving instance Functor m => Functor (Parse m)
-
-instance HFunctor Parse where
-  hmap f (Parse parser blob k) = Parse parser blob (f . k)
-
-instance Effect Parse where
-  handle state handler (Parse parser blob k) = Parse parser blob (handler . (<$ state) . k)
-
-
-newtype ParseC m a = ParseC { runParse :: m a }
-  deriving (Applicative, Functor, Monad, MonadIO)
-
-instance ( Carrier sig m
-         , Member (Error SomeException) sig
-         , Member (Reader TaskSession) sig
-         , Member Resource sig
-         , Member Telemetry sig
-         , Member Timeout sig
-         , Member Trace sig
-         , MonadIO m
-         )
-      => Carrier (Parse :+: sig) (ParseC m) where
-  eff (L (Parse parser blob k)) = runParser blob parser >>= k
-  eff (R other) = ParseC (eff (handleCoercible other))
-
-
--- | Log an 'Error.Error' at the specified 'Level'.
-logError :: (Member Telemetry sig, Carrier sig m)
-         => TaskSession
-         -> Level
-         -> Blob
-         -> Error.Error String
-         -> [(String, String)]
-         -> m ()
-logError TaskSession{..} level blob err =
-  let shouldLogSource = configLogPrintSource config
-      shouldColorize = Flag.switch IsTerminal Error.Colourize $ configIsTerminal config
-  in writeLog level (Error.formatError shouldLogSource shouldColorize blob err)
-
-data ParserCancelled = ParserTimedOut | AssignmentTimedOut
-  deriving (Show, Typeable)
-
-instance Exception ParserCancelled
-
--- | Parse a 'Blob' in 'IO'.
-runParser :: (Member (Error SomeException) sig, Member (Reader TaskSession) sig, Member Resource sig, Member Telemetry sig, Member Timeout sig, Member Trace sig, Carrier sig m, MonadIO m)
-          => Blob
-          -> Parser term
-          -> m term
-runParser blob@Blob{..} parser = case parser of
-  ASTParser language ->
-    time "parse.tree_sitter_ast_parse" languageTag $ do
-      config <- asks config
-      parseToAST (configTreeSitterParseTimeout config) language blob
-        >>= maybeM (throwError (SomeException ParserTimedOut))
-
-  UnmarshalParser language ->
-    time "parse.tree_sitter_ast_parse" languageTag $ do
-      config <- asks config
-      parseToPreciseAST (configTreeSitterParseTimeout config) language blob
-        >>= maybeM (throwError (SomeException ParserTimedOut))
-
-  AssignmentParser    parser assignment -> runAssignment Assignment.assign    parser blob assignment
-  DeterministicParser parser assignment -> runAssignment Deterministic.assign parser blob assignment
-
-  MarkdownParser ->
-    time "parse.cmark_parse" languageTag $
-      let term = cmarkParser blobSource
-      in length term `seq` pure term
-  SomeParser parser -> SomeTerm <$> runParser blob parser
-  where languageTag = [("language" :: String, show (blobLanguage blob))]
-
-errors :: (Syntax.Error :< fs, Apply Foldable fs, Apply Functor fs) => Term (Sum fs) Assignment.Loc -> [Error.Error String]
-errors = cata $ \ (In Assignment.Loc{..} syntax) ->
-  maybe (fold syntax) (pure . Syntax.unError span) (project syntax)
-
-runAssignment
-  :: ( Apply Foldable syntaxes
-     , Apply Functor syntaxes
-     , Element Syntax.Error syntaxes
-     , Member (Error SomeException) sig
-     , Member (Reader TaskSession) sig
-     , Member Resource sig
-     , Member Telemetry sig
-     , Member Timeout sig
-     , Member Trace sig
-     , Carrier sig m
-     , MonadIO m
-     )
-  => (Source -> assignment (Term (Sum syntaxes) Assignment.Loc) -> ast -> Either (Error.Error String) (Term (Sum syntaxes) Assignment.Loc))
-  -> Parser ast
-  -> Blob
-  -> assignment (Term (Sum syntaxes) Assignment.Loc)
-  -> m (Term (Sum syntaxes) Assignment.Loc)
-runAssignment assign parser blob@Blob{..} assignment = do
-  taskSession <- ask
-  let requestID' = ("github_request_id", requestID taskSession)
-  let isPublic'  = ("github_is_public", show (isPublic taskSession))
-  let logPrintFlag = configLogPrintSource . config $ taskSession
-  let blobFields = ("path", if isPublic taskSession || Flag.toBool LogPrintSource logPrintFlag then blobPath blob else "<filtered>")
-  let logFields = requestID' : isPublic' : blobFields : languageTag
-  let shouldFailForTesting = configFailParsingForTesting $ config taskSession
-  let shouldFailOnParsing = optionsFailOnParseError . configOptions $ config taskSession
-  let shouldFailOnWarning = optionsFailOnWarning . configOptions $ config taskSession
-
-  ast <- runParser blob parser `catchError` \ (SomeException err) -> do
-    writeStat (increment "parse.parse_failures" languageTag)
-    writeLog Error "failed parsing" (("task", "parse") : logFields)
-    throwError (toException err)
-
-  res <- timeout (configAssignmentTimeout (config taskSession)) . time "parse.assign" languageTag $
-    case assign blobSource assignment ast of
-      Left err -> do
-        writeStat (increment "parse.assign_errors" languageTag)
-        logError taskSession Error blob err (("task", "assign") : logFields)
-        throwError (toException err)
-      Right term -> do
-        for_ (zip (errors term) [(0::Integer)..]) $ \ (err, i) -> case Error.errorActual err of
-          Just "ParseError" -> do
-            when (i == 0) $ writeStat (increment "parse.parse_errors" languageTag)
-            logError taskSession Warning blob err (("task", "parse") : logFields)
-            when (Flag.toBool FailOnParseError shouldFailOnParsing) (throwError (toException err))
-          _ -> do
-            when (i == 0) $ writeStat (increment "parse.assign_warnings" languageTag)
-            logError taskSession Warning blob err (("task", "assign") : logFields)
-            when (Flag.toBool FailOnWarning shouldFailOnWarning) (throwError (toException err))
-        term <$ writeStat (count "parse.nodes" (length term) languageTag)
-  case res of
-    Just r | not (Flag.toBool FailTestParsing shouldFailForTesting) -> pure r
-    _ -> do
-      writeStat (increment "assign.assign_timeouts" languageTag)
-      writeLog Error "assignment timeout" (("task", "assign") : logFields)
-      throwError (SomeException AssignmentTimedOut)
-  where languageTag = [("language", show (blobLanguage blob))]

--- a/src/Semantic/Task.hs
+++ b/src/Semantic/Task.hs
@@ -28,7 +28,6 @@ module Semantic.Task
 , time'
 -- * High-level flow
 , diff
-, render
 , serialize
 -- * Concurrency
 , distribute
@@ -120,13 +119,6 @@ diff :: (Diffable syntax, Eq1 syntax, Hashable1 syntax, Traversable syntax, Memb
      => These (Term syntax ann) (Term syntax ann)
      -> m (Diff syntax ann ann)
 diff terms = send (Semantic.Task.Diff terms pure)
-
--- | A task which renders some input using the supplied 'Renderer' function.
-render :: Applicative m
-       => (input -> output)
-       -> input
-       -> m output
-render renderer = pure . renderer
 
 serialize :: (Member Task sig, Carrier sig m)
           => Format input

--- a/src/Semantic/Task.hs
+++ b/src/Semantic/Task.hs
@@ -108,12 +108,12 @@ parse :: (Member Parse sig, Carrier sig m)
       -> m term
 parse parser blob = send (Parse parser blob pure)
 
-serialize :: (Member (Reader TaskSession) sig, Carrier sig m)
+serialize :: (Member (Reader Config) sig, Carrier sig m)
           => Format input
           -> input
           -> m Builder
 serialize format input = do
-  formatStyle <- asks (Flag.choose IsTerminal Plain Colourful . configIsTerminal . config)
+  formatStyle <- asks (Flag.choose IsTerminal Plain Colourful . configIsTerminal)
   pure (runSerialize formatStyle format input)
 
 data TaskSession

--- a/src/Semantic/Task.hs
+++ b/src/Semantic/Task.hs
@@ -227,7 +227,7 @@ runTaskF = runTaskC
 newtype TaskC m a = TaskC { runTaskC :: m a }
   deriving (Applicative, Functor, Monad, MonadIO)
 
-instance (Member (Error SomeException) sig, Member (Lift IO) sig, Member (Reader TaskSession) sig, Member Resource sig, Member Telemetry sig, Member Timeout sig, Member Trace sig, Carrier sig m, MonadIO m) => Carrier (Task :+: sig) (TaskC m) where
+instance (Member (Error SomeException) sig, Member (Reader TaskSession) sig, Member Resource sig, Member Telemetry sig, Member Timeout sig, Member Trace sig, Carrier sig m, MonadIO m) => Carrier (Task :+: sig) (TaskC m) where
   eff (R other) = TaskC . eff . handleCoercible $ other
   eff (L op) = case op of
     Parse parser blob k -> runParser blob parser >>= k
@@ -258,7 +258,7 @@ data ParserCancelled = ParserTimedOut | AssignmentTimedOut
 instance Exception ParserCancelled
 
 -- | Parse a 'Blob' in 'IO'.
-runParser :: (Member (Error SomeException) sig, Member (Lift IO) sig, Member (Reader TaskSession) sig, Member Resource sig, Member Telemetry sig, Member Timeout sig, Member Trace sig, Carrier sig m, MonadIO m)
+runParser :: (Member (Error SomeException) sig, Member (Reader TaskSession) sig, Member Resource sig, Member Telemetry sig, Member Timeout sig, Member Trace sig, Carrier sig m, MonadIO m)
           => Blob
           -> Parser term
           -> m term
@@ -292,7 +292,6 @@ runParser blob@Blob{..} parser = case parser of
                          , Apply Functor syntaxes
                          , Element Syntax.Error syntaxes
                          , Member (Error SomeException) sig
-                         , Member (Lift IO) sig
                          , Member (Reader TaskSession) sig
                          , Member Resource sig
                          , Member Telemetry sig

--- a/src/Semantic/Task.hs
+++ b/src/Semantic/Task.hs
@@ -4,7 +4,6 @@ module Semantic.Task
 ( Task
 , TaskEff
 , Level(..)
-, RAlgebra
 -- * Parse effect
 , Parse
 , parse
@@ -28,7 +27,6 @@ module Semantic.Task
 , time
 , time'
 -- * High-level flow
-, decorate
 , diff
 , render
 , serialize
@@ -60,7 +58,6 @@ module Semantic.Task
 , Telemetry
 ) where
 
-import           Analysis.Decorator (decoratorWithAlgebra)
 import qualified Assigning.Assignment as Assignment
 import qualified Assigning.Assignment.Deterministic as Deterministic
 import           Control.Effect.Carrier
@@ -93,7 +90,6 @@ import qualified Semantic.Task.Files as Files
 import           Semantic.Telemetry
 import           Semantic.Timeout
 import           Serializing.Format hiding (Options)
-import           Source.Loc
 import           Source.Source (Source)
 
 -- | A high-level task producing some result, e.g. parsing, diffing, rendering. 'Task's can also specify explicit concurrency via 'distribute', 'distributeFor', and 'distributeFoldMap'
@@ -121,13 +117,6 @@ parse :: (Member Parse sig, Carrier sig m)
       -> Blob
       -> m term
 parse parser blob = send (Parse parser blob pure)
-
--- | A task which decorates a 'Term' with values computed using the supplied 'RAlgebra' function.
-decorate :: (Functor f, Applicative m)
-         => RAlgebra (TermF f Loc) (Term f Loc) field
-         -> Term f Loc
-         -> m (Term f field)
-decorate algebra term = pure (decoratorWithAlgebra algebra term)
 
 -- | A task which diffs a pair of terms using the supplied 'Differ' function.
 diff :: (Diffable syntax, Eq1 syntax, Hashable1 syntax, Traversable syntax, Member Task sig, Carrier sig m)

--- a/src/Semantic/Task.hs
+++ b/src/Semantic/Task.hs
@@ -45,7 +45,7 @@ module Semantic.Task
 , withOptions
 , TaskSession(..)
 , runTraceInTelemetry
-, runTaskF
+, runTaskC
 -- * Exceptions
 , ParserCancelled(..)
 -- * Re-exports
@@ -155,7 +155,7 @@ runTask taskSession@TaskSession{..} task = do
           . Files.runFiles
           . runResolution
           . runParse
-          . runTaskF
+          . runTaskC
     run task
   queueStat statter stat
   pure result
@@ -224,9 +224,6 @@ instance HFunctor Task where
 instance Effect Task where
   handle state handler (Semantic.Task.Diff terms k) = Semantic.Task.Diff terms (handler . (<$ state) . k)
 
--- | Run a 'Task' effect by performing the actions in 'IO'.
-runTaskF :: TaskC m a -> m a
-runTaskF = runTaskC
 
 newtype TaskC m a = TaskC { runTaskC :: m a }
   deriving (Applicative, Functor, Monad, MonadIO)

--- a/src/Semantic/Task.hs
+++ b/src/Semantic/Task.hs
@@ -90,6 +90,7 @@ type TaskC
   = ParseC
   ( ResolutionC
   ( Files.FilesC
+  ( ReaderC Config
   ( ReaderC TaskSession
   ( TraceInTelemetryC
   ( TelemetryC
@@ -98,7 +99,7 @@ type TaskC
   ( ResourceC
   ( CatchC
   ( DistributeC
-  ( LiftC IO)))))))))))
+  ( LiftC IO))))))))))))
 
 -- | A task which parses a 'Blob' with the given 'Parser'.
 parse :: (Member Parse sig, Carrier sig m)
@@ -139,6 +140,7 @@ runTask taskSession@TaskSession{..} task = do
           . runTelemetry logger statter
           . runTraceInTelemetry
           . runReader taskSession
+          . runReader config
           . Files.runFiles
           . runResolution
           . runParse

--- a/src/Semantic/Util.hs
+++ b/src/Semantic/Util.hs
@@ -20,7 +20,7 @@ import Prelude hiding (readFile)
 import           Control.Abstract
 import           Control.Abstract.Heap (runHeapError)
 import           Control.Abstract.ScopeGraph (runScopeError)
-import           Control.Carrier.Parse.Measured
+import           Control.Carrier.Parse.Simple
 import           Control.Effect.Lift
 import           Control.Effect.Trace (runTraceByPrinting)
 import           Control.Exception (displayException)
@@ -103,7 +103,7 @@ evaluateProject proxy parser paths = withOptions debugOptions $ \ config logger 
 
 -- Evaluate a project consisting of the listed paths.
 evaluateProject' session proxy parser paths = do
-  res <- runTask session . runParse $ do
+  res <- runTask session $ asks configTreeSitterParseTimeout >>= \ timeout -> runParse timeout $ do
     blobs <- catMaybes <$> traverse readBlobFromFile (flip File (Language.reflect proxy) <$> paths)
     package <- fmap (quieterm . snd) <$> parsePackage parser (Project (takeDirectory (maybe "/" fst (uncons paths))) blobs (Language.reflect proxy) [])
     modules <- topologicalSort <$> runImportGraphToModules proxy package
@@ -122,8 +122,8 @@ parseFile parser = runTask' . (parse parser <=< readBlob . fileForPath)
 parseFileQuiet parser = runTaskQuiet . (parse parser <=< readBlob . fileForPath)
 
 runTask', runTaskQuiet :: ParseC TaskC a -> IO a
-runTask' task = runTaskWithOptions debugOptions (runParse task) >>= either (die . displayException) pure
-runTaskQuiet task = runTaskWithOptions defaultOptions (runParse task) >>= either (die . displayException) pure
+runTask' task = runTaskWithOptions debugOptions (asks configTreeSitterParseTimeout >>= \ timeout -> runParse timeout task) >>= either (die . displayException) pure
+runTaskQuiet task = runTaskWithOptions defaultOptions (asks configTreeSitterParseTimeout >>= \ timeout -> runParse timeout task) >>= either (die . displayException) pure
 
 mergeErrors :: Either (SomeError (Sum errs)) (Either (SomeError err) result) -> Either (SomeError (Sum (err ': errs))) result
 mergeErrors = either (\ (SomeError sum) -> Left (SomeError (weaken sum))) (either (\ (SomeError err) -> Left (SomeError (inject err))) Right)

--- a/src/Semantic/Util.hs
+++ b/src/Semantic/Util.hs
@@ -120,7 +120,7 @@ parseFile, parseFileQuiet :: Parser term -> FilePath -> IO term
 parseFile parser = runTask' . (parse parser <=< readBlob . fileForPath)
 parseFileQuiet parser = runTaskQuiet . (parse parser <=< readBlob . fileForPath)
 
-runTask', runTaskQuiet :: TaskEff a -> IO a
+runTask', runTaskQuiet :: TaskC a -> IO a
 runTask' task = runTaskWithOptions debugOptions task >>= either (die . displayException) pure
 runTaskQuiet task = runTaskWithOptions defaultOptions task >>= either (die . displayException) pure
 

--- a/src/Semantic/Util.hs
+++ b/src/Semantic/Util.hs
@@ -20,6 +20,7 @@ import Prelude hiding (readFile)
 import           Control.Abstract
 import           Control.Abstract.Heap (runHeapError)
 import           Control.Abstract.ScopeGraph (runScopeError)
+import           Control.Carrier.Parse.Measured
 import           Control.Effect.Lift
 import           Control.Effect.Trace (runTraceByPrinting)
 import           Control.Exception (displayException)
@@ -47,7 +48,6 @@ import           Prologue
 import           Semantic.Analysis
 import           Semantic.Config
 import           Semantic.Graph
-import           Semantic.Parse
 import           Semantic.Task
 import           Source.Loc
 import           System.Exit (die)

--- a/test/Examples.hs
+++ b/test/Examples.hs
@@ -2,6 +2,7 @@
 {-# OPTIONS_GHC -O1 #-}
 module Main (main) where
 
+import           Control.Carrier.Parse.Measured
 import           Control.Effect
 import           Control.Effect.Reader
 import           Control.Exception (displayException)
@@ -76,7 +77,7 @@ buildExamples session lang tsDir = do
   files <- globDir1 (compile ("**/*" <> languageExtension lang)) (Path.toString (tsDir </> languageExampleDir lang))
   let paths = Path.relFile <$> files
   trees <- forConcurrently paths $ \file -> pure $ HUnit.testCase (Path.toString file) $ do
-    res <- runTask session (parseFilePath file)
+    res <- runTask session (runParse (parseFilePath file))
     case res of
       Left (SomeException e) -> case cast e of
         -- We have a number of known assignment timeouts, consider these pending specs instead of failing the build.
@@ -122,5 +123,5 @@ knownFailuresForPath tsDir (Just path)
   )
 
 
-parseFilePath :: (Member (Error SomeException) sig, Member Distribute sig, Member Task sig, Member Files sig, Carrier sig m, MonadIO m) => Path.RelFile -> m Bool
+parseFilePath :: (Member (Error SomeException) sig, Member Distribute sig, Member Parse sig, Member Files sig, Member (Reader Config) sig, Carrier sig m, MonadIO m) => Path.RelFile -> m Bool
 parseFilePath path = readBlob (fileForRelPath path) >>= runReader (PerLanguageModes ALaCarte) . parseTermBuilder @[] TermShow . pure >>= const (pure True)

--- a/test/Parsing/Spec.hs
+++ b/test/Parsing/Spec.hs
@@ -1,11 +1,11 @@
+{-# LANGUAGE TypeApplications #-}
 module Parsing.Spec (spec) where
 
-import Data.AST
 import Data.Blob
 import Data.ByteString.Char8 (pack)
 import Data.Duration
+import Data.Either
 import Data.Language
-import Data.Maybe
 import Parsing.TreeSitter
 import Source.Source
 import SpecHelpers
@@ -19,15 +19,15 @@ spec = do
 
     it "returns a result when the timeout does not expire" $ do
       let timeout = fromMicroseconds 0 -- Zero microseconds indicates no timeout
-      let parseTask = parseToAST timeout tree_sitter_json largeBlob :: TaskC (Maybe (AST [] Grammar))
+      let parseTask = parseToAST @Grammar timeout tree_sitter_json largeBlob
       result <- runTaskOrDie parseTask
-      (isJust result) `shouldBe` True
+      isRight result `shouldBe` True
 
     it "returns nothing when the timeout expires" $ do
       let timeout = fromMicroseconds 1000
-      let parseTask = parseToAST timeout tree_sitter_json largeBlob :: TaskC (Maybe (AST [] Grammar))
+      let parseTask = parseToAST @Grammar timeout tree_sitter_json largeBlob
       result <- runTaskOrDie parseTask
-      (isNothing result) `shouldBe` True
+      isLeft result `shouldBe` True
 
 toJSONSource :: Show a => a -> Source
 toJSONSource = fromUTF8 . pack . show

--- a/test/Parsing/Spec.hs
+++ b/test/Parsing/Spec.hs
@@ -19,13 +19,13 @@ spec = do
 
     it "returns a result when the timeout does not expire" $ do
       let timeout = fromMicroseconds 0 -- Zero microseconds indicates no timeout
-      let parseTask = parseToAST timeout tree_sitter_json largeBlob :: TaskEff (Maybe (AST [] Grammar))
+      let parseTask = parseToAST timeout tree_sitter_json largeBlob :: TaskC (Maybe (AST [] Grammar))
       result <- runTaskOrDie parseTask
       (isJust result) `shouldBe` True
 
     it "returns nothing when the timeout expires" $ do
       let timeout = fromMicroseconds 1000
-      let parseTask = parseToAST timeout tree_sitter_json largeBlob :: TaskEff (Maybe (AST [] Grammar))
+      let parseTask = parseToAST timeout tree_sitter_json largeBlob :: TaskC (Maybe (AST [] Grammar))
       result <- runTaskOrDie parseTask
       (isNothing result) `shouldBe` True
 

--- a/test/Rendering/TOC/Spec.hs
+++ b/test/Rendering/TOC/Spec.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE DataKinds, MonoLocalBinds, TypeOperators #-}
 module Rendering.TOC.Spec (spec) where
 
+import Analysis.Decorator
 import Analysis.TOCSummary
 import Control.Effect
+import Control.Effect.Parse
 import Data.Aeson hiding (defaultOptions)
 import Data.Bifunctor
 import Data.Bifunctor.Join
@@ -232,10 +234,10 @@ diffWithParser :: ( Eq1 syntax
                   , HasDeclaration syntax
                   , Hashable1 syntax
                   , Member Distribute sig
-                  , Member Task sig
+                  , Member Parse sig
                   , Carrier sig m
                   )
                => Parser (Term syntax Loc)
                -> BlobPair
                -> m (Diff syntax (Maybe Declaration) (Maybe Declaration))
-diffWithParser parser blobs = distributeFor blobs (\ blob -> parse parser blob >>= decorate (declarationAlgebra blob)) >>= SpecHelpers.diff . runJoin
+diffWithParser parser blobs = diffTermPair . runJoin <$> distributeFor blobs (\ blob -> decoratorWithAlgebra (declarationAlgebra blob) <$> parse parser blob)

--- a/test/Reprinting/Spec.hs
+++ b/test/Reprinting/Spec.hs
@@ -4,6 +4,7 @@ module Reprinting.Spec (spec) where
 
 import SpecHelpers
 
+import           Control.Effect.Parse
 import           Data.Foldable
 import           Streaming hiding (Sum)
 import qualified Streaming.Prelude as Streaming
@@ -66,5 +67,5 @@ spec = describe "reprinting" $ do
         let eitherPrinted = runReprinter src defaultJSONPipeline tagged
         printed <- either (fail "reprinter failed") pure eitherPrinted
 
-        tree' <- runTaskOrDie (parse jsonParser (makeBlob printed path Language.JSON mempty))
+        tree' <- runTaskOrDie (runParseWithConfig (parse jsonParser (makeBlob printed path Language.JSON mempty)))
         length tree' `shouldSatisfy` (/= 0)

--- a/test/Semantic/CLI/Spec.hs
+++ b/test/Semantic/CLI/Spec.hs
@@ -33,7 +33,7 @@ renderDiff ref new = unsafePerformIO $ do
     else ["git", "diff", ref, new]
 {-# NOINLINE renderDiff #-}
 
-testForDiffFixture :: (String, [BlobPair] -> TaskEff Builder, [Both File], Path.RelFile) -> TestTree
+testForDiffFixture :: (String, [BlobPair] -> TaskC Builder, [Both File], Path.RelFile) -> TestTree
 testForDiffFixture (diffRenderer, runDiff, files, expected) =
   goldenVsStringDiff
     ("diff fixture renders to " <> diffRenderer <> " " <> show files)
@@ -41,7 +41,7 @@ testForDiffFixture (diffRenderer, runDiff, files, expected) =
     (Path.toString expected)
     (fmap toLazyByteString . runTaskOrDie $ readBlobPairs (Right files) >>= runDiff)
 
-testForParseFixture :: (String, [Blob] -> TaskEff Builder, [File], Path.RelFile) -> TestTree
+testForParseFixture :: (String, [Blob] -> TaskC Builder, [File], Path.RelFile) -> TestTree
 testForParseFixture (format, runParse, files, expected) =
   goldenVsStringDiff
     ("diff fixture renders to " <> format)
@@ -49,7 +49,7 @@ testForParseFixture (format, runParse, files, expected) =
     (Path.toString expected)
     (fmap toLazyByteString . runTaskOrDie $ readBlobs (FilesFromPaths files) >>= runParse)
 
-parseFixtures :: [(String, [Blob] -> TaskEff Builder, [File], Path.RelFile)]
+parseFixtures :: [(String, [Blob] -> TaskC Builder, [File], Path.RelFile)]
 parseFixtures =
   [ ("s-expression", run . parseTermBuilder TermSExpression, path, Path.relFile "test/fixtures/ruby/corpus/and-or.parseA.txt")
   , ("json", run . parseTermBuilder TermJSONTree, path, prefix </> Path.file "parse-tree.json")
@@ -64,7 +64,7 @@ parseFixtures =
         prefix = Path.relDir "test/fixtures/cli"
         run = runReader (PerLanguageModes ALaCarte)
 
-diffFixtures :: [(String, [BlobPair] -> TaskEff Builder, [Both File], Path.RelFile)]
+diffFixtures :: [(String, [BlobPair] -> TaskC Builder, [Both File], Path.RelFile)]
 diffFixtures =
   [ ("json diff", parseDiffBuilder DiffJSONTree, pathMode, prefix </> Path.file "diff-tree.json")
   , ("s-expression diff", parseDiffBuilder DiffSExpression, pathMode, Path.relFile "test/fixtures/ruby/corpus/method-declaration.diffA-B.txt")

--- a/test/Semantic/CLI/Spec.hs
+++ b/test/Semantic/CLI/Spec.hs
@@ -1,5 +1,6 @@
 module Semantic.CLI.Spec (testTree) where
 
+import           Control.Carrier.Parse.Simple
 import           Control.Effect.Reader
 import           Data.ByteString.Builder
 import           Semantic.Api hiding (Blob, BlobPair, File)
@@ -33,7 +34,7 @@ renderDiff ref new = unsafePerformIO $ do
     else ["git", "diff", ref, new]
 {-# NOINLINE renderDiff #-}
 
-testForDiffFixture :: (String, [BlobPair] -> TaskC Builder, [Both File], Path.RelFile) -> TestTree
+testForDiffFixture :: (String, [BlobPair] -> ParseC TaskC Builder, [Both File], Path.RelFile) -> TestTree
 testForDiffFixture (diffRenderer, runDiff, files, expected) =
   goldenVsStringDiff
     ("diff fixture renders to " <> diffRenderer <> " " <> show files)
@@ -41,7 +42,7 @@ testForDiffFixture (diffRenderer, runDiff, files, expected) =
     (Path.toString expected)
     (fmap toLazyByteString . runTaskOrDie $ readBlobPairs (Right files) >>= runDiff)
 
-testForParseFixture :: (String, [Blob] -> TaskC Builder, [File], Path.RelFile) -> TestTree
+testForParseFixture :: (String, [Blob] -> ParseC TaskC Builder, [File], Path.RelFile) -> TestTree
 testForParseFixture (format, runParse, files, expected) =
   goldenVsStringDiff
     ("diff fixture renders to " <> format)
@@ -49,7 +50,7 @@ testForParseFixture (format, runParse, files, expected) =
     (Path.toString expected)
     (fmap toLazyByteString . runTaskOrDie $ readBlobs (FilesFromPaths files) >>= runParse)
 
-parseFixtures :: [(String, [Blob] -> TaskC Builder, [File], Path.RelFile)]
+parseFixtures :: [(String, [Blob] -> ParseC TaskC Builder, [File], Path.RelFile)]
 parseFixtures =
   [ ("s-expression", run . parseTermBuilder TermSExpression, path, Path.relFile "test/fixtures/ruby/corpus/and-or.parseA.txt")
   , ("json", run . parseTermBuilder TermJSONTree, path, prefix </> Path.file "parse-tree.json")
@@ -64,7 +65,7 @@ parseFixtures =
         prefix = Path.relDir "test/fixtures/cli"
         run = runReader (PerLanguageModes ALaCarte)
 
-diffFixtures :: [(String, [BlobPair] -> TaskC Builder, [Both File], Path.RelFile)]
+diffFixtures :: [(String, [BlobPair] -> ParseC TaskC Builder, [Both File], Path.RelFile)]
 diffFixtures =
   [ ("json diff", parseDiffBuilder DiffJSONTree, pathMode, prefix </> Path.file "diff-tree.json")
   , ("s-expression diff", parseDiffBuilder DiffSExpression, pathMode, Path.relFile "test/fixtures/ruby/corpus/method-declaration.diffA-B.txt")

--- a/test/Semantic/Spec.hs
+++ b/test/Semantic/Spec.hs
@@ -20,7 +20,7 @@ spec = do
       output `shouldBe` "{\"trees\":[{\"path\":\"methods.rb\",\"error\":\"NoLanguageForBlob \\\"methods.rb\\\"\",\"language\":\"Unknown\"}]}\n"
 
     it "throws if given an unknown language for sexpression output" $ do
-      res <- runTaskWithOptions defaultOptions (runReader (PerLanguageModes ALaCarte) (parseTermBuilder TermSExpression [setBlobLanguage Unknown methodsBlob]))
+      res <- runTaskWithOptions defaultOptions (runReader (PerLanguageModes ALaCarte) (runParseWithConfig (parseTermBuilder TermSExpression [setBlobLanguage Unknown methodsBlob])))
       case res of
         Left exc    -> fromException exc `shouldBe` Just (NoLanguageForBlob "methods.rb")
         Right _bad  -> fail "Expected parseTermBuilder to fail for an unknown language"

--- a/test/SpecHelpers.hs
+++ b/test/SpecHelpers.hs
@@ -8,6 +8,7 @@ module SpecHelpers
 , parseTestFile
 , readFilePathPair
 , runTaskOrDie
+, runParseWithConfig
 , TaskSession(..)
 , testEvaluating
 , toList
@@ -20,6 +21,7 @@ module SpecHelpers
 ) where
 
 import Control.Abstract
+import Control.Carrier.Parse.Simple
 import Data.Abstract.ScopeGraph (EdgeLabel(..))
 import qualified Data.Abstract.ScopeGraph as ScopeGraph
 import qualified Data.Abstract.Heap as Heap
@@ -88,15 +90,18 @@ instance IsString Name where
 diffFilePaths :: TaskSession -> Both Path.RelFile -> IO ByteString
 diffFilePaths session paths
   = readFilePathPair paths
-    >>= runTask session . parseDiffBuilder @[] DiffSExpression . pure
+    >>= runTask session . runParse (configTreeSitterParseTimeout (config session)) . parseDiffBuilder @[] DiffSExpression . pure
     >>= either (die . displayException) (pure . runBuilder)
 
 -- | Returns an s-expression parse tree for the specified path.
 parseFilePath :: TaskSession -> Path.RelFile -> IO (Either SomeException ByteString)
 parseFilePath session path = do
   blob <- readBlobFromFile (fileForRelPath path)
-  res <- runTask session . runReader (PerLanguageModes ALaCarte) $ parseTermBuilder TermSExpression (toList blob)
+  res <- runTask session . runParse (configTreeSitterParseTimeout (config session)) . runReader (PerLanguageModes ALaCarte) $ parseTermBuilder TermSExpression (toList blob)
   pure (runBuilder <$> res)
+
+runParseWithConfig :: (Carrier sig m, Member (Reader Config) sig) => ParseC m a -> m a
+runParseWithConfig task = asks configTreeSitterParseTimeout >>= \ timeout -> runParse timeout task
 
 -- | Read two files to a BlobPair.
 readFilePathPair :: Both Path.RelFile -> IO BlobPair
@@ -110,8 +115,8 @@ parseTestFile parser path = runTaskOrDie $ do
   pure (blob, term)
 
 -- Run a Task and call `die` if it returns an Exception.
-runTaskOrDie :: TaskC a -> IO a
-runTaskOrDie task = runTaskWithOptions defaultOptions { optionsLogLevel = Nothing } task >>= either (die . displayException) pure
+runTaskOrDie :: ParseC TaskC a -> IO a
+runTaskOrDie task = runTaskWithOptions defaultOptions { optionsLogLevel = Nothing } (runParseWithConfig task) >>= either (die . displayException) pure
 
 type TestEvaluatingC term
   = ResumableC (BaseError (AddressError Precise (Val term)))

--- a/test/SpecHelpers.hs
+++ b/test/SpecHelpers.hs
@@ -110,7 +110,7 @@ parseTestFile parser path = runTaskOrDie $ do
   pure (blob, term)
 
 -- Run a Task and call `die` if it returns an Exception.
-runTaskOrDie :: TaskEff a -> IO a
+runTaskOrDie :: TaskC a -> IO a
 runTaskOrDie task = runTaskWithOptions defaultOptions { optionsLogLevel = Nothing } task >>= either (die . displayException) pure
 
 type TestEvaluatingC term


### PR DESCRIPTION
This PR:

- [x] Factors a `Parse` effect out of `Task`.
- [x] Defines two separate carriers for `Parse`: one which does all the telemetry stuff, and one which does not and therefore makes far fewer requests of its calling environment, making it more suitable for `ghci` & the tests.
- [x] Factors the rest of the actions, all of which amounted to pure functions, out of `Task` as well.
- [x] 🔥s `Task`.

Two things I’d like to try with this but haven’t got that far yet:

1. Make the `Parser` constructors into separate constructors of the `Parse` effect instead, so instead of doing `parse pythonParser blob` you’d have `parsePython blob` or something like that.

2. Define the `Measured` carrier for the `Parse` effect by composing onto the basic one, just layering in the timing/telemetry/etc.