### PR TITLE
Make Data.Name.Name a newtype rather than a synonym.

### DIFF
--- a/semantic-core/src/Analysis/Concrete.hs
+++ b/semantic-core/src/Analysis/Concrete.hs
@@ -197,7 +197,7 @@ heapAddressGraph = heapGraph (\ addr v -> (Value v, addr)) (fmap G.vertex . (,) 
 addressStyle :: Heap term -> G.Style (EdgeType term, Precise) Text
 addressStyle heap = (G.defaultStyle vertex) { G.edgeAttributes }
   where vertex (_, addr) = pack (show addr) <> " = " <> maybe "?" fromConcrete (IntMap.lookup addr heap)
-        edgeAttributes _ (Slot name,    _) = ["label" G.:= name]
+        edgeAttributes _ (Slot name,    _) = ["label" G.:= unName name]
         edgeAttributes _ (Edge Import,  _) = ["color" G.:= "blue"]
         edgeAttributes _ (Edge Lexical, _) = ["color" G.:= "green"]
         edgeAttributes _ _                 = []
@@ -205,7 +205,7 @@ addressStyle heap = (G.defaultStyle vertex) { G.edgeAttributes }
           Unit ->  "()"
           Bool b -> pack $ show b
           String s -> pack $ show s
-          Closure (Loc p (Span s e)) n _ _ -> "\\\\ " <> n <> " [" <> p <> ":" <> showPos s <> "-" <> showPos e <> "]"
+          Closure (Loc p (Span s e)) n _ _ -> "\\\\ " <> unName n <> " [" <> p <> ":" <> showPos s <> "-" <> showPos e <> "]"
           Record _ -> "{}"
         showPos (Pos l c) = pack (show l) <> ":" <> pack (show c)
 

--- a/semantic-core/src/Analysis/ScopeGraph.hs
+++ b/semantic-core/src/Analysis/ScopeGraph.hs
@@ -25,12 +25,11 @@ import qualified Data.Map as Map
 import           Data.Name
 import           Data.Proxy
 import qualified Data.Set as Set
-import           Data.Text (Text)
 import           Data.Traversable (for)
 import           Prelude hiding (fail)
 
 data Decl = Decl
-  { declSymbol :: Text
+  { declSymbol :: Name
   , declLoc    :: Loc
   }
   deriving (Eq, Ord, Show)

--- a/semantic-core/src/Data/Name.hs
+++ b/semantic-core/src/Data/Name.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE DeriveTraversable, LambdaCase, OverloadedLists #-}
+{-# LANGUAGE DeriveGeneric, DeriveTraversable, GeneralizedNewtypeDeriving, LambdaCase, OverloadedLists #-}
 module Data.Name
-( Name
+( Name (..)
 , Named(..)
 , named
 , named'
@@ -15,10 +15,14 @@ module Data.Name
 import qualified Data.Char as Char
 import           Data.HashSet (HashSet)
 import qualified Data.HashSet as HashSet
+import           Data.String (IsString)
 import           Data.Text as Text (Text, any, unpack)
+import           Data.Text.Prettyprint.Doc (Pretty)
+import           GHC.Generics (Generic)
 
 -- | User-specified and -relevant names.
-type Name = Text
+newtype Name = Name { unName :: Text }
+  deriving (Eq, Show, Ord, Generic, Pretty, IsString)
 
 -- | Annotates an @a@ with a 'Name'-provided name, which is ignored for '==' and 'compare'.
 data Named a = Named (Ignored Name) a
@@ -50,7 +54,7 @@ reservedNames = [ "#true", "#false", "if", "then", "else"
 -- | Returns true if any character would require quotation or if the
 -- name conflicts with a Core primitive.
 needsQuotation :: Name -> Bool
-needsQuotation u = HashSet.member (unpack u) reservedNames || Text.any (not . isSimpleCharacter) u
+needsQuotation (Name u) = HashSet.member (unpack u) reservedNames || Text.any (not . isSimpleCharacter) u
 
 -- | A ‘simple’ character is, loosely defined, a character that is compatible
 -- with identifiers in most ASCII-oriented programming languages. This is defined

--- a/semantic-core/test/Generators.hs
+++ b/semantic-core/test/Generators.hs
@@ -26,7 +26,7 @@ import Data.Term
 -- interesting property as they parse regardless.
 name :: MonadGen m => m (Named Name)
 name = Gen.prune (named' <$> names) where
-  names = Gen.text (Range.linear 1 10) Gen.lower
+  names = Name <$> Gen.text (Range.linear 1 10) Gen.lower
 
 boolean :: (Carrier sig t, Member Core.Core sig, MonadGen m) => m (t Name)
 boolean = Core.bool <$> Gen.bool

--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE ConstraintKinds, DataKinds, DefaultSignatures, DeriveAnyClass, DeriveGeneric, DerivingStrategies,
              DerivingVia, DisambiguateRecordFields, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving,
              KindSignatures, LambdaCase, NamedFieldPuns, OverloadedLists, OverloadedStrings, PatternSynonyms,
@@ -52,7 +53,7 @@ def n = coerce (Stack.:> n)
 pattern SingleIdentifier :: Name -> Py.ExpressionList a
 pattern SingleIdentifier name <- Py.ExpressionList
   { Py.extraChildren =
-    [ Py.PrimaryExpressionExpression (Py.IdentifierPrimaryExpression (Py.Identifier { bytes = name }))
+    [ Py.PrimaryExpressionExpression (Py.IdentifierPrimaryExpression (Py.Identifier { bytes = (Name -> name) }))
     ]
   }
 
@@ -254,18 +255,18 @@ instance Compile Py.FunctionDefinition where
       -- Give it a name (below), then augment the current continuation
       -- with the new name (with 'def'), so that calling contexts know
       -- that we have built an exportable definition.
-      assigning located <$> local (def name) cc
-    where param (Py.IdentifierParameter (Py.Identifier _pann pname)) = pure (named' pname)
+      assigning located <$> local (def (Name name)) cc
+    where param (Py.IdentifierParameter (Py.Identifier _pann pname)) = pure . named' . Name $ pname
           param x                                                    = unimplemented x
           unimplemented x = fail $ "unimplemented: " <> show x
-          assigning item f = (Name.named' name :<- item) >>>= f
+          assigning item f = (Name.named' (Name name) :<- item) >>>= f
 
 instance Compile Py.FutureImportStatement
 instance Compile Py.GeneratorExpression
 instance Compile Py.GlobalStatement
 
 instance Compile Py.Identifier where
-  compileCC Py.Identifier { bytes } _ = pure (pure bytes)
+  compileCC Py.Identifier { bytes } _ = pure . pure . Name $ bytes
 
 instance Compile Py.IfStatement where
   compileCC it@Py.IfStatement{ condition, consequence, alternative} cc =

--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE ConstraintKinds, DataKinds, DefaultSignatures, DeriveAnyClass, DeriveGeneric, DerivingStrategies,
              DerivingVia, DisambiguateRecordFields, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving,
              KindSignatures, LambdaCase, NamedFieldPuns, OverloadedLists, OverloadedStrings, PatternSynonyms,
-             ScopedTypeVariables, StandaloneDeriving, TypeApplications, TypeOperators, UndecidableInstances #-}
+             ScopedTypeVariables, StandaloneDeriving, TypeApplications, TypeOperators, UndecidableInstances,
+             ViewPatterns #-}
 
 module Language.Python.Core
 ( compile

--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -53,7 +53,7 @@ def n = coerce (Stack.:> n)
 pattern SingleIdentifier :: Name -> Py.ExpressionList a
 pattern SingleIdentifier name <- Py.ExpressionList
   { Py.extraChildren =
-    [ Py.PrimaryExpressionExpression (Py.IdentifierPrimaryExpression (Py.Identifier { bytes = (Name -> name) }))
+    [ Py.PrimaryExpressionExpression (Py.IdentifierPrimaryExpression (Py.Identifier { bytes = Name -> name }))
     ]
   }
 

--- a/semantic-python/test/Instances.hs
+++ b/semantic-python/test/Instances.hs
@@ -8,18 +8,15 @@ module Instances () where
 -- we should keep track of them in a dedicated file.
 
 import           Analysis.ScopeGraph
-import           Control.Effect.Sum
 import           Data.Aeson
-import qualified Data.HashMap.Strict as HashMap
 import           Data.Loc
-import           Data.Core (Core, Ann (..))
 import qualified Data.Map as Map
 import           Data.File
-import           Data.Term
 import           Data.Text (Text)
-import           Data.Scope (Scope, Incr)
-import qualified Data.Scope as Scope
 import           Data.Name
+
+deriving newtype instance ToJSON Name
+deriving newtype instance ToJSONKey Name
 
 instance ToJSON a => ToJSON (File a) where
   toJSON File{fileLoc, fileBody} = object


### PR DESCRIPTION
The fact that `Name` was a simple alias for `Text` was creeping into
the error messages I'm seeing in `semantic-python`, which was a bit of
a buzzkill. This remedies that.