### PR TITLE
List parsers independently

### DIFF
--- a/src/Control/Effect/Parse.hs
+++ b/src/Control/Effect/Parse.hs
@@ -40,9 +40,9 @@ parse parser blob = send (Parse parser blob pure)
 -- | Parse a 'Blob' with one of the provided parsers, and run an action on the abstracted term.
 parseWith
   :: (Carrier sig m, Member (Error SomeException) sig, Member Parse sig)
-  => Map.Map Language (SomeParser c ann)
-  -> (forall term . c term => term ann -> m a)
-  -> Blob
+  => Map.Map Language (SomeParser c ann)       -- ^ The set of parsers to select from.
+  -> (forall term . c term => term ann -> m a) -- ^ A function to run on the parsed term. Note that the term is abstract, but constrained by @c@, allowing you to do anything @c@ allows, and requiring that all the input parsers produce terms supporting @c@.
+  -> Blob                                      -- ^ The blob to parse.
   -> m a
 parseWith parsers with blob = case Map.lookup (blobLanguage blob) parsers of
   Just (SomeParser parser) -> parse parser blob >>= with
@@ -51,9 +51,9 @@ parseWith parsers with blob = case Map.lookup (blobLanguage blob) parsers of
 -- | Parse a 'BlobPair' with one of the provided parsers, and run an action on the abstracted term pair.
 parsePairWith
   :: (Carrier sig m, Member (Error SomeException) sig, Member Parse sig)
-  => Map.Map Language (SomeParser c ann)
-  -> (forall term . c term => These (term ann) (term ann) -> m a)
-  -> BlobPair
+  => Map.Map Language (SomeParser c ann)                          -- ^ The set of parsers to select from.
+  -> (forall term . c term => These (term ann) (term ann) -> m a) -- ^ A function to run on the parsed terms. Note that the terms are abstract, but constrained by @c@, allowing you to do anything @c@ allows, and requiring that all the input parsers produce terms supporting @c@.
+  -> BlobPair                                                     -- ^ The blob pair to parse.
   -> m a
 parsePairWith parsers with blobPair = case Map.lookup (languageForBlobPair blobPair) parsers of
   Just (SomeParser parser) -> traverse (parse parser) blobPair >>= with . runJoin

--- a/src/Control/Effect/Parse.hs
+++ b/src/Control/Effect/Parse.hs
@@ -13,6 +13,7 @@ import Control.Exception (SomeException)
 import Data.Bifunctor.Join
 import Data.Blob
 import Data.Language
+import qualified Data.Map as Map
 import Data.These
 import Parsing.Parser
 
@@ -38,20 +39,20 @@ parse parser blob = send (Parse parser blob pure)
 
 parseWith
   :: (Carrier sig m, Member (Error SomeException) sig, Member Parse sig)
-  => [(Language, SomeParser c ann)]
+  => Map.Map Language (SomeParser c ann)
   -> (forall term . c term => term ann -> m a)
   -> Blob
   -> m a
-parseWith parsers with blob = case lookup (blobLanguage blob) parsers of
+parseWith parsers with blob = case Map.lookup (blobLanguage blob) parsers of
   Just (SomeParser parser) -> parse parser blob >>= with
   _                        -> noLanguageForBlob (blobPath blob)
 
 parsePairWith
   :: (Carrier sig m, Member (Error SomeException) sig, Member Parse sig)
-  => [(Language, SomeParser c ann)]
+  => Map.Map Language (SomeParser c ann)
   -> (forall term . c term => These (term ann) (term ann) -> m a)
   -> BlobPair
   -> m a
-parsePairWith parsers with blobPair = case lookup (languageForBlobPair blobPair) parsers of
+parsePairWith parsers with blobPair = case Map.lookup (languageForBlobPair blobPair) parsers of
   Just (SomeParser parser) -> traverse (parse parser) blobPair >>= with . runJoin
   _                        -> noLanguageForBlob (pathForBlobPair blobPair)

--- a/src/Control/Effect/Parse.hs
+++ b/src/Control/Effect/Parse.hs
@@ -37,6 +37,7 @@ parse :: (Member Parse sig, Carrier sig m)
 parse parser blob = send (Parse parser blob pure)
 
 
+-- | Parse a 'Blob' with one of the provided parsers, and run an action on the abstracted term.
 parseWith
   :: (Carrier sig m, Member (Error SomeException) sig, Member Parse sig)
   => Map.Map Language (SomeParser c ann)
@@ -47,6 +48,7 @@ parseWith parsers with blob = case Map.lookup (blobLanguage blob) parsers of
   Just (SomeParser parser) -> parse parser blob >>= with
   _                        -> noLanguageForBlob (blobPath blob)
 
+-- | Parse a 'BlobPair' with one of the provided parsers, and run an action on the abstracted term pair.
 parsePairWith
   :: (Carrier sig m, Member (Error SomeException) sig, Member Parse sig)
   => Map.Map Language (SomeParser c ann)

--- a/src/Control/Effect/Parse.hs
+++ b/src/Control/Effect/Parse.hs
@@ -49,9 +49,9 @@ parseWith parsers with blob = case lookup (blobLanguage blob) parsers of
 parsePairWith
   :: (Carrier sig m, Member (Error SomeException) sig, Member Parse sig)
   => [(Language, SomeParser c ann)]
-  -> (forall term . c term => Join These (term ann) -> m a)
+  -> (forall term . c term => These (term ann) (term ann) -> m a)
   -> BlobPair
   -> m a
 parsePairWith parsers with blobPair = case lookup (languageForBlobPair blobPair) parsers of
-  Just (SomeParser parser) -> traverse (parse parser) blobPair >>= with
+  Just (SomeParser parser) -> traverse (parse parser) blobPair >>= with . runJoin
   _                        -> noLanguageForBlob (pathForBlobPair blobPair)

--- a/src/Diffing/Interpreter.hs
+++ b/src/Diffing/Interpreter.hs
@@ -33,7 +33,7 @@ stripDiff = bimap snd snd
 class HasDiffFor (term :: * -> *) where
   type DiffFor term = (res :: * -> * -> *) | res -> term
 
-class HasDiffFor term => DiffTerms term where
+class (Bifoldable (DiffFor term), HasDiffFor term) => DiffTerms term where
   -- | Diff a 'These' of terms.
   diffTermPair :: These (term ann1) (term ann2) -> DiffFor term ann1 ann2
 

--- a/src/Diffing/Interpreter.hs
+++ b/src/Diffing/Interpreter.hs
@@ -30,7 +30,7 @@ stripDiff :: Functor syntax
 stripDiff = bimap snd snd
 
 class (Bifoldable (DiffFor term)) => DiffTerms term where
-  type DiffFor term = (res :: * -> * -> *) | res -> term
+  type DiffFor term = (diff :: * -> * -> *) | diff -> term
 
   -- | Diff a 'These' of terms.
   diffTermPair :: These (term ann1) (term ann2) -> DiffFor term ann1 ann2

--- a/src/Diffing/Interpreter.hs
+++ b/src/Diffing/Interpreter.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving, TypeFamilyDependencies, TypeOperators, UndecidableInstances #-}
 module Diffing.Interpreter
 ( diffTerms
-, HasDiffFor(..)
 , DiffTerms(..)
 , stripDiff
 ) where
@@ -30,17 +29,14 @@ stripDiff :: Functor syntax
           -> Diff.Diff syntax ann1 ann2
 stripDiff = bimap snd snd
 
-class HasDiffFor (term :: * -> *) where
+class (Bifoldable (DiffFor term)) => DiffTerms term where
   type DiffFor term = (res :: * -> * -> *) | res -> term
 
-class (Bifoldable (DiffFor term), HasDiffFor term) => DiffTerms term where
   -- | Diff a 'These' of terms.
   diffTermPair :: These (term ann1) (term ann2) -> DiffFor term ann1 ann2
 
-instance HasDiffFor (Term syntax) where
-  type DiffFor (Term syntax) = Diff.Diff syntax
-
 instance (Diffable syntax, Eq1 syntax, Hashable1 syntax, Traversable syntax) => DiffTerms (Term syntax) where
+  type DiffFor (Term syntax) = Diff.Diff syntax
   diffTermPair = these Diff.deleting Diff.inserting diffTerms
 
 

--- a/src/Diffing/Interpreter.hs
+++ b/src/Diffing/Interpreter.hs
@@ -29,6 +29,7 @@ stripDiff :: Functor syntax
           -> Diff.Diff syntax ann1 ann2
 stripDiff = bimap snd snd
 
+-- | The class of term types for which we can compute a diff.
 class (Bifoldable (DiffFor term)) => DiffTerms term where
   type DiffFor term = (diff :: * -> * -> *) | diff -> term
 

--- a/src/Diffing/Interpreter.hs
+++ b/src/Diffing/Interpreter.hs
@@ -31,6 +31,9 @@ stripDiff = bimap snd snd
 
 -- | The class of term types for which we can compute a diff.
 class (Bifoldable (DiffFor term)) => DiffTerms term where
+  -- | The type of diffs for the given term type.
+  --
+  -- Note that the dependency means that the diff type is in 1:1 correspondence with the term type. This allows subclasses of 'DiffTerms' to receive e.g. @'DiffFor' term a b@ without incurring ambiguity, since every diff type is unique to its term type.
   type DiffFor term = (diff :: * -> * -> *) | diff -> term
 
   -- | Diff a 'These' of terms.

