### PR TITLE
Build, but don't run, the benchmarks in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
 
 install:
 - cabal new-update -v
-- cabal new-configure --enable-tests --disable-optimization --write-ghc-environment-files=always --jobs=2
+- cabal new-configure --enable-tests --enable-benchmarks --disable-optimization --write-ghc-environment-files=always --jobs=2
 - cabal new-build --only-dependencies
 
 script:


### PR DESCRIPTION
Should address issues with the benchmarks bitrotting.