### PR TITLE
Use Exception.try and throw to handle errors from tree-sitter FFI.

### DIFF
--- a/src/Control/Carrier/Parse/Measured.hs
+++ b/src/Control/Carrier/Parse/Measured.hs
@@ -60,13 +60,13 @@ runParser blob@Blob{..} parser = case parser of
     time "parse.tree_sitter_ast_parse" languageTag $ do
       config <- asks config
       parseToAST (configTreeSitterParseTimeout config) language blob
-        >>= either (trace >=> const (throwError (SomeException ParserTimedOut))) pure
+        >>= either (\e -> trace (displayException e) *> throwError e) pure
 
   UnmarshalParser language ->
     time "parse.tree_sitter_ast_parse" languageTag $ do
       config <- asks config
       parseToPreciseAST (configTreeSitterParseTimeout config) language blob
-        >>= either (trace >=> const (throwError (SomeException ParserTimedOut))) pure
+        >>= either (\e -> trace (displayException e) *> throwError e) pure
 
   AssignmentParser    parser assignment -> runAssignment Assignment.assign    parser blob assignment
   DeterministicParser parser assignment -> runAssignment Deterministic.assign parser blob assignment

--- a/src/Control/Carrier/Parse/Measured.hs
+++ b/src/Control/Carrier/Parse/Measured.hs
@@ -60,13 +60,13 @@ runParser blob@Blob{..} parser = case parser of
     time "parse.tree_sitter_ast_parse" languageTag $ do
       config <- asks config
       parseToAST (configTreeSitterParseTimeout config) language blob
-        >>= either (\e -> trace (displayException e) *> throwError e) pure
+        >>= either (\e -> trace (displayException e) *> throwError (SomeException e)) pure
 
   UnmarshalParser language ->
     time "parse.tree_sitter_ast_parse" languageTag $ do
       config <- asks config
       parseToPreciseAST (configTreeSitterParseTimeout config) language blob
-        >>= either (\e -> trace (displayException e) *> throwError e) pure
+        >>= either (\e -> trace (displayException e) *> throwError (SomeException e)) pure
 
   AssignmentParser    parser assignment -> runAssignment Assignment.assign    parser blob assignment
   DeterministicParser parser assignment -> runAssignment Deterministic.assign parser blob assignment

--- a/src/Control/Carrier/Parse/Simple.hs
+++ b/src/Control/Carrier/Parse/Simple.hs
@@ -51,11 +51,11 @@ runParser
 runParser timeout blob@Blob{..} parser = case parser of
   ASTParser language ->
     parseToAST timeout language blob
-      >>= either (throwError . SomeException . ParseFailure) pure
+      >>= either throwError pure
 
   UnmarshalParser language ->
     parseToPreciseAST timeout language blob
-      >>= either (throwError . SomeException . ParseFailure) pure
+      >>= either throwError pure
 
   AssignmentParser    parser assignment ->
     runParser timeout blob parser >>= either (throwError . toException) pure . Assignment.assign    blobSource assignment

--- a/src/Control/Carrier/Parse/Simple.hs
+++ b/src/Control/Carrier/Parse/Simple.hs
@@ -51,11 +51,11 @@ runParser
 runParser timeout blob@Blob{..} parser = case parser of
   ASTParser language ->
     parseToAST timeout language blob
-      >>= either throwError pure
+      >>= either (throwError . SomeException) pure
 
   UnmarshalParser language ->
     parseToPreciseAST timeout language blob
-      >>= either throwError pure
+      >>= either (throwError . SomeException) pure
 
   AssignmentParser    parser assignment ->
     runParser timeout blob parser >>= either (throwError . toException) pure . Assignment.assign    blobSource assignment


### PR DESCRIPTION
The crossing into IO and across the FFI boundary is a dangerous
journey. A `try` call handles all possible dynamic/IO-bound
exceptions, and enables the use of a more precise error type on our
end (rather than `String`) and makes downstream code simpler (we just
pass on the thrown `SomeException` rather than throwing a new one
based on a `Left String`).