### PR TITLE
[semantic-python] Remove problematic `compile` and rename `compileCC`.

### DIFF
--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -241,7 +241,6 @@ instance Compile Py.FunctionDefinition where
     } cc = do
       -- Compile each of the parameters, then the body.
       parameters' <- traverse param parameters
-      -- BUG: ignoring the continuation here
       body' <- compile body (pure none)
       -- Build a lambda.
       located <- locate it (lams parameters' body')
@@ -263,11 +262,10 @@ instance Compile Py.Identifier where
 
 instance Compile Py.IfStatement where
   compile it@Py.IfStatement{ condition, consequence, alternative} cc =
-    locate it =<< (if'
-                    <$> compile condition (pure none)
-                    <*> compile consequence cc
-                    <*> foldr clause cc alternative
-                  )
+    locate it =<< if'
+    <$> compile condition (pure none)
+    <*> compile consequence cc
+    <*> foldr clause cc alternative
     where clause (R1 Py.ElseClause{ body }) _ = compile body cc
           clause (L1 Py.ElifClause{ condition, consequence }) rest  =
             if' <$> compile condition (pure none) <*> compile consequence cc <*> rest

--- a/semantic-python/test/Test.hs
+++ b/semantic-python/test/Test.hs
@@ -35,7 +35,6 @@ import qualified Streaming.Process
 import           System.Directory
 import           System.Exit
 import qualified TreeSitter.Python as TSP
-import qualified TreeSitter.Python.AST as TSP
 import qualified TreeSitter.Unmarshal as TS
 import           Text.Show.Pretty (ppShow)
 import qualified System.Path as Path
@@ -98,7 +97,7 @@ fixtureTestTreeForFile fp = HUnit.testCaseSteps (Path.toString fp) $ \step -> wi
                    . runFail
                    . runReader (fromString @Py.SourcePath . Path.toString $ fp)
                    . runReader @Py.Bindings mempty
-                   . Py.compile @TSP.Module @_ @(Term (Ann :+: Core))
+                   . Py.toplevelCompile
                    <$> result
 
   for_ directives $ \directive -> do


### PR DESCRIPTION
`compileCC py (pure none)` is an antipatttern, as mentioned in #305. This cleans up and indicates clearly the presence of these bugs, since I’m still stuck on #305.