--- a/src/Diffing/Interpreter.hs
+++ b/src/Diffing/Interpreter.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FunctionalDependencies, GeneralizedNewtypeDeriving, TypeFamilyDependencies, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, TypeFamilyDependencies, TypeOperators, UndecidableInstances #-}
 module Diffing.Interpreter
 ( diffTerms
 , HasDiffFor(..)
@@ -33,14 +33,14 @@ stripDiff = bimap snd snd
 class HasDiffFor (term :: * -> *) where
   type DiffFor term = (res :: * -> * -> *) | res -> term
 
-class DiffTerms term diff | diff -> term, term -> diff where
+class HasDiffFor term => DiffTerms term where
   -- | Diff a 'These' of terms.
-  diffTermPair :: These (term ann1) (term ann2) -> diff ann1 ann2
+  diffTermPair :: These (term ann1) (term ann2) -> DiffFor term ann1 ann2
 
 instance HasDiffFor (Term syntax) where
   type DiffFor (Term syntax) = Diff.Diff syntax
 
-instance (Diffable syntax, Eq1 syntax, Hashable1 syntax, Traversable syntax) => DiffTerms (Term syntax) (Diff.Diff syntax) where
+instance (Diffable syntax, Eq1 syntax, Hashable1 syntax, Traversable syntax) => DiffTerms (Term syntax) where
   diffTermPair = these Diff.deleting Diff.inserting diffTerms
 
 

--- a/src/Diffing/Interpreter.hs
+++ b/src/Diffing/Interpreter.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE FunctionalDependencies, GeneralizedNewtypeDeriving, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE FunctionalDependencies, GeneralizedNewtypeDeriving, TypeFamilyDependencies, TypeOperators, UndecidableInstances #-}
 module Diffing.Interpreter
 ( diffTerms
+, HasDiffFor(..)
 , DiffTerms(..)
 , stripDiff
 ) where
@@ -29,9 +30,15 @@ stripDiff :: Functor syntax
           -> Diff.Diff syntax ann1 ann2
 stripDiff = bimap snd snd
 
+class HasDiffFor (term :: * -> *) where
+  type DiffFor term = (res :: * -> * -> *) | res -> term
+
 class DiffTerms term diff | diff -> term, term -> diff where
   -- | Diff a 'These' of terms.
   diffTermPair :: These (term ann1) (term ann2) -> diff ann1 ann2
+
+instance HasDiffFor (Term syntax) where
+  type DiffFor (Term syntax) = Diff.Diff syntax
 
 instance (Diffable syntax, Eq1 syntax, Hashable1 syntax, Traversable syntax) => DiffTerms (Term syntax) (Diff.Diff syntax) where
   diffTermPair = these Diff.deleting Diff.inserting diffTerms

--- a/src/Parsing/Parser.hs
+++ b/src/Parsing/Parser.hs
@@ -170,8 +170,8 @@ markdownParser :: Parser Markdown.Term
 markdownParser = AssignmentParser MarkdownParser Markdown.assignment
 
 
-precisePythonParser :: Parser (Py.Term Loc)
-precisePythonParser = UnmarshalParser tree_sitter_python
+pythonParserPrecise :: Parser (Py.Term Loc)
+pythonParserPrecise = UnmarshalParser tree_sitter_python
 
 
 -- | A parser for producing specialized (tree-sitter) ASTs.
@@ -228,12 +228,12 @@ pythonParserALaCarte' :: c (Term (Sum Python.Syntax)) => (Language, SomeParser c
 pythonParserALaCarte' = (Python, SomeParser pythonParser)
 
 pythonParserPrecise' :: c Py.Term => (Language, SomeParser c Loc)
-pythonParserPrecise' = (Python, SomeParser precisePythonParser)
+pythonParserPrecise' = (Python, SomeParser pythonParserPrecise)
 
 pythonParser' :: (c (Term (Sum Python.Syntax)), c Py.Term) => PerLanguageModes -> (Language, SomeParser c Loc)
 pythonParser' modes = case pythonMode modes of
   ALaCarte -> (Python, SomeParser pythonParser)
-  Precise  -> (Python, SomeParser precisePythonParser)
+  Precise  -> (Python, SomeParser pythonParserPrecise)
 
 rubyParser' :: c (Term (Sum Ruby.Syntax)) => (Language, SomeParser c Loc)
 rubyParser' = (Ruby, SomeParser rubyParser)

--- a/src/Parsing/Parser.hs
+++ b/src/Parsing/Parser.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE AllowAmbiguousTypes, ConstraintKinds, GADTs, RankNTypes, ScopedTypeVariables, TypeOperators #-}
+{-# LANGUAGE AllowAmbiguousTypes, ConstraintKinds, KindSignatures, GADTs, RankNTypes, ScopedTypeVariables, TypeOperators #-}
 module Parsing.Parser
 ( Parser(..)
 , SomeAnalysisParser(..)
@@ -50,6 +50,7 @@ import           Data.Abstract.Evaluatable (HasPrelude)
 import           Data.AST
 import           Data.Graph.ControlFlowVertex (VertexDeclaration')
 import           Data.Language
+import           Data.Kind (Constraint)
 import qualified Data.Map as Map
 import           Data.Sum
 import qualified Data.Syntax as Syntax
@@ -80,7 +81,7 @@ import           TreeSitter.Unmarshal
 
 
 -- | A parser, suitable for program analysis, for some specific language, producing 'Term's whose syntax satisfies a list of typeclass constraints.
-data SomeAnalysisParser constraint ann where
+data SomeAnalysisParser (constraint :: (* -> *) -> Constraint) ann where
   SomeAnalysisParser :: ( constraint (Sum fs)
                         , Apply (VertexDeclaration' (Sum fs)) fs
                         , HasPrelude lang

--- a/src/Parsing/Parser.hs
+++ b/src/Parsing/Parser.hs
@@ -81,26 +81,26 @@ import           TreeSitter.Unmarshal
 
 
 -- | A parser, suitable for program analysis, for some specific language, producing 'Term's whose syntax satisfies a list of typeclass constraints.
-data SomeAnalysisParser typeclasses ann where
-  SomeAnalysisParser :: ( ApplyAll typeclasses (Sum fs)
+data SomeAnalysisParser constraint ann where
+  SomeAnalysisParser :: ( constraint (Sum fs)
                         , Apply (VertexDeclaration' (Sum fs)) fs
                         , HasPrelude lang
                         )
                      => Parser (Term (Sum fs) ann)
                      -> Proxy lang
-                     -> SomeAnalysisParser typeclasses ann
+                     -> SomeAnalysisParser constraint ann
 
 -- | A parser for some specific language, producing 'Term's whose syntax satisfies a list of typeclass constraints.
-someAnalysisParser :: ( ApplyAll typeclasses (Sum Go.Syntax)
-                      , ApplyAll typeclasses (Sum PHP.Syntax)
-                      , ApplyAll typeclasses (Sum Python.Syntax)
-                      , ApplyAll typeclasses (Sum Ruby.Syntax)
-                      , ApplyAll typeclasses (Sum TypeScript.Syntax)
-                      , ApplyAll typeclasses (Sum Haskell.Syntax)
+someAnalysisParser :: ( constraint (Sum Go.Syntax)
+                      , constraint (Sum PHP.Syntax)
+                      , constraint (Sum Python.Syntax)
+                      , constraint (Sum Ruby.Syntax)
+                      , constraint (Sum TypeScript.Syntax)
+                      , constraint (Sum Haskell.Syntax)
                       )
-                   => proxy typeclasses                  -- ^ A proxy for the list of typeclasses required, e.g. @(Proxy :: Proxy '[Show1])@.
-                   -> Language                           -- ^ The 'Language' to select.
-                   -> SomeAnalysisParser typeclasses Loc -- ^ A 'SomeAnalysisParser' abstracting the syntax type to be produced.
+                   => proxy constraint                  -- ^ A proxy for the list of typeclasses required, e.g. @(Proxy :: Proxy '[Show1])@.
+                   -> Language                          -- ^ The 'Language' to select.
+                   -> SomeAnalysisParser constraint Loc -- ^ A 'SomeAnalysisParser' abstracting the syntax type to be produced.
 someAnalysisParser _ Go         = SomeAnalysisParser goParser         (Proxy @'Go)
 someAnalysisParser _ Haskell    = SomeAnalysisParser haskellParser    (Proxy @'Haskell)
 someAnalysisParser _ JavaScript = SomeAnalysisParser typescriptParser (Proxy @'JavaScript)

--- a/src/Parsing/Parser.hs
+++ b/src/Parsing/Parser.hs
@@ -201,6 +201,9 @@ someASTParser Markdown   = Nothing
 someASTParser Unknown    = Nothing
 
 
+-- | A parser producing terms of existentially-quantified type under some constraint @c@.
+--
+--   This can be used to perform actions on terms supporting some feature abstracted using a typeclass, without knowing (or caring) what the specific term types are.
 data SomeParser c a where
   SomeParser :: c t => Parser (t a) -> SomeParser c a
 

--- a/src/Parsing/Parser.hs
+++ b/src/Parsing/Parser.hs
@@ -48,6 +48,7 @@ import           Data.Abstract.Evaluatable (HasPrelude)
 import           Data.AST
 import           Data.Graph.ControlFlowVertex (VertexDeclaration')
 import           Data.Language
+import qualified Data.Map as Map
 import           Data.Sum
 import qualified Data.Syntax as Syntax
 import           Data.Term
@@ -256,8 +257,8 @@ aLaCarteParsers
      , c (Term (Sum TSX.Syntax))
      , c (Term (Sum TypeScript.Syntax))
      )
-  => [(Language, SomeParser c Loc)]
-aLaCarteParsers =
+  => Map Language (SomeParser c Loc)
+aLaCarteParsers = Map.fromList
   [ goParser'
   , haskellParser'
   , javascriptParser'
@@ -271,8 +272,8 @@ aLaCarteParsers =
   , tsxParser'
   ]
 
-preciseParsers :: c Py.Term => [(Language, SomeParser c Loc)]
-preciseParsers =
+preciseParsers :: c Py.Term => Map Language (SomeParser c Loc)
+preciseParsers = Map.fromList
   [ pythonParserPrecise'
   ]
 
@@ -289,8 +290,8 @@ allParsers
      , c (Term (Sum TypeScript.Syntax))
      )
   => PerLanguageModes
-  -> [(Language, SomeParser c Loc)]
-allParsers modes =
+  -> Map Language (SomeParser c Loc)
+allParsers modes = Map.fromList
   [ goParser'
   , haskellParser'
   , javascriptParser'

--- a/src/Parsing/Parser.hs
+++ b/src/Parsing/Parser.hs
@@ -246,6 +246,7 @@ typescriptParser' :: c (Term (Sum TypeScript.Syntax)) => (Language, SomeParser c
 typescriptParser' = (TypeScript, SomeParser typescriptParser)
 
 
+-- | The canonical set of parsers producing à la carte terms.
 aLaCarteParsers
   :: ( c (Term (Sum Go.Syntax))
      , c (Term (Sum Haskell.Syntax))
@@ -272,11 +273,13 @@ aLaCarteParsers = Map.fromList
   , tsxParser'
   ]
 
+-- | The canonical set of parsers producing precise terms.
 preciseParsers :: c Py.Term => Map Language (SomeParser c Loc)
 preciseParsers = Map.fromList
   [ pythonParserPrecise'
   ]
 
+-- | The canonical set of all parsers for the passed per-language modes.
 allParsers
   :: ( c (Term (Sum Go.Syntax))
      , c (Term (Sum Haskell.Syntax))

--- a/src/Parsing/Parser.hs
+++ b/src/Parsing/Parser.hs
@@ -98,7 +98,7 @@ someAnalysisParser :: ( constraint (Sum Go.Syntax)
                       , constraint (Sum TypeScript.Syntax)
                       , constraint (Sum Haskell.Syntax)
                       )
-                   => proxy constraint                  -- ^ A proxy for the list of typeclasses required, e.g. @(Proxy :: Proxy '[Show1])@.
+                   => proxy constraint                  -- ^ A proxy for the constraint required, e.g. @(Proxy \@Show1)@.
                    -> Language                          -- ^ The 'Language' to select.
                    -> SomeAnalysisParser constraint Loc -- ^ A 'SomeAnalysisParser' abstracting the syntax type to be produced.
 someAnalysisParser _ Go         = SomeAnalysisParser goParser         (Proxy @'Go)

--- a/src/Parsing/Parser.hs
+++ b/src/Parsing/Parser.hs
@@ -1,11 +1,10 @@
-{-# LANGUAGE AllowAmbiguousTypes, ConstraintKinds, GADTs, RankNTypes, ScopedTypeVariables, TypeFamilies, TypeOperators #-}
+{-# LANGUAGE AllowAmbiguousTypes, ConstraintKinds, GADTs, RankNTypes, ScopedTypeVariables, TypeOperators #-}
 module Parsing.Parser
 ( Parser(..)
 , SomeAnalysisParser(..)
 , SomeASTParser(..)
 , someASTParser
 , someAnalysisParser
-, ApplyAll
 -- * À la carte parsers
 , goParser
 , goASTParser
@@ -50,7 +49,6 @@ import qualified CMarkGFM
 import           Data.Abstract.Evaluatable (HasPrelude)
 import           Data.AST
 import           Data.Graph.ControlFlowVertex (VertexDeclaration')
-import           Data.Kind
 import           Data.Language
 import           Data.Sum
 import qualified Data.Syntax as Syntax
@@ -129,12 +127,6 @@ data Parser term where
                       -> Parser (Term (Sum syntaxes) Loc)
   -- | A parser for 'Markdown' using cmark.
   MarkdownParser :: Parser (Term (TermF [] CMarkGFM.NodeType) (Node Markdown.Grammar))
-
-
--- | Apply all of a list of typeclasses to all of a list of functors using 'Apply'. Used by 'someParser' to constrain all of the language-specific syntax types to the typeclasses in question.
-type family ApplyAll (typeclasses :: [(* -> *) -> Constraint]) (syntax :: * -> *) :: Constraint where
-  ApplyAll (typeclass ': typeclasses) syntax = (typeclass syntax, ApplyAll typeclasses syntax)
-  ApplyAll '[] syntax = ()
 
 
 goParser :: Parser Go.Term

--- a/src/Parsing/Parser.hs
+++ b/src/Parsing/Parser.hs
@@ -20,8 +20,6 @@ module Parsing.Parser
 , phpParser
 , phpASTParser
 , haskellParser
-  -- * Precise parsers
-, precisePythonParser
   -- * Abstract parsers
 , SomeParser(..)
 , goParser'

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -5,6 +5,7 @@ module Semantic.Api.Diffs
   , diffGraph
 
   , doDiff
+  , diffWith
   , DiffEffects
 
   , SomeTermPair(..)

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -256,7 +256,3 @@ doParse blobPair decorate = case languageForBlobPair blobPair of
 
 data SomeTermPair ann where
   SomeTermPair :: DiffActions term  => Join These (term ann) -> SomeTermPair ann
-
-
-diffParsers :: [(Language, SomeParser DiffActions Loc)]
-diffParsers = aLaCarteParsers

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -176,28 +176,6 @@ instance (Foldable syntax, Functor syntax, HasDeclaration syntax) => SummarizeDi
         = TOCSummaryFile path language changes (V.cons (TOCSummaryError errorText (converting #? errorSpan)) errors)
 
 
-class
-  ( DiffTerms term
-  , DOTGraphDiff term
-  , JSONGraphDiff term
-  , JSONTreeDiff term
-  , SExprDiff term
-  , ShowDiff term
-  , LegacySummarizeDiff term
-  , SummarizeDiff term
-  ) => DiffActions term
-instance
-  ( DiffTerms term
-  , DOTGraphDiff term
-  , JSONGraphDiff term
-  , JSONTreeDiff term
-  , SExprDiff term
-  , ShowDiff term
-  , LegacySummarizeDiff term
-  , SummarizeDiff term
-  ) => DiffActions term
-
-
 class (c1 term, c2 term) => ((c1 :: (* -> *) -> Constraint) & (c2 :: (* -> *) -> Constraint)) (term :: * -> *)
 
 infixl 9 &

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -62,7 +62,7 @@ parseDiffBuilder :: (Traversable t, DiffEffects sig m) => DiffOutputFormat -> t 
 parseDiffBuilder DiffJSONTree    = distributeFoldMap jsonDiff >=> serialize Format.JSON -- NB: Serialize happens at the top level for these two JSON formats to collect results of multiple blob pairs.
 parseDiffBuilder DiffJSONGraph   = diffGraph >=> serialize Format.JSON
 parseDiffBuilder DiffSExpression = distributeFoldMap (diffWith @Loc sexprDiffParsers (const id) sexprDiff)
-parseDiffBuilder DiffShow        = distributeFoldMap (doDiff (const id) showDiff)
+parseDiffBuilder DiffShow        = distributeFoldMap (diffWith @Loc showDiffParsers (const id) showDiff)
 parseDiffBuilder DiffDotGraph    = distributeFoldMap (doDiff (const id) dotGraphDiff)
 
 jsonDiff :: DiffEffects sig m => BlobPair -> m (Rendering.JSON.JSON "diffs" SomeJSON)

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -10,7 +10,9 @@ module Semantic.Api.Diffs
 
   , SomeTermPair(..)
 
+  , legacySummarizeDiffParsers
   , LegacySummarizeDiff(..)
+  , summarizeDiffParsers
   , SummarizeDiff(..)
   ) where
 
@@ -85,12 +87,18 @@ type DiffEffects sig m = (Member (Error SomeException) sig, Member (Reader Confi
 type Decorate a b = forall term . DiffActions term => Blob -> term a -> term b
 
 
+dotGraphDiffParsers :: [(Language, SomeParser DOTGraphDiff Loc)]
+dotGraphDiffParsers = aLaCarteParsers
+
 class HasDiffFor term => DOTGraphDiff term where
   dotGraphDiff :: (Carrier sig m, Member (Reader Config) sig) => DiffFor term Loc Loc -> m Builder
 
 instance (ConstructorName syntax, Foldable syntax, Functor syntax) => DOTGraphDiff (Term syntax) where
   dotGraphDiff = serialize (DOT (diffStyle "diffs")) . renderTreeGraph
 
+
+jsonGraphDiffParsers :: [(Language, SomeParser JSONGraphDiff Loc)]
+jsonGraphDiffParsers = aLaCarteParsers
 
 class HasDiffFor term => JSONGraphDiff term where
   jsonGraphDiff :: BlobPair -> DiffFor term Loc Loc -> DiffTreeFileGraph
@@ -104,12 +112,18 @@ instance (Foldable syntax, Functor syntax, ConstructorName syntax) => JSONGraphD
         lang = bridging # languageForBlobPair blobPair
 
 
+jsonTreeDiffParsers :: [(Language, SomeParser JSONTreeDiff Loc)]
+jsonTreeDiffParsers = aLaCarteParsers
+
 class HasDiffFor term => JSONTreeDiff term where
   jsonTreeDiff :: BlobPair -> DiffFor term Loc Loc -> Rendering.JSON.JSON "diffs" SomeJSON
 
 instance ToJSONFields1 syntax => JSONTreeDiff (Term syntax) where
   jsonTreeDiff = renderJSONDiff
 
+
+sexprDiffParsers :: [(Language, SomeParser SExprDiff Loc)]
+sexprDiffParsers = aLaCarteParsers
 
 class HasDiffFor term => SExprDiff term where
   sexprDiff :: (Carrier sig m, Member (Reader Config) sig) => DiffFor term Loc Loc -> m Builder
@@ -118,12 +132,18 @@ instance (ConstructorName syntax, Foldable syntax, Functor syntax) => SExprDiff 
   sexprDiff = serialize (SExpression ByConstructorName)
 
 
+showDiffParsers :: [(Language, SomeParser ShowDiff Loc)]
+showDiffParsers = aLaCarteParsers
+
 class HasDiffFor term => ShowDiff term where
   showDiff :: (Carrier sig m, Member (Reader Config) sig) => DiffFor term Loc Loc -> m Builder
 
 instance Show1 syntax => ShowDiff (Term syntax) where
   showDiff = serialize Show
 
+
+legacySummarizeDiffParsers :: [(Language, SomeParser LegacySummarizeDiff Loc)]
+legacySummarizeDiffParsers = aLaCarteParsers
 
 class HasDiffFor term => LegacySummarizeDiff term where
   legacyDecorateTerm :: Blob -> term Loc -> term (Maybe Declaration)
@@ -133,6 +153,9 @@ instance (Foldable syntax, Functor syntax, HasDeclaration syntax) => LegacySumma
   legacyDecorateTerm = decoratorWithAlgebra . declarationAlgebra
   legacySummarizeDiff = renderToCDiff
 
+
+summarizeDiffParsers :: [(Language, SomeParser SummarizeDiff Loc)]
+summarizeDiffParsers = aLaCarteParsers
 
 class HasDiffFor term => SummarizeDiff term where
   decorateTerm :: Blob -> term Loc -> term (Maybe Declaration)

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -87,7 +87,7 @@ type DiffEffects sig m = (Member (Error SomeException) sig, Member (Reader Confi
 type Decorate a b = forall term . DiffActions term => Blob -> term a -> term b
 
 
-dotGraphDiffParsers :: [(Language, SomeParser DOTGraphDiff Loc)]
+dotGraphDiffParsers :: [(Language, SomeParser (DiffTerms & DOTGraphDiff) Loc)]
 dotGraphDiffParsers = aLaCarteParsers
 
 class HasDiffFor term => DOTGraphDiff term where
@@ -97,7 +97,7 @@ instance (ConstructorName syntax, Foldable syntax, Functor syntax) => DOTGraphDi
   dotGraphDiff = serialize (DOT (diffStyle "diffs")) . renderTreeGraph
 
 
-jsonGraphDiffParsers :: [(Language, SomeParser JSONGraphDiff Loc)]
+jsonGraphDiffParsers :: [(Language, SomeParser (DiffTerms & JSONGraphDiff) Loc)]
 jsonGraphDiffParsers = aLaCarteParsers
 
 class HasDiffFor term => JSONGraphDiff term where
@@ -112,7 +112,7 @@ instance (Foldable syntax, Functor syntax, ConstructorName syntax) => JSONGraphD
         lang = bridging # languageForBlobPair blobPair
 
 
-jsonTreeDiffParsers :: [(Language, SomeParser JSONTreeDiff Loc)]
+jsonTreeDiffParsers :: [(Language, SomeParser (DiffTerms & JSONTreeDiff) Loc)]
 jsonTreeDiffParsers = aLaCarteParsers
 
 class HasDiffFor term => JSONTreeDiff term where
@@ -122,7 +122,7 @@ instance ToJSONFields1 syntax => JSONTreeDiff (Term syntax) where
   jsonTreeDiff = renderJSONDiff
 
 
-sexprDiffParsers :: [(Language, SomeParser SExprDiff Loc)]
+sexprDiffParsers :: [(Language, SomeParser (DiffTerms & SExprDiff) Loc)]
 sexprDiffParsers = aLaCarteParsers
 
 class HasDiffFor term => SExprDiff term where
@@ -132,7 +132,7 @@ instance (ConstructorName syntax, Foldable syntax, Functor syntax) => SExprDiff 
   sexprDiff = serialize (SExpression ByConstructorName)
 
 
-showDiffParsers :: [(Language, SomeParser ShowDiff Loc)]
+showDiffParsers :: [(Language, SomeParser (DiffTerms & ShowDiff) Loc)]
 showDiffParsers = aLaCarteParsers
 
 class HasDiffFor term => ShowDiff term where
@@ -142,7 +142,7 @@ instance Show1 syntax => ShowDiff (Term syntax) where
   showDiff = serialize Show
 
 
-legacySummarizeDiffParsers :: [(Language, SomeParser LegacySummarizeDiff Loc)]
+legacySummarizeDiffParsers :: [(Language, SomeParser (DiffTerms & LegacySummarizeDiff) Loc)]
 legacySummarizeDiffParsers = aLaCarteParsers
 
 class HasDiffFor term => LegacySummarizeDiff term where
@@ -154,7 +154,7 @@ instance (Foldable syntax, Functor syntax, HasDeclaration syntax) => LegacySumma
   legacySummarizeDiff = renderToCDiff
 
 
-summarizeDiffParsers :: [(Language, SomeParser SummarizeDiff Loc)]
+summarizeDiffParsers :: [(Language, SomeParser (DiffTerms & SummarizeDiff) Loc)]
 summarizeDiffParsers = aLaCarteParsers
 
 class HasDiffFor term => SummarizeDiff term where

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -176,6 +176,9 @@ instance (Diffable syntax, Eq1 syntax, HasDeclaration syntax, Hashable1 syntax, 
         = TOCSummaryFile path language changes (V.cons (TOCSummaryError errorText (converting #? errorSpan)) errors)
 
 
+-- | Parse a 'BlobPair' using one of the provided parsers, diff the resulting terms, and run an action on the abstracted diff.
+--
+-- This allows us to define features using an abstract interface, and use them with diffs for any parser whose terms support that interface.
 diffWith
   :: (forall term . c term => DiffTerms term, DiffEffects sig m)
   => Map Language (SomeParser c Loc)
@@ -184,6 +187,9 @@ diffWith
   -> m output
 diffWith parsers render blobPair = parsePairWith parsers (render <=< diffTerms blobPair) blobPair
 
+-- | Parse a 'BlobPair' using one of the provided parsers, decorate the resulting terms, diff them, and run an action on the abstracted diff.
+--
+-- This allows us to define features using an abstract interface, and use them with diffs for any parser whose terms support that interface.
 decoratingDiffWith
   :: forall ann c output m sig
   .  (forall term . c term => DiffTerms term, DiffEffects sig m)

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -192,13 +192,13 @@ decoratingDiffWith
   -> (forall term . c term => DiffFor term ann ann -> m output)
   -> BlobPair
   -> m output
-decoratingDiffWith parsers decorate render blobPair = parsePairWith parsers (render <=< diffTerms blobPair . Join . bimap (decorate blobL) (decorate blobR) . runJoin) blobPair where
+decoratingDiffWith parsers decorate render blobPair = parsePairWith parsers (render <=< diffTerms blobPair . bimap (decorate blobL) (decorate blobR)) blobPair where
   (blobL, blobR) = fromThese errorBlob errorBlob (runJoin blobPair)
   errorBlob = Prelude.error "evaluating blob on absent side"
 
 diffTerms :: (DiffTerms term, Member Telemetry sig, Carrier sig m, MonadIO m)
-  => BlobPair -> Join These (term ann) -> m (DiffFor term ann ann)
+  => BlobPair -> These (term ann) (term ann) -> m (DiffFor term ann ann)
 diffTerms blobs terms = time "diff" languageTag $ do
-  let diff = diffTermPair (runJoin terms)
+  let diff = diffTermPair terms
   diff <$ writeStat (Stat.count "diff.nodes" (bilength diff) languageTag)
   where languageTag = languageTagForBlobPair blobs

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -181,9 +181,9 @@ instance (Diffable syntax, Eq1 syntax, HasDeclaration syntax, Hashable1 syntax, 
 -- This allows us to define features using an abstract interface, and use them with diffs for any parser whose terms support that interface.
 diffWith
   :: (forall term . c term => DiffTerms term, DiffEffects sig m)
-  => Map Language (SomeParser c Loc)
-  -> (forall term . c term => DiffFor term Loc Loc -> m output)
-  -> BlobPair
+  => Map Language (SomeParser c Loc)                            -- ^ The set of parsers to select from.
+  -> (forall term . c term => DiffFor term Loc Loc -> m output) -- ^ A function to run on the computed diff. Note that the diff is abstract (it’s the diff type corresponding to an abstract term type), but the term type is constrained by @c@, allowing you to do anything @c@ allows, and requiring that all the input parsers produce terms supporting @c@.
+  -> BlobPair                                                   -- ^ The blob pair to parse.
   -> m output
 diffWith parsers render blobPair = parsePairWith parsers (render <=< diffTerms blobPair) blobPair
 
@@ -193,10 +193,10 @@ diffWith parsers render blobPair = parsePairWith parsers (render <=< diffTerms b
 decoratingDiffWith
   :: forall ann c output m sig
   .  (forall term . c term => DiffTerms term, DiffEffects sig m)
-  => Map Language (SomeParser c Loc)
-  -> (forall term . c term => Blob -> term Loc -> term ann)
-  -> (forall term . c term => DiffFor term ann ann -> m output)
-  -> BlobPair
+  => Map Language (SomeParser c Loc)                            -- ^ The set of parsers to select from.
+  -> (forall term . c term => Blob -> term Loc -> term ann)     -- ^ A function to decorate the terms, replacing their annotations and thus the annotations in the resulting diff.
+  -> (forall term . c term => DiffFor term ann ann -> m output) -- ^ A function to run on the computed diff. Note that the diff is abstract (it’s the diff type corresponding to an abstract term type), but the term type is constrained by @c@, allowing you to do anything @c@ allows, and requiring that all the input parsers produce terms supporting @c@.
+  -> BlobPair                                                   -- ^ The blob pair to parse.
   -> m output
 decoratingDiffWith parsers decorate render blobPair = parsePairWith parsers (render <=< diffTerms blobPair . bimap (decorate blobL) (decorate blobR)) blobPair where
   (blobL, blobR) = fromThese errorBlob errorBlob (runJoin blobPair)

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE AllowAmbiguousTypes, ConstraintKinds, KindSignatures, LambdaCase, MonoLocalBinds, QuantifiedConstraints, RankNTypes, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes, ConstraintKinds, LambdaCase, MonoLocalBinds, QuantifiedConstraints, RankNTypes #-}
 module Semantic.Api.Diffs
   ( parseDiffBuilder
   , DiffOutputFormat(..)

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -157,8 +157,7 @@ instance (Foldable syntax, Functor syntax, HasDeclaration syntax) => SummarizeDi
 
 
 class
-  ( Bifoldable (DiffFor term)
-  , DiffTerms term
+  ( DiffTerms term
   , DOTGraphDiff term
   , JSONGraphDiff term
   , JSONTreeDiff term
@@ -168,8 +167,7 @@ class
   , SummarizeDiff term
   ) => DiffActions term
 instance
-  ( Bifoldable (DiffFor term)
-  , DiffTerms term
+  ( DiffTerms term
   , DOTGraphDiff term
   , JSONGraphDiff term
   , JSONTreeDiff term
@@ -190,7 +188,7 @@ doDiff decorate render blobPair = do
   diff <- diffTerms blobPair terms
   render diff
 
-diffTerms :: (DiffActions term, Member Telemetry sig, Carrier sig m, MonadIO m)
+diffTerms :: (DiffTerms term, Member Telemetry sig, Carrier sig m, MonadIO m)
   => BlobPair -> Join These (term ann) -> m (DiffFor term ann ann)
 diffTerms blobs terms = time "diff" languageTag $ do
   let diff = diffTermPair (runJoin terms)

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -61,7 +61,7 @@ data DiffOutputFormat
 parseDiffBuilder :: (Traversable t, DiffEffects sig m) => DiffOutputFormat -> t BlobPair -> m Builder
 parseDiffBuilder DiffJSONTree    = distributeFoldMap jsonDiff >=> serialize Format.JSON -- NB: Serialize happens at the top level for these two JSON formats to collect results of multiple blob pairs.
 parseDiffBuilder DiffJSONGraph   = diffGraph >=> serialize Format.JSON
-parseDiffBuilder DiffSExpression = distributeFoldMap (doDiff (const id) sexprDiff)
+parseDiffBuilder DiffSExpression = distributeFoldMap (diffWith @Loc sexprDiffParsers (const id) sexprDiff)
 parseDiffBuilder DiffShow        = distributeFoldMap (doDiff (const id) showDiff)
 parseDiffBuilder DiffDotGraph    = distributeFoldMap (doDiff (const id) dotGraphDiff)
 

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -4,7 +4,6 @@ module Semantic.Api.Diffs
   , DiffOutputFormat(..)
   , diffGraph
 
-  , doDiff
   , diffWith
   , DiffEffects
 
@@ -202,16 +201,6 @@ instance
   , SummarizeDiff term
   ) => DiffActions term
 
-doDiff
-  :: DiffEffects sig m
-  => Decorate Loc ann
-  -> (forall term . DiffActions term => DiffFor term ann ann -> m output)
-  -> BlobPair
-  -> m output
-doDiff decorate render blobPair = do
-  SomeTermPair terms <- doParse blobPair decorate
-  diff <- diffTerms blobPair terms
-  render diff
 
 class (c1 term, c2 term) => ((c1 :: (* -> *) -> Constraint) & (c2 :: (* -> *) -> Constraint)) (term :: * -> *)
 

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -75,7 +75,7 @@ diffGraph :: (Traversable t, DiffEffects sig m) => t BlobPair -> m DiffTreeGraph
 diffGraph blobs = DiffTreeGraphResponse . V.fromList . toList <$> distributeFor blobs go
   where
     go :: DiffEffects sig m => BlobPair -> m DiffTreeFileGraph
-    go blobPair = doDiff (const id) (pure . jsonGraphDiff blobPair) blobPair
+    go blobPair = diffWith jsonGraphDiffParsers (const id) (pure . jsonGraphDiff blobPair) blobPair
       `catchError` \(SomeException e) ->
         pure (DiffTreeFileGraph path lang mempty mempty (V.fromList [ParseError (T.pack (show e))]))
       where

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -7,8 +7,6 @@ module Semantic.Api.Diffs
   , diffWith
   , DiffEffects
 
-  , SomeTermPair(..)
-
   , legacySummarizeDiffParsers
   , LegacySummarizeDiff(..)
   , summarizeDiffParsers
@@ -224,7 +222,3 @@ diffTerms blobs terms = time "diff" languageTag $ do
   let diff = diffTermPair (runJoin terms)
   diff <$ writeStat (Stat.count "diff.nodes" (bilength diff) languageTag)
   where languageTag = languageTagForBlobPair blobs
-
-
-data SomeTermPair ann where
-  SomeTermPair :: DiffActions term  => Join These (term ann) -> SomeTermPair ann

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GADTs, ConstraintKinds, LambdaCase, RankNTypes, UndecidableInstances #-}
+{-# LANGUAGE GADTs, ConstraintKinds, LambdaCase, KindSignatures, RankNTypes, TypeOperators, UndecidableInstances, UndecidableSuperClasses #-}
 module Semantic.Api.Diffs
   ( parseDiffBuilder
   , DiffOutputFormat(..)
@@ -26,6 +26,7 @@ import           Data.Blob
 import           Data.ByteString.Builder
 import           Data.Graph
 import           Data.JSON.Fields
+import           Data.Kind (Constraint)
 import           Data.Language
 import           Data.Term
 import qualified Data.Text as T
@@ -187,6 +188,12 @@ doDiff decorate render blobPair = do
   SomeTermPair terms <- doParse blobPair decorate
   diff <- diffTerms blobPair terms
   render diff
+
+class (c1 term, c2 term) => ((c1 :: (* -> *) -> Constraint) & (c2 :: (* -> *) -> Constraint)) (term :: * -> *)
+
+infixl 9 &
+
+instance (c1 term, c2 term) => (c1 & c2) term
 
 diffTerms :: (DiffTerms term, Member Telemetry sig, Carrier sig m, MonadIO m)
   => BlobPair -> Join These (term ann) -> m (DiffFor term ann ann)

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -215,3 +215,7 @@ doParse blobPair decorate = case languageForBlobPair blobPair of
 
 data SomeTermPair ann where
   SomeTermPair :: DiffActions term  => Join These (term ann) -> SomeTermPair ann
+
+
+diffParsers :: [(Language, SomeParser DiffActions Loc)]
+diffParsers = aLaCarteParsers

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -31,7 +31,7 @@ import           Data.Term
 import qualified Data.Text as T
 import qualified Data.Vector as V
 import           Diffing.Algorithm (Diffable)
-import           Diffing.Interpreter (HasDiffFor(..), DiffTerms(..))
+import           Diffing.Interpreter (DiffTerms(..))
 import           Parsing.Parser
 import           Prologue
 import           Rendering.Graph

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -227,21 +227,6 @@ diffTerms blobs terms = time "diff" languageTag $ do
   diff <$ writeStat (Stat.count "diff.nodes" (bilength diff) languageTag)
   where languageTag = languageTagForBlobPair blobs
 
-doParse :: (Member (Error SomeException) sig, Member Distribute sig, Member Parse sig, Carrier sig m)
-  => BlobPair -> Decorate Loc ann -> m (SomeTermPair ann)
-doParse blobPair decorate = case languageForBlobPair blobPair of
-  Go         -> SomeTermPair <$> distributeFor blobPair (\ blob -> decorate blob <$> parse goParser blob)
-  Haskell    -> SomeTermPair <$> distributeFor blobPair (\ blob -> decorate blob <$> parse haskellParser blob)
-  JavaScript -> SomeTermPair <$> distributeFor blobPair (\ blob -> decorate blob <$> parse tsxParser blob)
-  JSON       -> SomeTermPair <$> distributeFor blobPair (\ blob -> decorate blob <$> parse jsonParser blob)
-  JSX        -> SomeTermPair <$> distributeFor blobPair (\ blob -> decorate blob <$> parse tsxParser blob)
-  Markdown   -> SomeTermPair <$> distributeFor blobPair (\ blob -> decorate blob <$> parse markdownParser blob)
-  Python     -> SomeTermPair <$> distributeFor blobPair (\ blob -> decorate blob <$> parse pythonParser blob)
-  Ruby       -> SomeTermPair <$> distributeFor blobPair (\ blob -> decorate blob <$> parse rubyParser blob)
-  TypeScript -> SomeTermPair <$> distributeFor blobPair (\ blob -> decorate blob <$> parse typescriptParser blob)
-  TSX        -> SomeTermPair <$> distributeFor blobPair (\ blob -> decorate blob <$> parse tsxParser blob)
-  PHP        -> SomeTermPair <$> distributeFor blobPair (\ blob -> decorate blob <$> parse phpParser blob)
-  _          -> noLanguageForBlob (pathForBlobPair blobPair)
 
 data SomeTermPair ann where
   SomeTermPair :: DiffActions term  => Join These (term ann) -> SomeTermPair ann

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -63,7 +63,7 @@ parseDiffBuilder DiffJSONTree    = distributeFoldMap jsonDiff >=> serialize Form
 parseDiffBuilder DiffJSONGraph   = diffGraph >=> serialize Format.JSON
 parseDiffBuilder DiffSExpression = distributeFoldMap (diffWith @Loc sexprDiffParsers (const id) sexprDiff)
 parseDiffBuilder DiffShow        = distributeFoldMap (diffWith @Loc showDiffParsers (const id) showDiff)
-parseDiffBuilder DiffDotGraph    = distributeFoldMap (doDiff (const id) dotGraphDiff)
+parseDiffBuilder DiffDotGraph    = distributeFoldMap (diffWith @Loc dotGraphDiffParsers (const id) dotGraphDiff)
 
 jsonDiff :: DiffEffects sig m => BlobPair -> m (Rendering.JSON.JSON "diffs" SomeJSON)
 jsonDiff blobPair = doDiff (const id) (pure . jsonTreeDiff blobPair) blobPair `catchError` jsonError blobPair

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GADTs, ConstraintKinds, LambdaCase, RankNTypes #-}
+{-# LANGUAGE GADTs, ConstraintKinds, LambdaCase, RankNTypes, UndecidableInstances #-}
 module Semantic.Api.Diffs
   ( parseDiffBuilder
   , DiffOutputFormat(..)
@@ -156,7 +156,7 @@ instance (Foldable syntax, Functor syntax, HasDeclaration syntax) => SummarizeDi
         = TOCSummaryFile path language changes (V.cons (TOCSummaryError errorText (converting #? errorSpan)) errors)
 
 
-type DiffActions term =
+class
   ( Bifoldable (DiffFor term)
   , DiffTerms term
   , DOTGraphDiff term
@@ -166,7 +166,18 @@ type DiffActions term =
   , ShowDiff term
   , LegacySummarizeDiff term
   , SummarizeDiff term
-  )
+  ) => DiffActions term
+instance
+  ( Bifoldable (DiffFor term)
+  , DiffTerms term
+  , DOTGraphDiff term
+  , JSONGraphDiff term
+  , JSONTreeDiff term
+  , SExprDiff term
+  , ShowDiff term
+  , LegacySummarizeDiff term
+  , SummarizeDiff term
+  ) => DiffActions term
 
 doDiff
   :: DiffEffects sig m

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -82,7 +82,7 @@ diffGraph blobs = DiffTreeGraphResponse . V.fromList . toList <$> distributeFor 
 type DiffEffects sig m = (Member (Error SomeException) sig, Member (Reader Config) sig, Member Telemetry sig, Member Distribute sig, Member Parse sig, Carrier sig m, MonadIO m)
 
 
-dotGraphDiffParsers :: [(Language, SomeParser DOTGraphDiff Loc)]
+dotGraphDiffParsers :: Map Language (SomeParser DOTGraphDiff Loc)
 dotGraphDiffParsers = aLaCarteParsers
 
 class DiffTerms term => DOTGraphDiff term where
@@ -92,7 +92,7 @@ instance (ConstructorName syntax, Diffable syntax, Eq1 syntax, Hashable1 syntax,
   dotGraphDiff = serialize (DOT (diffStyle "diffs")) . renderTreeGraph
 
 
-jsonGraphDiffParsers :: [(Language, SomeParser JSONGraphDiff Loc)]
+jsonGraphDiffParsers :: Map Language (SomeParser JSONGraphDiff Loc)
 jsonGraphDiffParsers = aLaCarteParsers
 
 class DiffTerms term => JSONGraphDiff term where
@@ -107,7 +107,7 @@ instance (ConstructorName syntax, Diffable syntax, Eq1 syntax, Hashable1 syntax,
         lang = bridging # languageForBlobPair blobPair
 
 
-jsonTreeDiffParsers :: [(Language, SomeParser JSONTreeDiff Loc)]
+jsonTreeDiffParsers :: Map Language (SomeParser JSONTreeDiff Loc)
 jsonTreeDiffParsers = aLaCarteParsers
 
 class DiffTerms term => JSONTreeDiff term where
@@ -117,7 +117,7 @@ instance (Diffable syntax, Eq1 syntax, Hashable1 syntax, ToJSONFields1 syntax, T
   jsonTreeDiff = renderJSONDiff
 
 
-sexprDiffParsers :: [(Language, SomeParser SExprDiff Loc)]
+sexprDiffParsers :: Map Language (SomeParser SExprDiff Loc)
 sexprDiffParsers = aLaCarteParsers
 
 class DiffTerms term => SExprDiff term where
@@ -127,7 +127,7 @@ instance (ConstructorName syntax, Diffable syntax, Eq1 syntax, Hashable1 syntax,
   sexprDiff = serialize (SExpression ByConstructorName)
 
 
-showDiffParsers :: [(Language, SomeParser ShowDiff Loc)]
+showDiffParsers :: Map Language (SomeParser ShowDiff Loc)
 showDiffParsers = aLaCarteParsers
 
 class DiffTerms term => ShowDiff term where
@@ -137,7 +137,7 @@ instance (Diffable syntax, Eq1 syntax, Hashable1 syntax, Show1 syntax, Traversab
   showDiff = serialize Show
 
 
-legacySummarizeDiffParsers :: [(Language, SomeParser LegacySummarizeDiff Loc)]
+legacySummarizeDiffParsers :: Map Language (SomeParser LegacySummarizeDiff Loc)
 legacySummarizeDiffParsers = aLaCarteParsers
 
 class DiffTerms term => LegacySummarizeDiff term where
@@ -149,7 +149,7 @@ instance (Diffable syntax, Eq1 syntax, HasDeclaration syntax, Hashable1 syntax, 
   legacySummarizeDiff = renderToCDiff
 
 
-summarizeDiffParsers :: [(Language, SomeParser SummarizeDiff Loc)]
+summarizeDiffParsers :: Map Language (SomeParser SummarizeDiff Loc)
 summarizeDiffParsers = aLaCarteParsers
 
 class DiffTerms term => SummarizeDiff term where
@@ -178,7 +178,7 @@ instance (Diffable syntax, Eq1 syntax, HasDeclaration syntax, Hashable1 syntax, 
 
 diffWith
   :: (forall term . c term => DiffTerms term, DiffEffects sig m)
-  => [(Language, SomeParser c Loc)]
+  => Map Language (SomeParser c Loc)
   -> (forall term . c term => DiffFor term Loc Loc -> m output)
   -> BlobPair
   -> m output
@@ -187,7 +187,7 @@ diffWith parsers render blobPair = parsePairWith parsers (render <=< diffTerms b
 decoratingDiffWith
   :: forall ann c output m sig
   .  (forall term . c term => DiffTerms term, DiffEffects sig m)
-  => [(Language, SomeParser c Loc)]
+  => Map Language (SomeParser c Loc)
   -> (forall term . c term => Blob -> term Loc -> term ann)
   -> (forall term . c term => DiffFor term ann ann -> m output)
   -> BlobPair

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -220,7 +220,8 @@ infixl 9 &
 instance (c1 term, c2 term) => (c1 & c2) term
 
 diffWith
-  :: DiffEffects sig m
+  :: forall ann c output m sig
+  .  DiffEffects sig m
   => [(Language, SomeParser (DiffTerms & c) Loc)]
   -> (forall term . c term => Blob -> term Loc -> term ann)
   -> (forall term . c term => DiffFor term ann ann -> m output)

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -83,8 +83,6 @@ diffGraph blobs = DiffTreeGraphResponse . V.fromList . toList <$> distributeFor 
 
 type DiffEffects sig m = (Member (Error SomeException) sig, Member (Reader Config) sig, Member Telemetry sig, Member Distribute sig, Member Parse sig, Carrier sig m, MonadIO m)
 
-type Decorate a b = forall term . DiffActions term => Blob -> term a -> term b
-
 
 dotGraphDiffParsers :: [(Language, SomeParser (DiffTerms & DOTGraphDiff) Loc)]
 dotGraphDiffParsers = aLaCarteParsers

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE AllowAmbiguousTypes, GADTs, ConstraintKinds, LambdaCase, KindSignatures, RankNTypes, TypeOperators, UndecidableInstances, UndecidableSuperClasses #-}
+{-# LANGUAGE AllowAmbiguousTypes, ConstraintKinds, KindSignatures, LambdaCase, MonoLocalBinds, RankNTypes, TypeOperators, UndecidableInstances, UndecidableSuperClasses #-}
 module Semantic.Api.Diffs
   ( parseDiffBuilder
   , DiffOutputFormat(..)

--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -66,7 +66,7 @@ parseDiffBuilder DiffShow        = distributeFoldMap (diffWith @Loc showDiffPars
 parseDiffBuilder DiffDotGraph    = distributeFoldMap (diffWith @Loc dotGraphDiffParsers (const id) dotGraphDiff)
 
 jsonDiff :: DiffEffects sig m => BlobPair -> m (Rendering.JSON.JSON "diffs" SomeJSON)
-jsonDiff blobPair = doDiff (const id) (pure . jsonTreeDiff blobPair) blobPair `catchError` jsonError blobPair
+jsonDiff blobPair = diffWith jsonTreeDiffParsers (const id) (pure . jsonTreeDiff blobPair) blobPair `catchError` jsonError blobPair
 
 jsonError :: Applicative m => BlobPair -> SomeException -> m (Rendering.JSON.JSON "diffs" SomeJSON)
 jsonError blobPair (SomeException e) = pure $ renderJSONDiffError blobPair (show e)

--- a/src/Semantic/Api/Symbols.hs
+++ b/src/Semantic/Api/Symbols.hs
@@ -17,6 +17,7 @@ import           Data.Term
 import qualified Data.Text as T
 import qualified Data.Vector as V
 import           Data.Text (pack)
+import qualified Language.Python as Python
 import qualified Parsing.Parser as Parser
 import           Prologue
 import           Semantic.Api.Bridge
@@ -26,6 +27,7 @@ import           Semantic.Config
 import           Semantic.Task
 import           Serializing.Format (Format)
 import           Source.Loc
+import           Source.Source
 import           Tags.Taggable
 import           Tags.Tagging
 import qualified Tags.Tagging.Precise as Precise
@@ -34,7 +36,7 @@ legacyParseSymbols :: (Member Distribute sig, Member (Error SomeException) sig, 
 legacyParseSymbols blobs = Legacy.ParseTreeSymbolResponse <$> distributeFoldMap go blobs
   where
     go :: (Member (Error SomeException) sig, Member (Reader PerLanguageModes) sig, Member Parse sig, Carrier sig m) => Blob -> m [Legacy.File]
-    go blob@Blob{..} = doParse (pure . renderToSymbols) symbolsToSummarize blob `catchError` (\(SomeException _) -> pure (pure emptyFile))
+    go blob@Blob{..} = doParse (pure . renderToSymbols) blob `catchError` (\(SomeException _) -> pure (pure emptyFile))
       where
         emptyFile = tagsToFile []
 
@@ -42,8 +44,8 @@ legacyParseSymbols blobs = Legacy.ParseTreeSymbolResponse <$> distributeFoldMap 
         symbolsToSummarize :: [Text]
         symbolsToSummarize = ["Function", "Method", "Class", "Module"]
 
-        renderToSymbols :: Precise.ToTags t => t Loc -> [Legacy.File]
-        renderToSymbols = pure . tagsToFile . Precise.tags blobSource
+        renderToSymbols :: ToTags t => t Loc -> [Legacy.File]
+        renderToSymbols = pure . tagsToFile . tags (blobLanguage blob) symbolsToSummarize blobSource
 
         tagsToFile :: [Tag] -> Legacy.File
         tagsToFile tags = Legacy.File (pack (blobPath blob)) (pack (show (blobLanguage blob))) (fmap tagToSymbol tags)
@@ -64,15 +66,15 @@ parseSymbols :: (Member Distribute sig, Member (Error SomeException) sig, Member
 parseSymbols blobs = ParseTreeSymbolResponse . V.fromList . toList <$> distributeFor blobs go
   where
     go :: (Member (Error SomeException) sig, Member (Reader PerLanguageModes) sig, Member Parse sig, Carrier sig m) => Blob -> m File
-    go blob@Blob{..} = catching $ doParse (pure . renderToSymbols) symbolsToSummarize blob
+    go blob@Blob{..} = catching $ doParse (pure . renderToSymbols) blob
       where
         catching m = m `catchError` (\(SomeException e) -> pure $ errorFile (show e))
         blobLanguage' = blobLanguage blob
         blobPath' = pack $ blobPath blob
         errorFile e = File blobPath' (bridging # blobLanguage') mempty (V.fromList [ParseError (T.pack e)]) blobOid
 
-        renderToSymbols :: Precise.ToTags t => t Loc -> File
-        renderToSymbols term = tagsToFile (Precise.tags blobSource term)
+        renderToSymbols :: ToTags t => t Loc -> File
+        renderToSymbols term = tagsToFile (tags (blobLanguage blob) symbolsToSummarize blobSource term)
 
         tagsToFile :: [Tag] -> File
         tagsToFile tags = File blobPath' (bridging # blobLanguage') (V.fromList (fmap tagToSymbol tags)) mempty blobOid
@@ -90,10 +92,14 @@ tagToSymbol Tag{..} = Symbol
   }
 
 
-data ALaCarteTerm syntax ann = ALaCarteTerm Language [Text] (Term syntax ann)
+class ToTags t where
+  tags :: Language -> [Text] -> Source -> t Loc -> [Tag]
 
-instance IsTaggable syntax => Precise.ToTags (ALaCarteTerm syntax) where
-  tags source (ALaCarteTerm lang symbolsToSummarize term) = runTagging lang symbolsToSummarize source term
+instance IsTaggable syntax => ToTags (Term syntax) where
+  tags = runTagging
+
+instance ToTags Python.Term where
+  tags _ _ = Precise.tags
 
 
 doParse
@@ -102,26 +108,23 @@ doParse
      , Member Parse sig
      , Member (Reader PerLanguageModes) sig
      )
-  => (forall t . Precise.ToTags t => t Loc -> m a)
-  -> [Text]
+  => (forall t . ToTags t => t Loc -> m a)
   -> Blob
   -> m a
-doParse with symbolsToSummarize blob = do
+doParse with blob = do
   modes <- ask @PerLanguageModes
   case blobLanguage blob of
-    Go         -> parse Parser.goParser         blob >>= with . mkTerm
-    Haskell    -> parse Parser.haskellParser    blob >>= with . mkTerm
-    JavaScript -> parse Parser.tsxParser        blob >>= with . mkTerm
-    JSON       -> parse Parser.jsonParser       blob >>= with . mkTerm
-    JSX        -> parse Parser.tsxParser        blob >>= with . mkTerm
-    Markdown   -> parse Parser.markdownParser   blob >>= with . mkTerm
+    Go         -> parse Parser.goParser         blob >>= with
+    Haskell    -> parse Parser.haskellParser    blob >>= with
+    JavaScript -> parse Parser.tsxParser        blob >>= with
+    JSON       -> parse Parser.jsonParser       blob >>= with
+    JSX        -> parse Parser.tsxParser        blob >>= with
+    Markdown   -> parse Parser.markdownParser   blob >>= with
     Python
       | Precise <- pythonMode modes -> parse Parser.precisePythonParser blob >>= with
-      | otherwise                   -> parse Parser.pythonParser        blob >>= with . mkTerm
-    Ruby       -> parse Parser.rubyParser       blob >>= with . mkTerm
-    TypeScript -> parse Parser.typescriptParser blob >>= with . mkTerm
-    TSX        -> parse Parser.tsxParser        blob >>= with . mkTerm
-    PHP        -> parse Parser.phpParser        blob >>= with . mkTerm
+      | otherwise                   -> parse Parser.pythonParser        blob >>= with
+    Ruby       -> parse Parser.rubyParser       blob >>= with
+    TypeScript -> parse Parser.typescriptParser blob >>= with
+    TSX        -> parse Parser.tsxParser        blob >>= with
+    PHP        -> parse Parser.phpParser        blob >>= with
     _          -> noLanguageForBlob (blobPath blob)
-    where mkTerm :: Term syntax Loc -> ALaCarteTerm syntax Loc
-          mkTerm = ALaCarteTerm (blobLanguage blob) symbolsToSummarize

--- a/src/Semantic/Api/Symbols.hs
+++ b/src/Semantic/Api/Symbols.hs
@@ -93,7 +93,7 @@ tagToSymbol Tag{..} = Symbol
 data ALaCarteTerm syntax ann = ALaCarteTerm Language [Text] (Term syntax ann)
 
 instance IsTaggable syntax => Precise.ToTags (ALaCarteTerm syntax) where
-  tags source (ALaCarteTerm lang symbolsToSummarize term) = runTagging lang source symbolsToSummarize term
+  tags source (ALaCarteTerm lang symbolsToSummarize term) = runTagging lang symbolsToSummarize source term
 
 
 doParse

--- a/src/Semantic/Api/Symbols.hs
+++ b/src/Semantic/Api/Symbols.hs
@@ -102,5 +102,5 @@ instance ToTags Python.Term where
   tags _ _ = Precise.tags
 
 
-toTagsParsers :: PerLanguageModes -> [(Language, Parser.SomeParser ToTags Loc)]
+toTagsParsers :: PerLanguageModes -> Map Language (Parser.SomeParser ToTags Loc)
 toTagsParsers = Parser.allParsers

--- a/src/Semantic/Api/TOCSummaries.hs
+++ b/src/Semantic/Api/TOCSummaries.hs
@@ -23,7 +23,7 @@ legacyDiffSummary :: DiffEffects sig m => [BlobPair] -> m Summaries
 legacyDiffSummary = distributeFoldMap go
   where
     go :: DiffEffects sig m => BlobPair -> m Summaries
-    go blobPair = diffWith legacySummarizeDiffParsers legacyDecorateTerm (pure . legacySummarizeDiff blobPair) blobPair
+    go blobPair = decoratingDiffWith legacySummarizeDiffParsers legacyDecorateTerm (pure . legacySummarizeDiff blobPair) blobPair
       `catchError` \(SomeException e) ->
         pure $ Summaries mempty (Map.singleton path [toJSON (ErrorSummary (T.pack (show e)) lowerBound lang)])
       where path = T.pack $ pathKeyForBlobPair blobPair
@@ -34,7 +34,7 @@ diffSummary :: DiffEffects sig m => [BlobPair] -> m DiffTreeTOCResponse
 diffSummary blobs = DiffTreeTOCResponse . V.fromList <$> distributeFor blobs go
   where
     go :: DiffEffects sig m => BlobPair -> m TOCSummaryFile
-    go blobPair = diffWith summarizeDiffParsers decorateTerm (pure . summarizeDiff blobPair) blobPair
+    go blobPair = decoratingDiffWith summarizeDiffParsers decorateTerm (pure . summarizeDiff blobPair) blobPair
       `catchError` \(SomeException e) ->
         pure $ TOCSummaryFile path lang mempty (V.fromList [TOCSummaryError (T.pack (show e)) Nothing])
       where path = T.pack $ pathKeyForBlobPair blobPair

--- a/src/Semantic/Api/TOCSummaries.hs
+++ b/src/Semantic/Api/TOCSummaries.hs
@@ -23,7 +23,7 @@ legacyDiffSummary :: DiffEffects sig m => [BlobPair] -> m Summaries
 legacyDiffSummary = distributeFoldMap go
   where
     go :: DiffEffects sig m => BlobPair -> m Summaries
-    go blobPair = doDiff legacyDecorateTerm (pure . legacySummarizeDiff blobPair) blobPair
+    go blobPair = diffWith legacySummarizeDiffParsers legacyDecorateTerm (pure . legacySummarizeDiff blobPair) blobPair
       `catchError` \(SomeException e) ->
         pure $ Summaries mempty (Map.singleton path [toJSON (ErrorSummary (T.pack (show e)) lowerBound lang)])
       where path = T.pack $ pathKeyForBlobPair blobPair

--- a/src/Semantic/Api/TOCSummaries.hs
+++ b/src/Semantic/Api/TOCSummaries.hs
@@ -34,7 +34,7 @@ diffSummary :: DiffEffects sig m => [BlobPair] -> m DiffTreeTOCResponse
 diffSummary blobs = DiffTreeTOCResponse . V.fromList <$> distributeFor blobs go
   where
     go :: DiffEffects sig m => BlobPair -> m TOCSummaryFile
-    go blobPair = doDiff decorateTerm (pure . summarizeDiff blobPair) blobPair
+    go blobPair = diffWith summarizeDiffParsers decorateTerm (pure . summarizeDiff blobPair) blobPair
       `catchError` \(SomeException e) ->
         pure $ TOCSummaryFile path lang mempty (V.fromList [TOCSummaryError (T.pack (show e)) Nothing])
       where path = T.pack $ pathKeyForBlobPair blobPair

--- a/src/Semantic/Api/Terms.hs
+++ b/src/Semantic/Api/Terms.hs
@@ -143,29 +143,6 @@ instance (Foldable syntax, Functor syntax, ConstructorName syntax) => JSONGraphT
         lang = bridging # blobLanguage blob
 
 
-doParse
-  :: ( Carrier sig m
-     , Member (Error SomeException) sig
-     , Member Parse sig
-     )
-  => (forall term . term Loc -> m a)
-  -> Blob
-  -> m a
-doParse with blob = case blobLanguage blob of
-  Go         -> parse goParser         blob >>= with
-  Haskell    -> parse haskellParser    blob >>= with
-  JavaScript -> parse tsxParser        blob >>= with
-  JSON       -> parse jsonParser       blob >>= with
-  JSX        -> parse tsxParser        blob >>= with
-  Markdown   -> parse markdownParser   blob >>= with
-  Python     -> parse pythonParser     blob >>= with
-  Ruby       -> parse rubyParser       blob >>= with
-  TypeScript -> parse typescriptParser blob >>= with
-  TSX        -> parse tsxParser        blob >>= with
-  PHP        -> parse phpParser        blob >>= with
-  _          -> noLanguageForBlob (blobPath blob)
-
-
 parseWith
   :: (Carrier sig m, Member (Error SomeException) sig, Member Parse sig)
   => [(Language, SomeParser c ann)]

--- a/src/Semantic/Api/Terms.hs
+++ b/src/Semantic/Api/Terms.hs
@@ -85,7 +85,7 @@ quietTerm blob = showTiming blob <$> time' ( asks showTermParsers >>= \ parsers 
 type ParseEffects sig m = (Member (Error SomeException) sig, Member (Reader PerLanguageModes) sig, Member Parse sig, Member (Reader Config) sig, Carrier sig m)
 
 
-showTermParsers :: PerLanguageModes -> [(Language, SomeParser ShowTerm Loc)]
+showTermParsers :: PerLanguageModes -> Map Language (SomeParser ShowTerm Loc)
 showTermParsers = allParsers
 
 class ShowTerm term where
@@ -98,7 +98,7 @@ instance ShowTerm Py.Term where
   showTerm = serialize Show . (() <$) . Py.getTerm
 
 
-sexprTermParsers :: [(Language, SomeParser SExprTerm Loc)]
+sexprTermParsers :: Map Language (SomeParser SExprTerm Loc)
 sexprTermParsers = aLaCarteParsers
 
 class SExprTerm term where
@@ -108,7 +108,7 @@ instance (ConstructorName syntax, Foldable syntax, Functor syntax) => SExprTerm 
   sexprTerm = serialize (SExpression ByConstructorName)
 
 
-dotGraphTermParsers :: [(Language, SomeParser DOTGraphTerm Loc)]
+dotGraphTermParsers :: Map Language (SomeParser DOTGraphTerm Loc)
 dotGraphTermParsers = aLaCarteParsers
 
 class DOTGraphTerm term where
@@ -118,7 +118,7 @@ instance (ConstructorName syntax, Foldable syntax, Functor syntax) => DOTGraphTe
   dotGraphTerm = serialize (DOT (termStyle "terms")) . renderTreeGraph
 
 
-jsonTreeTermParsers :: [(Language, SomeParser JSONTreeTerm Loc)]
+jsonTreeTermParsers :: Map Language (SomeParser JSONTreeTerm Loc)
 jsonTreeTermParsers = aLaCarteParsers
 
 class JSONTreeTerm term where
@@ -128,7 +128,7 @@ instance ToJSONFields1 syntax => JSONTreeTerm (Term syntax) where
   jsonTreeTerm = renderJSONTerm
 
 
-jsonGraphTermParsers :: [(Language, SomeParser JSONGraphTerm Loc)]
+jsonGraphTermParsers :: Map Language (SomeParser JSONGraphTerm Loc)
 jsonGraphTermParsers = aLaCarteParsers
 
 class JSONGraphTerm term where

--- a/src/Semantic/Api/Terms.hs
+++ b/src/Semantic/Api/Terms.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ConstraintKinds, GADTs, RankNTypes #-}
+{-# LANGUAGE ConstraintKinds, MonoLocalBinds, RankNTypes #-}
 module Semantic.Api.Terms
   ( termGraph
   , parseTermBuilder

--- a/src/Semantic/Api/Terms.hs
+++ b/src/Semantic/Api/Terms.hs
@@ -141,14 +141,3 @@ instance (Foldable syntax, Functor syntax, ConstructorName syntax) => JSONGraphT
       in ParseTreeFileGraph path lang (V.fromList (vertexList graph)) (V.fromList (fmap toEdge (edgeList graph))) mempty where
         path = T.pack $ blobPath blob
         lang = bridging # blobLanguage blob
-
-
-parseWith
-  :: (Carrier sig m, Member (Error SomeException) sig, Member Parse sig)
-  => [(Language, SomeParser c ann)]
-  -> (forall term . c term => term ann -> m a)
-  -> Blob
-  -> m a
-parseWith parsers with blob = case lookup (blobLanguage blob) parsers of
-  Just (SomeParser parser) -> parse parser blob >>= with
-  _                        -> noLanguageForBlob (blobPath blob)

--- a/src/Semantic/Api/Terms.hs
+++ b/src/Semantic/Api/Terms.hs
@@ -95,7 +95,7 @@ instance (Functor syntax, Show1 syntax) => ShowTerm (Term syntax) where
   showTerm = serialize Show . quieterm
 
 instance ShowTerm Py.Term where
-  showTerm = serialize Show . (() <$) . Py.getTerm
+  showTerm = serialize Show . void . Py.getTerm
 
 
 sexprTermParsers :: Map Language (SomeParser SExprTerm Loc)

--- a/src/Semantic/Graph.hs
+++ b/src/Semantic/Graph.hs
@@ -71,8 +71,28 @@ import           Text.Show.Pretty (ppShow)
 
 data GraphType = ImportGraph | CallGraph
 
-class (Declarations1 syntax, Eq1 syntax, Evaluatable syntax, FreeVariables1 syntax, AccessControls1 syntax, Foldable syntax, Functor syntax, Ord1 syntax, Show1 syntax) => AnalysisClasses syntax
-instance (Declarations1 syntax, Eq1 syntax, Evaluatable syntax, FreeVariables1 syntax, AccessControls1 syntax, Foldable syntax, Functor syntax, Ord1 syntax, Show1 syntax) => AnalysisClasses syntax
+class
+  ( Declarations1 syntax
+  , Eq1 syntax
+  , Evaluatable syntax
+  , FreeVariables1 syntax
+  , AccessControls1 syntax
+  , Foldable syntax
+  , Functor syntax
+  , Ord1 syntax
+  , Show1 syntax
+  ) => AnalysisClasses syntax
+instance
+  ( Declarations1 syntax
+  , Eq1 syntax
+  , Evaluatable syntax
+  , FreeVariables1 syntax
+  , AccessControls1 syntax
+  , Foldable syntax
+  , Functor syntax
+  , Ord1 syntax
+  , Show1 syntax
+  ) => AnalysisClasses syntax
 
 runGraph :: ( Member Distribute sig
             , Member Parse sig

--- a/src/Semantic/Graph.hs
+++ b/src/Semantic/Graph.hs
@@ -71,6 +71,7 @@ import           Text.Show.Pretty (ppShow)
 
 data GraphType = ImportGraph | CallGraph
 
+-- | Constraints we require for a term’s syntax in order to analyze it.
 class
   ( Declarations1 syntax
   , Eq1 syntax

--- a/src/Semantic/Graph.hs
+++ b/src/Semantic/Graph.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GADTs, ScopedTypeVariables, TypeOperators #-}
+{-# LANGUAGE GADTs, ScopedTypeVariables, TypeOperators, UndecidableInstances #-}
 module Semantic.Graph
 ( runGraph
 , runCallGraph
@@ -71,7 +71,8 @@ import           Text.Show.Pretty (ppShow)
 
 data GraphType = ImportGraph | CallGraph
 
-type AnalysisClasses = '[ Declarations1, Eq1, Evaluatable, FreeVariables1, AccessControls1, Foldable, Functor, Ord1, Show1 ]
+class (Declarations1 syntax, Eq1 syntax, Evaluatable syntax, FreeVariables1 syntax, AccessControls1 syntax, Foldable syntax, Functor syntax, Ord1 syntax, Show1 syntax) => AnalysisClasses syntax
+instance (Declarations1 syntax, Eq1 syntax, Evaluatable syntax, FreeVariables1 syntax, AccessControls1 syntax, Foldable syntax, Functor syntax, Ord1 syntax, Show1 syntax) => AnalysisClasses syntax
 
 runGraph :: ( Member Distribute sig
             , Member (Error SomeException) sig

--- a/src/Tags/Tagging.hs
+++ b/src/Tags/Tagging.hs
@@ -23,11 +23,11 @@ import           Tags.Taggable
 
 runTagging :: (IsTaggable syntax)
            => Language
-           -> Source.Source
            -> [Text]
+           -> Source.Source
            -> Term syntax Loc
            -> [Tag]
-runTagging lang source symbolsToSummarize
+runTagging lang symbolsToSummarize source
   = Eff.run
   . evalState @[ContextToken] []
   . Streaming.toList_

--- a/test/Tags/Spec.hs
+++ b/test/Tags/Spec.hs
@@ -10,40 +10,40 @@ spec = do
   describe "go" $ do
     it "produces tags for functions with docs" $ do
       (blob, tree) <- parseTestFile goParser (Path.relFile "test/fixtures/go/tags/simple_functions.go")
-      runTagging (blobLanguage blob) (blobSource blob) symbolsToSummarize tree `shouldBe`
+      runTagging (blobLanguage blob) symbolsToSummarize (blobSource blob) tree `shouldBe`
         [ Tag "TestFromBits" Function (Span (Pos 6 1) (Pos 8 2)) "func TestFromBits(t *testing.T) {" (Just "// TestFromBits ...")
         , Tag "Hi" Function (Span (Pos 10 1) (Pos 11 2)) "func Hi()" Nothing ]
 
     it "produces tags for methods" $ do
       (blob, tree) <- parseTestFile goParser (Path.relFile "test/fixtures/go/tags/method.go")
-      runTagging (blobLanguage blob) (blobSource blob) symbolsToSummarize tree `shouldBe`
+      runTagging (blobLanguage blob) symbolsToSummarize (blobSource blob) tree `shouldBe`
         [ Tag "CheckAuth" Method (Span (Pos 3 1) (Pos 3 100)) "func (c *apiClient) CheckAuth(req *http.Request, user, repo string) (*authenticatedActor, error)" Nothing]
 
     it "produces tags for calls" $ do
       (blob, tree) <- parseTestFile goParser (Path.relFile "test/fixtures/go/tags/simple_functions.go")
-      runTagging (blobLanguage blob) (blobSource blob) ["Call"] tree `shouldBe`
+      runTagging (blobLanguage blob) ["Call"] (blobSource blob) tree `shouldBe`
         [ Tag "Hi" Call (Span (Pos 7 2) (Pos 7 6)) "Hi()" Nothing]
 
   describe "javascript and typescript" $ do
     it "produces tags for functions with docs" $ do
       (blob, tree) <- parseTestFile typescriptParser (Path.relFile "test/fixtures/javascript/tags/simple_function_with_docs.js")
-      runTagging (blobLanguage blob) (blobSource blob) symbolsToSummarize tree `shouldBe`
+      runTagging (blobLanguage blob) symbolsToSummarize (blobSource blob) tree `shouldBe`
         [ Tag "myFunction" Function (Span (Pos 2 1) (Pos 4 2)) "function myFunction()" (Just "// This is myFunction") ]
 
     it "produces tags for classes" $ do
       (blob, tree) <- parseTestFile typescriptParser (Path.relFile "test/fixtures/typescript/tags/class.ts")
-      runTagging (blobLanguage blob) (blobSource blob) symbolsToSummarize tree `shouldBe`
+      runTagging (blobLanguage blob) symbolsToSummarize (blobSource blob) tree `shouldBe`
         [ Tag "FooBar" Class (Span (Pos 1 1) (Pos 1 16)) "class FooBar" Nothing ]
 
     it "produces tags for modules" $ do
       (blob, tree) <- parseTestFile typescriptParser (Path.relFile "test/fixtures/typescript/tags/module.ts")
-      runTagging (blobLanguage blob) (blobSource blob) symbolsToSummarize tree `shouldBe`
+      runTagging (blobLanguage blob) symbolsToSummarize (blobSource blob) tree `shouldBe`
         [ Tag "APromise" Tags.Module (Span (Pos 1 1) (Pos 1 20)) "module APromise { }" Nothing ]
 
   describe "python" $ do
     it "produces tags for functions" $ do
       (blob, tree) <- parseTestFile pythonParser (Path.relFile "test/fixtures/python/tags/simple_functions.py")
-      runTagging (blobLanguage blob) (blobSource blob) symbolsToSummarize tree `shouldBe`
+      runTagging (blobLanguage blob) symbolsToSummarize (blobSource blob) tree `shouldBe`
         [ Tag "Foo" Function (Span (Pos 1 1) (Pos 5 17)) "def Foo(x):" Nothing
         , Tag "Bar" Function (Span (Pos 7 1) (Pos 11 13)) "def Bar():" Nothing
         , Tag "local" Function (Span (Pos 8 5) (Pos 9 17)) "def local():" Nothing
@@ -51,30 +51,30 @@ spec = do
 
     it "produces tags for functions with docs" $ do
       (blob, tree) <- parseTestFile pythonParser (Path.relFile "test/fixtures/python/tags/simple_function_with_docs.py")
-      runTagging (blobLanguage blob) (blobSource blob) symbolsToSummarize tree `shouldBe`
+      runTagging (blobLanguage blob) symbolsToSummarize (blobSource blob) tree `shouldBe`
         [ Tag "Foo" Function (Span (Pos 1 1) (Pos 3 13)) "def Foo(x):" (Just "\"\"\"This is the foo function\"\"\"") ]
 
     it "produces tags for classes" $ do
       (blob, tree) <- parseTestFile pythonParser (Path.relFile "test/fixtures/python/tags/class.py")
-      runTagging (blobLanguage blob) (blobSource blob) symbolsToSummarize tree `shouldBe`
+      runTagging (blobLanguage blob) symbolsToSummarize (blobSource blob) tree `shouldBe`
         [ Tag "Foo" Class (Span (Pos 1 1) (Pos 5 17)) "class Foo:" (Just "\"\"\"The Foo class\"\"\"")
         , Tag "f" Function (Span (Pos 3 5) (Pos 5 17)) "def f(self):" (Just "\"\"\"The f method\"\"\"")
         ]
 
     it "produces tags for multi-line functions" $ do
       (blob, tree) <- parseTestFile pythonParser (Path.relFile "test/fixtures/python/tags/multiline.py")
-      runTagging (blobLanguage blob) (blobSource blob) symbolsToSummarize tree `shouldBe`
+      runTagging (blobLanguage blob) symbolsToSummarize (blobSource blob) tree `shouldBe`
         [ Tag "Foo" Function (Span (Pos 1 1) (Pos 3 13)) "def Foo(x," Nothing ]
 
   describe "ruby" $ do
     it "produces tags for methods" $ do
       (blob, tree) <- parseTestFile rubyParser (Path.relFile "test/fixtures/ruby/tags/simple_method.rb")
-      runTagging (blobLanguage blob) (blobSource blob) symbolsToSummarize tree `shouldBe`
+      runTagging (blobLanguage blob) symbolsToSummarize (blobSource blob) tree `shouldBe`
         [ Tag "foo" Method (Span (Pos 1 1) (Pos 4 4)) "def foo" Nothing ]
 
     it "produces tags for sends" $ do
       (blob, tree) <- parseTestFile rubyParser (Path.relFile "test/fixtures/ruby/tags/simple_method.rb")
-      runTagging (blobLanguage blob) (blobSource blob) ["Send"] tree `shouldBe`
+      runTagging (blobLanguage blob) ["Send"] (blobSource blob) tree `shouldBe`
         [ Tag "puts" Call (Span (Pos 2 3) (Pos 2 12)) "puts \"hi\"" Nothing
         , Tag "bar" Call (Span (Pos 3 3) (Pos 3 8)) "a.bar" Nothing
         , Tag "a" Call (Span (Pos 3 3) (Pos 3 4)) "a" Nothing
@@ -82,17 +82,17 @@ spec = do
 
     it "produces tags for methods with docs" $ do
       (blob, tree) <- parseTestFile rubyParser (Path.relFile "test/fixtures/ruby/tags/simple_method_with_docs.rb")
-      runTagging (blobLanguage blob) (blobSource blob) symbolsToSummarize tree `shouldBe`
+      runTagging (blobLanguage blob) symbolsToSummarize (blobSource blob) tree `shouldBe`
         [ Tag "foo" Method (Span (Pos 2 1) (Pos 3 4)) "def foo" (Just "# Public: foo") ]
 
     it "correctly tags files containing multibyte UTF-8 characters" $ do
       (blob, tree) <- parseTestFile rubyParser (Path.relFile "test/fixtures/ruby/tags/unicode_identifiers.rb")
-      runTagging (blobLanguage blob) (blobSource blob) symbolsToSummarize tree `shouldBe`
+      runTagging (blobLanguage blob) symbolsToSummarize (blobSource blob) tree `shouldBe`
         [ Tag "日本語" Method (Span (Pos 2 1) (Pos 4 4)) "def 日本語" (Just "# coding: utf-8")]
 
     it "produces tags for methods and classes with docs" $ do
       (blob, tree) <- parseTestFile rubyParser (Path.relFile "test/fixtures/ruby/tags/class_module.rb")
-      runTagging (blobLanguage blob) (blobSource blob) symbolsToSummarize tree `shouldBe`
+      runTagging (blobLanguage blob) symbolsToSummarize (blobSource blob) tree `shouldBe`
         [ Tag "Foo" Tags.Module (Span (Pos 2 1 ) (Pos 12 4)) "module Foo" (Just "# Public: Foo")
         , Tag "Bar" Class  (Span (Pos 5 3 ) (Pos 11 6)) "class Bar" (Just "# Public: Bar")
         , Tag "baz" Method (Span (Pos 8 5 ) (Pos 10 8)) "def baz(a)" (Just "# Public: baz")


### PR DESCRIPTION
This PR defines a consistent, reusable, abstract mechanism for working with parsers producing arbitrary term types via constraints on the terms. Goals:

- **Consistency:** We shouldn’t run the risk of mapping JavaScript to the TSX parser in one place, and to the TypeScript parser in another.
- **Flexibility:** It should be possible to develop new features and quickly spin them up on actual parse trees.
- **Incrementality:** We must be able to develop support for new languages incrementally; we shouldn’t have to wait til we can do _everything_ before we can do _anything_. This is especially relevant as we migrate from à la carte to precise ASTs, as it must further accommodate multiple ways of expressing existing languages’ terms on a feature-by-feature basis.
- **Convenience:** There should be ready-made accommodations for selecting from well-known sets of parsers.
- **Compile times:** We don’t want to pay high compile-time costs for flexibility & incrementality; our compile times are high enough already.