### PR TITLE
semantic-source-0.0.0.1/ghc-8.8.1

### DIFF
--- a/semantic-source/CHANGELOG.md
+++ b/semantic-source/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.0.0.0
+
+Initial release

--- a/semantic-source/CHANGELOG.md
+++ b/semantic-source/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.0.0.1
+
+- Loosens the upper bound on `hashable`.
+- Adds support for GHC 8.8.1.
+
+
 # 0.0.0.0
 
 Initial release

--- a/semantic-source/semantic-source.cabal
+++ b/semantic-source/semantic-source.cabal
@@ -20,6 +20,7 @@ extra-source-files:
 
 tested-with:
   GHC == 8.6.5
+  GHC == 8.8.1
 
 common common
   default-language: Haskell2010

--- a/semantic-source/semantic-source.cabal
+++ b/semantic-source/semantic-source.cabal
@@ -46,8 +46,6 @@ library
     Source.Range
     Source.Source
     Source.Span
-  -- other-modules:
-  -- other-extensions:
   build-depends:
       aeson          ^>= 1.4.2.0
     , base            >= 4.12 && < 5

--- a/semantic-source/semantic-source.cabal
+++ b/semantic-source/semantic-source.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.4
 
 name:                semantic-source
-version:             0.0.0.0
+version:             0.0.0.1
 synopsis:            Types and functionality for working with source code
 description:         Types and functionality for working with source code (program text).
 homepage:            https://github.com/github/semantic/tree/master/semantic-source#readme

--- a/semantic-source/semantic-source.cabal
+++ b/semantic-source/semantic-source.cabal
@@ -36,6 +36,8 @@ common common
     -Wno-missed-specialisations
     -Wno-all-missed-specialisations
     -Wno-star-is-type
+  if (impl(ghc >= 8.8))
+    ghc-options: -Wno-missing-deriving-strategies
 
 library
   import: common

--- a/semantic-source/semantic-source.cabal
+++ b/semantic-source/semantic-source.cabal
@@ -51,7 +51,7 @@ library
     , bytestring     ^>= 0.10.8.2
     , deepseq        ^>= 1.4.4.0
     , generic-monoid ^>= 0.1.0.0
-    , hashable       ^>= 1.2.7.0
+    , hashable        >= 1.2.7 && < 1.4
     , semilattices   ^>= 0.0.0.3
     , text           ^>= 1.2.3.1
   hs-source-dirs: src

--- a/semantic-source/semantic-source.cabal
+++ b/semantic-source/semantic-source.cabal
@@ -15,6 +15,7 @@ category:            Data
 build-type:          Simple
 stability:           alpha
 extra-source-files:
+  CHANGELOG.md
   README.md
 
 

--- a/semantic-source/semantic-source.cabal
+++ b/semantic-source/semantic-source.cabal
@@ -18,7 +18,6 @@ extra-source-files:
   CHANGELOG.md
   README.md
 
-
 tested-with:
   GHC == 8.6.5
   GHC == 8.8.1


### PR DESCRIPTION
This PR adds support for `ghc` 8.8.1 to `semantic-source`.