### PR TITLE
Add Java as supported code nav language

### DIFF
--- a/src/Data/Language.hs
+++ b/src/Data/Language.hs
@@ -104,7 +104,7 @@ supportedExts = foldr append mempty supportedLanguages
     lookup k = Map.lookup k Lingo.languages
 
 codeNavLanguages :: [Language]
-codeNavLanguages = [Go, Ruby, Python, JavaScript, TypeScript, PHP]
+codeNavLanguages = [Go, Java, Ruby, Python, JavaScript, TypeScript, PHP]
 
 pathIsMinified :: FilePath -> Bool
 pathIsMinified = isExtensionOf ".min.js"

--- a/src/Parsing/Parser.hs
+++ b/src/Parsing/Parser.hs
@@ -180,7 +180,7 @@ goParser' :: c (Term (Sum Go.Syntax)) => (Language, SomeParser c Loc)
 goParser' = (Go, SomeParser goParser)
 
 javaParser' :: c PreciseJava.Term => (Language, SomeParser c Loc)
-javaParser' = (Python, SomeParser javaParserPrecise)
+javaParser' = (Java, SomeParser javaParserPrecise)
 
 javascriptParser' :: c (Term (Sum TSX.Syntax)) => (Language, SomeParser c Loc)
 javascriptParser' = (JavaScript, SomeParser tsxParser)

--- a/test/Data/Language/Spec.hs
+++ b/test/Data/Language/Spec.hs
@@ -7,7 +7,7 @@ import Test.Tasty.HUnit
 testTree :: TestTree
 testTree = testGroup "Data.Language"
   [ testCase "supportedExts returns expected list" $
-      supportedExts @=? [".go",".rb",".builder",".eye",".fcgi",".gemspec",".god",".jbuilder",".mspec",".pluginspec",".podspec",".rabl",".rake",".rbuild",".rbw",".rbx",".ru",".ruby",".spec",".thor",".watchr",".py",".bzl",".cgi",".fcgi",".gyp",".gypi",".lmi",".py3",".pyde",".pyi",".pyp",".pyt",".pyw",".rpy",".spec",".tac",".wsgi",".xpy",".js","._js",".bones",".es",".es6",".frag",".gs",".jake",".jsb",".jscad",".jsfl",".jsm",".jss",".mjs",".njs",".pac",".sjs",".ssjs",".xsjs",".xsjslib",".ts",".php",".aw",".ctp",".fcgi",".inc",".php3",".php4",".php5",".phps",".phpt"]
+      supportedExts @=? [".go",".java",".rb",".builder",".eye",".fcgi",".gemspec",".god",".jbuilder",".mspec",".pluginspec",".podspec",".rabl",".rake",".rbuild",".rbw",".rbx",".ru",".ruby",".spec",".thor",".watchr",".py",".bzl",".cgi",".fcgi",".gyp",".gypi",".lmi",".py3",".pyde",".pyi",".pyp",".pyt",".pyw",".rpy",".spec",".tac",".wsgi",".xpy",".js","._js",".bones",".es",".es6",".frag",".gs",".jake",".jsb",".jscad",".jsfl",".jsm",".jss",".mjs",".njs",".pac",".sjs",".ssjs",".xsjs",".xsjslib",".ts",".php",".aw",".ctp",".fcgi",".inc",".php3",".php4",".php5",".phps",".phpt"]
   , testCase "codeNavLanguages returns expected list" $
-      codeNavLanguages @=? [Go, Ruby, Python, JavaScript, TypeScript, PHP]
+      codeNavLanguages @=? [Go, Java, Ruby, Python, JavaScript, TypeScript, PHP]
   ]


### PR DESCRIPTION
This allows us to start testing Java language support for tag symbol generation for code navigation.

