### PR TITLE
Separate file and span annotations

### DIFF
--- a/semantic-core/semantic-core.cabal
+++ b/semantic-core/semantic-core.cabal
@@ -25,7 +25,7 @@ library
                      , Analysis.ImportGraph
                      , Analysis.ScopeGraph
                      , Analysis.Typecheck
-                     , Control.Carrier.Fail.WithFile
+                     , Control.Carrier.Fail.WithLoc
                      , Control.Effect.Readline
                      , Control.Monad.Module
                      , Data.Core

--- a/semantic-core/semantic-core.cabal
+++ b/semantic-core/semantic-core.cabal
@@ -84,6 +84,7 @@ test-suite spec
   other-modules:       Generators
   build-depends:       base
                      , semantic-core
+                     , semantic-source ^>= 0
                      , fused-effects
                      , hedgehog ^>= 1
                      , tasty >= 1.2 && <2

--- a/semantic-core/semantic-core.cabal
+++ b/semantic-core/semantic-core.cabal
@@ -25,7 +25,7 @@ library
                      , Analysis.ImportGraph
                      , Analysis.ScopeGraph
                      , Analysis.Typecheck
-                     , Control.Carrier.Fail.WithLoc
+                     , Control.Carrier.Fail.WithFile
                      , Control.Effect.Readline
                      , Control.Monad.Module
                      , Data.Core

--- a/semantic-core/src/Analysis/Concrete.hs
+++ b/semantic-core/src/Analysis/Concrete.hs
@@ -13,7 +13,7 @@ import qualified Algebra.Graph as G
 import qualified Algebra.Graph.Export.Dot as G
 import           Analysis.Eval
 import           Control.Applicative (Alternative (..))
-import           Control.Carrier.Fail.WithFile
+import           Control.Carrier.Fail.WithLoc
 import           Control.Effect
 import           Control.Effect.Fresh
 import           Control.Effect.NonDet

--- a/semantic-core/src/Analysis/Concrete.hs
+++ b/semantic-core/src/Analysis/Concrete.hs
@@ -13,7 +13,7 @@ import qualified Algebra.Graph as G
 import qualified Algebra.Graph.Export.Dot as G
 import           Analysis.Eval
 import           Control.Applicative (Alternative (..))
-import           Control.Carrier.Fail.WithLoc
+import           Control.Carrier.Fail.WithFile
 import           Control.Effect
 import           Control.Effect.Fresh
 import           Control.Effect.NonDet

--- a/semantic-core/src/Analysis/Concrete.hs
+++ b/semantic-core/src/Analysis/Concrete.hs
@@ -67,7 +67,7 @@ data Edge = Lexical | Import
 
 -- | Concrete evaluation of a term to a value.
 --
---   >>> map fileBody (snd (concrete eval [File (Loc "bool" (Span (Pos 1 1) (Pos 1 5))) (Core.bool True)]))
+--   >>> map fileBody (snd (concrete eval [File (Path "bool") (Span (Pos 1 1) (Pos 1 5)) (Core.bool True)]))
 --   [Right (Bool True)]
 concrete
   :: (Foldable term, Show (term Name))

--- a/semantic-core/src/Analysis/Concrete.hs
+++ b/semantic-core/src/Analysis/Concrete.hs
@@ -78,7 +78,7 @@ concrete
      -> (term Name -> m (Concrete (term Name)))
      )
   -> [File (term Name)]
-  -> (Heap (term Name), [File (Either (Path, Span, String) (Concrete (term Name)))])
+  -> (Heap (term Name), [File (Either (File String) (Concrete (term Name)))])
 concrete eval
   = run
   . runFresh
@@ -100,7 +100,7 @@ runFile
      -> (term Name -> m (Concrete (term Name)))
      )
   -> File (term Name)
-  -> m (File (Either (Path, Span, String) (Concrete (term Name))))
+  -> m (File (Either (File String) (Concrete (term Name))))
 runFile eval file = traverse run file
   where run = runReader (filePath file)
             . runReader (fileSpan file)

--- a/semantic-core/src/Analysis/Concrete.hs
+++ b/semantic-core/src/Analysis/Concrete.hs
@@ -206,7 +206,7 @@ addressStyle heap = (G.defaultStyle vertex) { G.edgeAttributes }
           Unit ->  "()"
           Bool b -> pack $ show b
           String s -> pack $ show s
-          Closure (Loc p (Span s e)) n _ _ -> "\\\\ " <> unName n <> " [" <> p <> ":" <> showPos s <> "-" <> showPos e <> "]"
+          Closure (Loc p (Span s e)) n _ _ -> "\\\\ " <> unName n <> " [" <> getPath p <> ":" <> showPos s <> "-" <> showPos e <> "]"
           Record _ -> "{}"
         showPos (Pos l c) = pack (show l) <> ":" <> pack (show c)
 

--- a/semantic-core/src/Analysis/Concrete.hs
+++ b/semantic-core/src/Analysis/Concrete.hs
@@ -78,7 +78,7 @@ concrete
      -> (term Name -> m (Concrete (term Name)))
      )
   -> [File (term Name)]
-  -> (Heap (term Name), [File (Either (File String) (Concrete (term Name)))])
+  -> (Heap (term Name), [File (Either (Path, Span, String) (Concrete (term Name)))])
 concrete eval
   = run
   . runFresh
@@ -100,7 +100,7 @@ runFile
      -> (term Name -> m (Concrete (term Name)))
      )
   -> File (term Name)
-  -> m (File (Either (File String) (Concrete (term Name))))
+  -> m (File (Either (Path, Span, String) (Concrete (term Name))))
 runFile eval file = traverse run file
   where run = runReader (filePath file)
             . runReader (fileSpan file)

--- a/semantic-core/src/Analysis/Eval.hs
+++ b/semantic-core/src/Analysis/Eval.hs
@@ -129,9 +129,9 @@ prog5 = fromBody $ ann (do'
 
 prog6 :: (Carrier sig t, Member Core sig) => [File (t Name)]
 prog6 =
-  [ File (Loc "dep"  (locSpan (fromJust here))) $ Core.record
+  [ File (Loc (Path "dep")  (locSpan (fromJust here))) $ Core.record
     [ ("dep", Core.record [ ("var", Core.bool True) ]) ]
-  , File (Loc "main" (locSpan (fromJust here))) $ do' (map (Nothing :<-)
+  , File (Loc (Path "main") (locSpan (fromJust here))) $ do' (map (Nothing :<-)
     [ load (Core.string "dep")
     , Core.record [ ("thing", pure "dep" Core.... "var") ]
     ])

--- a/semantic-core/src/Analysis/Eval.hs
+++ b/semantic-core/src/Analysis/Eval.hs
@@ -120,7 +120,7 @@ prog4 = fromBody
     (Core.bool True)
     (Core.bool False))
 
-prog5 :: (Carrier sig t, Member (Ann Path) sig, Member (Ann Span) sig, Member Core sig) => File (t Name)
+prog5 :: (Carrier sig t, Member (Ann Span) sig, Member Core sig) => File (t Name)
 prog5 = fromBody $ ann (do'
   [ Just (named' "mkPoint") :<- lams [named' "_x", named' "_y"] (ann (Core.record
     [ ("x", ann (pure "_x"))
@@ -141,7 +141,7 @@ prog6 =
     ])
   ]
 
-ruby :: (Carrier sig t, Member (Ann Path) sig, Member (Ann Span) sig, Member Core sig) => File (t Name)
+ruby :: (Carrier sig t, Member (Ann Span) sig, Member Core sig) => File (t Name)
 ruby = fromBody $ annWith callStack (rec (named' __semantic_global) (do' statements))
   where statements =
           [ Just "Class" :<- record

--- a/semantic-core/src/Analysis/Eval.hs
+++ b/semantic-core/src/Analysis/Eval.hs
@@ -129,9 +129,9 @@ prog5 = fromBody $ ann (do'
 
 prog6 :: (Carrier sig t, Member Core sig) => [File (t Name)]
 prog6 =
-  [ File (Loc (Path "dep")  (locSpan (fromJust here))) $ Core.record
+  [ File (Path "dep")  (locSpan (fromJust here)) $ Core.record
     [ ("dep", Core.record [ ("var", Core.bool True) ]) ]
-  , File (Loc (Path "main") (locSpan (fromJust here))) $ do' (map (Nothing :<-)
+  , File (Path "main") (locSpan (fromJust here)) $ do' (map (Nothing :<-)
     [ load (Core.string "dep")
     , Core.record [ ("thing", pure "dep" Core.... "var") ]
     ])

--- a/semantic-core/src/Analysis/Eval.hs
+++ b/semantic-core/src/Analysis/Eval.hs
@@ -120,7 +120,7 @@ prog4 = fromBody
     (Core.bool True)
     (Core.bool False))
 
-prog5 :: (Carrier sig t, Member (Ann Loc) sig, Member Core sig) => File (t Name)
+prog5 :: (Carrier sig t, Member (Ann Path) sig, Member (Ann Span) sig, Member Core sig) => File (t Name)
 prog5 = fromBody $ ann (do'
   [ Just (named' "mkPoint") :<- lams [named' "_x", named' "_y"] (ann (Core.record
     [ ("x", ann (pure "_x"))
@@ -133,15 +133,15 @@ prog5 = fromBody $ ann (do'
 
 prog6 :: (Carrier sig t, Member Core sig) => [File (t Name)]
 prog6 =
-  [ File (Path "dep")  (locSpan (fromJust here)) $ Core.record
+  [ File (Path "dep")  (snd (fromJust here)) $ Core.record
     [ ("dep", Core.record [ ("var", Core.bool True) ]) ]
-  , File (Path "main") (locSpan (fromJust here)) $ do' (map (Nothing :<-)
+  , File (Path "main") (snd (fromJust here)) $ do' (map (Nothing :<-)
     [ load (Core.string "dep")
     , Core.record [ ("thing", pure "dep" Core.... "var") ]
     ])
   ]
 
-ruby :: (Carrier sig t, Member (Ann Loc) sig, Member Core sig) => File (t Name)
+ruby :: (Carrier sig t, Member (Ann Path) sig, Member (Ann Span) sig, Member Core sig) => File (t Name)
 ruby = fromBody $ annWith callStack (rec (named' __semantic_global) (do' statements))
   where statements =
           [ Just "Class" :<- record

--- a/semantic-core/src/Analysis/Eval.hs
+++ b/semantic-core/src/Analysis/Eval.hs
@@ -33,9 +33,9 @@ eval :: ( Carrier sig m
         , MonadFail m
         , Semigroup value
         )
-     => Analysis (Term (Ann :+: Core) Name) address value m
-     -> (Term (Ann :+: Core) Name -> m value)
-     -> (Term (Ann :+: Core) Name -> m value)
+     => Analysis (Term (Ann Loc :+: Core) Name) address value m
+     -> (Term (Ann Loc :+: Core) Name -> m value)
+     -> (Term (Ann Loc :+: Core) Name -> m value)
 eval Analysis{..} eval = \case
   Var n -> lookupEnv' n >>= deref' n
   Term (R c) -> case c of
@@ -116,7 +116,7 @@ prog4 = fromBody
     (Core.bool True)
     (Core.bool False))
 
-prog5 :: (Carrier sig t, Member Ann sig, Member Core sig) => File (t Name)
+prog5 :: (Carrier sig t, Member (Ann Loc) sig, Member Core sig) => File (t Name)
 prog5 = fromBody $ ann (do'
   [ Just (named' "mkPoint") :<- lams [named' "_x", named' "_y"] (ann (Core.record
     [ ("x", ann (pure "_x"))
@@ -137,7 +137,7 @@ prog6 =
     ])
   ]
 
-ruby :: (Carrier sig t, Member Ann sig, Member Core sig) => File (t Name)
+ruby :: (Carrier sig t, Member (Ann Loc) sig, Member Core sig) => File (t Name)
 ruby = fromBody $ annWith callStack (rec (named' __semantic_global) (do' statements))
   where statements =
           [ Just "Class" :<- record

--- a/semantic-core/src/Analysis/ImportGraph.hs
+++ b/semantic-core/src/Analysis/ImportGraph.hs
@@ -8,7 +8,7 @@ module Analysis.ImportGraph
 import           Analysis.Eval
 import           Analysis.FlowInsensitive
 import           Control.Applicative (Alternative(..))
-import           Control.Carrier.Fail.WithFile
+import           Control.Carrier.Fail.WithLoc
 import           Control.Effect
 import           Control.Effect.Fresh
 import           Control.Effect.Reader

--- a/semantic-core/src/Analysis/ImportGraph.hs
+++ b/semantic-core/src/Analysis/ImportGraph.hs
@@ -59,7 +59,7 @@ importGraph
      )
   -> [File term]
   -> ( Heap Name (Value term)
-     , [File (Either (Path, Span, String) (Value term))]
+     , [File (Either (File String) (Value term))]
      )
 importGraph eval
   = run
@@ -82,7 +82,7 @@ runFile
      -> (term -> m (Value term))
      )
   -> File term
-  -> m (File (Either (Path, Span, String) (Value term)))
+  -> m (File (Either (File String) (Value term)))
 runFile eval file = traverse run file
   where run = runReader (filePath file)
             . runReader (fileSpan file)

--- a/semantic-core/src/Analysis/ImportGraph.hs
+++ b/semantic-core/src/Analysis/ImportGraph.hs
@@ -59,7 +59,7 @@ importGraph
      )
   -> [File term]
   -> ( Heap Name (Value term)
-     , [File (Either (File String) (Value term))]
+     , [File (Either (Path, Span, String) (Value term))]
      )
 importGraph eval
   = run
@@ -82,7 +82,7 @@ runFile
      -> (term -> m (Value term))
      )
   -> File term
-  -> m (File (Either (File String) (Value term)))
+  -> m (File (Either (Path, Span, String) (Value term)))
 runFile eval file = traverse run file
   where run = runReader (filePath file)
             . runReader (fileSpan file)

--- a/semantic-core/src/Analysis/ImportGraph.hs
+++ b/semantic-core/src/Analysis/ImportGraph.hs
@@ -8,7 +8,7 @@ module Analysis.ImportGraph
 import           Analysis.Eval
 import           Analysis.FlowInsensitive
 import           Control.Applicative (Alternative(..))
-import           Control.Carrier.Fail.WithLoc
+import           Control.Carrier.Fail.WithFile
 import           Control.Effect
 import           Control.Effect.Fresh
 import           Control.Effect.Reader

--- a/semantic-core/src/Analysis/ScopeGraph.hs
+++ b/semantic-core/src/Analysis/ScopeGraph.hs
@@ -36,7 +36,10 @@ data Decl = Decl
   }
   deriving (Eq, Ord, Show)
 
-newtype Ref = Ref Loc
+data Ref = Ref
+  { refPath :: Path
+  , refSpan :: Span
+  }
   deriving (Eq, Ord, Show)
 
 newtype ScopeGraph = ScopeGraph { unScopeGraph :: Map.Map Decl (Set.Set Ref) }
@@ -132,7 +135,7 @@ scopeGraphAnalysis = Analysis{..}
           pure (foldMap snd fields')
         _ ... m = pure (Just m)
 
-        askRef = Ref <$> askLoc
+        askRef = Ref <$> ask <*> ask
         askLoc = Loc <$> ask <*> ask
 
         extendBinding addr ref bindLoc = ScopeGraph (maybe Map.empty (\ (Loc path span) -> Map.singleton (Decl addr path span) (Set.singleton ref)) bindLoc)

--- a/semantic-core/src/Analysis/ScopeGraph.hs
+++ b/semantic-core/src/Analysis/ScopeGraph.hs
@@ -10,7 +10,7 @@ module Analysis.ScopeGraph
 import           Analysis.Eval
 import           Analysis.FlowInsensitive
 import           Control.Applicative (Alternative (..))
-import           Control.Carrier.Fail.WithFile
+import           Control.Carrier.Fail.WithLoc
 import           Control.Effect.Carrier
 import           Control.Effect.Fresh
 import           Control.Effect.Reader

--- a/semantic-core/src/Analysis/ScopeGraph.hs
+++ b/semantic-core/src/Analysis/ScopeGraph.hs
@@ -56,7 +56,7 @@ scopeGraph
      -> (term -> m ScopeGraph)
      )
   -> [File term]
-  -> (Heap Name ScopeGraph, [File (Either (File String) ScopeGraph)])
+  -> (Heap Name ScopeGraph, [File (Either (Path, Span, String) ScopeGraph)])
 scopeGraph eval
   = run
   . runFresh
@@ -77,7 +77,7 @@ runFile
      -> (term -> m ScopeGraph)
      )
   -> File term
-  -> m (File (Either (File String) ScopeGraph))
+  -> m (File (Either (Path, Span, String) ScopeGraph))
 runFile eval file = traverse run file
   where run = runReader (filePath file)
             . runReader (fileSpan file)

--- a/semantic-core/src/Analysis/ScopeGraph.hs
+++ b/semantic-core/src/Analysis/ScopeGraph.hs
@@ -31,7 +31,8 @@ import           Source.Span
 
 data Decl = Decl
   { declSymbol :: Name
-  , declLoc    :: Loc
+  , declPath   :: Path
+  , declSpan   :: Span
   }
   deriving (Eq, Ord, Show)
 
@@ -124,8 +125,9 @@ scopeGraphAnalysis = Analysis{..}
         record fields = do
           fields' <- for fields $ \ (k, v) -> do
             addr <- alloc k
-            loc <- askLoc
-            let v' = ScopeGraph (Map.singleton (Decl k loc) mempty) <> v
+            path <- ask
+            span <- ask
+            let v' = ScopeGraph (Map.singleton (Decl k path span) mempty) <> v
             (k, v') <$ assign addr v'
           pure (foldMap snd fields')
         _ ... m = pure (Just m)
@@ -133,4 +135,4 @@ scopeGraphAnalysis = Analysis{..}
         askRef = Ref <$> askLoc
         askLoc = Loc <$> ask <*> ask
 
-        extendBinding addr ref bindLoc = ScopeGraph (maybe Map.empty (\ bindLoc -> Map.singleton (Decl addr bindLoc) (Set.singleton ref)) bindLoc)
+        extendBinding addr ref bindLoc = ScopeGraph (maybe Map.empty (\ (Loc path span) -> Map.singleton (Decl addr path span) (Set.singleton ref)) bindLoc)

--- a/semantic-core/src/Analysis/ScopeGraph.hs
+++ b/semantic-core/src/Analysis/ScopeGraph.hs
@@ -10,7 +10,7 @@ module Analysis.ScopeGraph
 import           Analysis.Eval
 import           Analysis.FlowInsensitive
 import           Control.Applicative (Alternative (..))
-import           Control.Carrier.Fail.WithLoc
+import           Control.Carrier.Fail.WithFile
 import           Control.Effect.Carrier
 import           Control.Effect.Fresh
 import           Control.Effect.Reader

--- a/semantic-core/src/Analysis/ScopeGraph.hs
+++ b/semantic-core/src/Analysis/ScopeGraph.hs
@@ -56,7 +56,7 @@ scopeGraph
      -> (term -> m ScopeGraph)
      )
   -> [File term]
-  -> (Heap Name ScopeGraph, [File (Either (Path, Span, String) ScopeGraph)])
+  -> (Heap Name ScopeGraph, [File (Either (File String) ScopeGraph)])
 scopeGraph eval
   = run
   . runFresh
@@ -77,7 +77,7 @@ runFile
      -> (term -> m ScopeGraph)
      )
   -> File term
-  -> m (File (Either (Path, Span, String) ScopeGraph))
+  -> m (File (Either (File String) ScopeGraph))
 runFile eval file = traverse run file
   where run = runReader (filePath file)
             . runReader (fileSpan file)

--- a/semantic-core/src/Analysis/ScopeGraph.hs
+++ b/semantic-core/src/Analysis/ScopeGraph.hs
@@ -102,7 +102,7 @@ scopeGraphAnalysis
 scopeGraphAnalysis = Analysis{..}
   where alloc = pure
         bind name _ m = do
-          loc <- askLoc
+          loc <- Loc <$> ask <*> ask
           local (Map.insert name loc) m
         lookupEnv = pure . Just
         deref addr = do
@@ -136,6 +136,5 @@ scopeGraphAnalysis = Analysis{..}
         _ ... m = pure (Just m)
 
         askRef = Ref <$> ask <*> ask
-        askLoc = Loc <$> ask <*> ask
 
         extendBinding addr ref bindLoc = ScopeGraph (maybe Map.empty (\ (Loc path span) -> Map.singleton (Decl addr path span) (Set.singleton ref)) bindLoc)

--- a/semantic-core/src/Analysis/Typecheck.hs
+++ b/semantic-core/src/Analysis/Typecheck.hs
@@ -10,7 +10,7 @@ module Analysis.Typecheck
 import           Analysis.Eval
 import           Analysis.FlowInsensitive
 import           Control.Applicative (Alternative (..))
-import           Control.Carrier.Fail.WithFile
+import           Control.Carrier.Fail.WithLoc
 import           Control.Effect.Carrier
 import           Control.Effect.Fresh as Fresh
 import           Control.Effect.Reader hiding (Local)

--- a/semantic-core/src/Analysis/Typecheck.hs
+++ b/semantic-core/src/Analysis/Typecheck.hs
@@ -102,7 +102,7 @@ typecheckingFlowInsensitive
      )
   -> [File term]
   -> ( Heap Name Type
-     , [File (Either (File String) (Term (Polytype :+: Monotype) Void))]
+     , [File (Either (Path, Span, String) (Term (Polytype :+: Monotype) Void))]
      )
 typecheckingFlowInsensitive eval
   = run
@@ -125,7 +125,7 @@ runFile
      -> (term -> m Type)
      )
   -> File term
-  -> m (File (Either (File String) Type))
+  -> m (File (Either (Path, Span, String) Type))
 runFile eval file = traverse run file
   where run
           = (\ m -> do

--- a/semantic-core/src/Analysis/Typecheck.hs
+++ b/semantic-core/src/Analysis/Typecheck.hs
@@ -10,7 +10,7 @@ module Analysis.Typecheck
 import           Analysis.Eval
 import           Analysis.FlowInsensitive
 import           Control.Applicative (Alternative (..))
-import           Control.Carrier.Fail.WithLoc
+import           Control.Carrier.Fail.WithFile
 import           Control.Effect.Carrier
 import           Control.Effect.Fresh as Fresh
 import           Control.Effect.Reader hiding (Local)

--- a/semantic-core/src/Analysis/Typecheck.hs
+++ b/semantic-core/src/Analysis/Typecheck.hs
@@ -102,7 +102,7 @@ typecheckingFlowInsensitive
      )
   -> [File term]
   -> ( Heap Name Type
-     , [File (Either (Path, Span, String) (Term (Polytype :+: Monotype) Void))]
+     , [File (Either (File String) (Term (Polytype :+: Monotype) Void))]
      )
 typecheckingFlowInsensitive eval
   = run
@@ -125,7 +125,7 @@ runFile
      -> (term -> m Type)
      )
   -> File term
-  -> m (File (Either (Path, Span, String) Type))
+  -> m (File (Either (File String) Type))
 runFile eval file = traverse run file
   where run
           = (\ m -> do

--- a/semantic-core/src/Control/Carrier/Fail/WithFile.hs
+++ b/semantic-core/src/Control/Carrier/Fail/WithFile.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
-module Control.Carrier.Fail.WithLoc
+module Control.Carrier.Fail.WithFile
 ( -- * Fail effect
   module Control.Effect.Fail
   -- * Fail carrier

--- a/semantic-core/src/Control/Carrier/Fail/WithFile.hs
+++ b/semantic-core/src/Control/Carrier/Fail/WithFile.hs
@@ -13,20 +13,18 @@ import Control.Effect.Error
 import Control.Effect.Fail (Fail(..), MonadFail(..))
 import Control.Effect.Reader
 import Data.Loc
+import Data.File
 import Prelude hiding (fail)
 import Source.Span
 
-runFail :: FailC m a -> m (Either (Path, Span, String) a)
+runFail :: FailC m a -> m (Either (File String) a)
 runFail = runError . runFailC
 
-newtype FailC m a = FailC { runFailC :: ErrorC (Path, Span, String) m a }
+newtype FailC m a = FailC { runFailC :: ErrorC (File String) m a }
   deriving (Alternative, Applicative, Functor, Monad)
 
 instance (Carrier sig m, Effect sig, Member (Reader Path) sig, Member (Reader Span) sig) => MonadFail (FailC m) where
-  fail s = do
-    path <- ask
-    span <- ask
-    FailC (throwError (path :: Path, span :: Span, s))
+  fail s = File <$> ask <*> ask <*> pure s >>= FailC . throwError
 
 instance (Carrier sig m, Effect sig, Member (Reader Path) sig, Member (Reader Span) sig) => Carrier (Fail :+: sig) (FailC m) where
   eff (L (Fail s)) = fail s

--- a/semantic-core/src/Control/Carrier/Fail/WithLoc.hs
+++ b/semantic-core/src/Control/Carrier/Fail/WithLoc.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
-module Control.Carrier.Fail.WithFile
+module Control.Carrier.Fail.WithLoc
 ( -- * Fail effect
   module Control.Effect.Fail
   -- * Fail carrier

--- a/semantic-core/src/Data/Core.hs
+++ b/semantic-core/src/Data/Core.hs
@@ -215,27 +215,27 @@ a .= b = send (a := b)
 infix 3 .=
 
 
-data Ann f a
-  = Ann Loc (f a)
+data Ann ann f a
+  = Ann ann (f a)
   deriving (Eq, Foldable, Functor, Generic1, Ord, Show, Traversable)
 
-instance HFunctor Ann
+instance HFunctor (Ann ann)
 
-instance RightModule Ann where
+instance RightModule (Ann ann) where
   Ann l b >>=* f = Ann l (b >>= f)
 
 
-ann :: (Carrier sig m, Member Ann sig) => HasCallStack => m a -> m a
+ann :: (Carrier sig m, Member (Ann Loc) sig) => HasCallStack => m a -> m a
 ann = annWith callStack
 
-annAt :: (Carrier sig m, Member Ann sig) => Loc -> m a -> m a
+annAt :: (Carrier sig m, Member (Ann Loc) sig) => Loc -> m a -> m a
 annAt loc = send . Ann loc
 
-annWith :: (Carrier sig m, Member Ann sig) => CallStack -> m a -> m a
+annWith :: (Carrier sig m, Member (Ann Loc) sig) => CallStack -> m a -> m a
 annWith callStack = maybe id annAt (stackLoc callStack)
 
 
-stripAnnotations :: (HFunctor sig, forall g . Functor g => Functor (sig g)) => Term (Ann :+: sig) a -> Term sig a
+stripAnnotations :: (HFunctor sig, forall g . Functor g => Functor (sig g)) => Term (Ann ann :+: sig) a -> Term sig a
 stripAnnotations (Var v)              = Var v
 stripAnnotations (Term (L (Ann _ b))) = stripAnnotations b
 stripAnnotations (Term (R        b))  = Term (hmap stripAnnotations b)

--- a/semantic-core/src/Data/Core.hs
+++ b/semantic-core/src/Data/Core.hs
@@ -226,14 +226,14 @@ instance RightModule (Ann ann) where
   Ann l b >>=* f = Ann l (b >>= f)
 
 
-ann :: (Carrier sig m, Member (Ann Path) sig, Member (Ann Span) sig) => HasCallStack => m a -> m a
+ann :: (Carrier sig m, Member (Ann Span) sig) => HasCallStack => m a -> m a
 ann = annWith callStack
 
 annAt :: (Carrier sig m, Member (Ann ann) sig) => ann -> m a -> m a
 annAt ann = send . Ann ann
 
-annWith :: (Carrier sig m, Member (Ann Path) sig, Member (Ann Span) sig) => CallStack -> m a -> m a
-annWith callStack = maybe id (\ (path, span) -> annAt path . annAt span) (stackLoc callStack)
+annWith :: (Carrier sig m, Member (Ann Span) sig) => CallStack -> m a -> m a
+annWith callStack = maybe id (annAt . snd) (stackLoc callStack)
 
 
 stripAnnotations :: forall ann a sig . (HFunctor sig, forall g . Functor g => Functor (sig g)) => Term (Ann ann :+: sig) a -> Term sig a

--- a/semantic-core/src/Data/Core.hs
+++ b/semantic-core/src/Data/Core.hs
@@ -236,7 +236,7 @@ annWith :: (Carrier sig m, Member (Ann Path) sig, Member (Ann Span) sig) => Call
 annWith callStack = maybe id (\ (path, span) -> annAt path . annAt span) (stackLoc callStack)
 
 
-stripAnnotations :: (HFunctor sig, forall g . Functor g => Functor (sig g)) => Term (Ann ann :+: sig) a -> Term sig a
+stripAnnotations :: forall ann a sig . (HFunctor sig, forall g . Functor g => Functor (sig g)) => Term (Ann ann :+: sig) a -> Term sig a
 stripAnnotations (Var v)              = Var v
 stripAnnotations (Term (L (Ann _ b))) = stripAnnotations b
 stripAnnotations (Term (R        b))  = Term (hmap stripAnnotations b)

--- a/semantic-core/src/Data/Core/Parser.hs
+++ b/semantic-core/src/Data/Core/Parser.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE FlexibleContexts, TypeOperators #-}
 module Data.Core.Parser
-  ( module Text.Trifecta
-  , core
+  ( core
   , lit
   , expr
   , record

--- a/semantic-core/src/Data/File.hs
+++ b/semantic-core/src/Data/File.hs
@@ -22,4 +22,4 @@ fileLoc (File p s _) = Loc p s
 
 fromBody :: HasCallStack => a -> File a
 fromBody body = File path span body where
-  Loc path span = fromJust (stackLoc callStack)
+  (path, span) = fromJust (stackLoc callStack)

--- a/semantic-core/src/Data/File.hs
+++ b/semantic-core/src/Data/File.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveTraversable #-}
 module Data.File
 ( File(..)
-, fileLoc
 , fromBody
 ) where
 
@@ -16,9 +15,6 @@ data File a = File
   , fileBody :: !a
   }
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
-
-fileLoc :: File a -> Loc
-fileLoc (File p s _) = Loc p s
 
 fromBody :: HasCallStack => a -> File a
 fromBody body = File path span body where

--- a/semantic-core/src/Data/File.hs
+++ b/semantic-core/src/Data/File.hs
@@ -1,18 +1,25 @@
 {-# LANGUAGE DeriveTraversable #-}
 module Data.File
 ( File(..)
+, fileLoc
 , fromBody
 ) where
 
 import Data.Loc
 import Data.Maybe (fromJust)
 import GHC.Stack
+import Source.Span
 
 data File a = File
-  { fileLoc  :: !Loc
+  { filePath :: !Path
+  , fileSpan :: {-# UNPACK #-} !Span
   , fileBody :: !a
   }
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
+fileLoc :: File a -> Loc
+fileLoc (File p s _) = Loc p s
+
 fromBody :: HasCallStack => a -> File a
-fromBody body = File (fromJust (stackLoc callStack)) body
+fromBody body = File path span body where
+  Loc path span = fromJust (stackLoc callStack)

--- a/semantic-core/src/Data/Loc.hs
+++ b/semantic-core/src/Data/Loc.hs
@@ -24,13 +24,13 @@ interactive :: Loc
 interactive = Loc (Path "<interactive>") (Span (Pos 1 1) (Pos 1 1))
 
 
-here :: HasCallStack => Maybe Loc
+here :: HasCallStack => Maybe (Path, Span)
 here = stackLoc callStack
 
-stackLoc :: CallStack -> Maybe Loc
+stackLoc :: CallStack -> Maybe (Path, Span)
 stackLoc cs = case getCallStack cs of
   (_, srcLoc):_ -> Just (fromGHCSrcLoc srcLoc)
   _             -> Nothing
 
-fromGHCSrcLoc :: SrcLoc -> Loc
-fromGHCSrcLoc SrcLoc{..} = Loc (Path (pack srcLocFile)) (Span (Pos srcLocStartLine srcLocStartCol) (Pos srcLocEndLine srcLocEndCol))
+fromGHCSrcLoc :: SrcLoc -> (Path, Span)
+fromGHCSrcLoc SrcLoc{..} = (Path (pack srcLocFile), Span (Pos srcLocStartLine srcLocStartCol) (Pos srcLocEndLine srcLocEndCol))

--- a/semantic-core/src/Data/Loc.hs
+++ b/semantic-core/src/Data/Loc.hs
@@ -2,7 +2,6 @@
 module Data.Loc
 ( Loc(..)
 , Path(..)
-, interactive
 , here
 , stackLoc
 ) where
@@ -19,9 +18,6 @@ data Loc = Loc
   , locSpan :: {-# UNPACK #-} !Span
   }
   deriving (Eq, Ord, Show)
-
-interactive :: Loc
-interactive = Loc (Path "<interactive>") (Span (Pos 1 1) (Pos 1 1))
 
 
 here :: HasCallStack => Maybe (Path, Span)

--- a/semantic-core/src/Data/Loc.hs
+++ b/semantic-core/src/Data/Loc.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings, RecordWildCards #-}
 module Data.Loc
 ( Loc(..)
+, Path(..)
 , interactive
 , here
 , stackLoc
@@ -10,14 +11,17 @@ import Data.Text (Text, pack)
 import GHC.Stack
 import Source.Span
 
+newtype Path = Path { getPath :: Text }
+  deriving (Eq, Ord, Show)
+
 data Loc = Loc
-  { locPath :: !Text
+  { locPath :: !Path
   , locSpan :: {-# UNPACK #-} !Span
   }
   deriving (Eq, Ord, Show)
 
 interactive :: Loc
-interactive = Loc "<interactive>" (Span (Pos 1 1) (Pos 1 1))
+interactive = Loc (Path "<interactive>") (Span (Pos 1 1) (Pos 1 1))
 
 
 here :: HasCallStack => Maybe Loc
@@ -29,4 +33,4 @@ stackLoc cs = case getCallStack cs of
   _             -> Nothing
 
 fromGHCSrcLoc :: SrcLoc -> Loc
-fromGHCSrcLoc SrcLoc{..} = Loc (pack srcLocFile) (Span (Pos srcLocStartLine srcLocStartCol) (Pos srcLocEndLine srcLocEndCol))
+fromGHCSrcLoc SrcLoc{..} = Loc (Path (pack srcLocFile)) (Span (Pos srcLocStartLine srcLocStartCol) (Pos srcLocEndLine srcLocEndCol))

--- a/semantic-core/src/Data/Loc.hs
+++ b/semantic-core/src/Data/Loc.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE RecordWildCards #-}
 module Data.Loc
-( Loc(..)
-, Path(..)
+( Path(..)
 , here
 , stackLoc
 ) where
@@ -11,12 +10,6 @@ import GHC.Stack
 import Source.Span
 
 newtype Path = Path { getPath :: Text }
-  deriving (Eq, Ord, Show)
-
-data Loc = Loc
-  { locPath :: !Path
-  , locSpan :: {-# UNPACK #-} !Span
-  }
   deriving (Eq, Ord, Show)
 
 

--- a/semantic-core/src/Data/Loc.hs
+++ b/semantic-core/src/Data/Loc.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, RecordWildCards #-}
+{-# LANGUAGE RecordWildCards #-}
 module Data.Loc
 ( Loc(..)
 , Path(..)

--- a/semantic-core/test/Spec.hs
+++ b/semantic-core/test/Spec.hs
@@ -108,7 +108,7 @@ parserExamples = testGroup "Parsing: Eval.hs examples"
   , testCase "prog4" (assert_roundtrips Eval.prog4)
   , testCase "prog6.1" (assert_roundtrips (head Eval.prog6))
   , testCase "prog6.2" (assert_roundtrips (last Eval.prog6))
-  , testCase "ruby" (assert_roundtrips (stripAnnotations @Span . stripAnnotations @Path <$> Eval.ruby))
+  , testCase "ruby" (assert_roundtrips (stripAnnotations @Span <$> Eval.ruby))
   ]
 
 tests :: TestTree

--- a/semantic-python/test/Instances.hs
+++ b/semantic-python/test/Instances.hs
@@ -19,27 +19,27 @@ deriving newtype instance ToJSON Name
 deriving newtype instance ToJSONKey Name
 
 instance ToJSON a => ToJSON (File a) where
-  toJSON File{fileLoc, fileBody} = object
-    [ "location" .= fileLoc
+  toJSON File{filePath, fileSpan, fileBody} = object
+    [ "path" .= filePath
+    , "span" .= fileSpan
     , "body" .= fileBody
     ]
 
-instance ToJSON Loc where
-  toJSON Loc{locPath, locSpan} = object
-    [ "kind" .= ("loc" :: Text)
-    , "path" .= locPath
-    , "span" .= locSpan
-    ]
+deriving newtype instance ToJSON Path
 
 instance ToJSON Ref where
-  toJSON (Ref loc) = object [ "kind" .= ("ref" :: Text)
-                            , "location" .= loc]
+  toJSON (Ref path span) = object
+    [ "kind" .= ("ref" :: Text)
+    , "path" .= path
+    , "span" .= span
+    ]
 
 instance ToJSON Decl where
-  toJSON Decl{declSymbol, declLoc} = object
+  toJSON Decl{declSymbol, declPath, declSpan} = object
     [ "kind"   .= ("decl" :: Text)
     , "symbol" .= declSymbol
-    , "location" .= declLoc
+    , "path" .= declPath
+    , "span" .= declSpan
     ]
 
 instance ToJSON ScopeGraph where

--- a/semantic-python/test/Test.hs
+++ b/semantic-python/test/Test.hs
@@ -29,6 +29,7 @@ import           Data.String (fromString)
 import           GHC.Stack
 import qualified Language.Python.Core as Py
 import           Prelude hiding (fail)
+import           Source.Span
 import           Streaming
 import qualified Streaming.Prelude as Stream
 import qualified Streaming.Process
@@ -49,10 +50,10 @@ import qualified Directive
 import           Instances ()
 
 
-assertJQExpressionSucceeds :: Show a => Directive.Directive -> a -> Term (Ann :+: Core) Name -> HUnit.Assertion
+assertJQExpressionSucceeds :: Show a => Directive.Directive -> a -> Term (Ann Span :+: Core) Name -> HUnit.Assertion
 assertJQExpressionSucceeds directive tree core = do
-  bod <- case scopeGraph Eval.eval [File interactive core] of
-    (heap, [File _ (Right result)]) -> pure $ Aeson.object
+  bod <- case scopeGraph Eval.eval [File (Path "<interactive>") (Span (Pos 1 1) (Pos 1 1)) core] of
+    (heap, [File _ _ (Right result)]) -> pure $ Aeson.object
       [ "scope" Aeson..= heap
       , "heap"  Aeson..= result
       ]

--- a/semantic-python/test/Test.hs
+++ b/semantic-python/test/Test.hs
@@ -25,7 +25,6 @@ import           Data.Loc
 import           Data.Maybe
 import           Data.Name
 import           Data.Term
-import           Data.String (fromString)
 import           GHC.Stack
 import qualified Language.Python.Core as Py
 import           Prelude hiding (fail)
@@ -96,7 +95,6 @@ fixtureTestTreeForFile fp = HUnit.testCaseSteps (Path.toString fp) $ \step -> wi
   result <- ByteString.readFile (Path.toString fullPath) >>= TS.parseByteString TSP.tree_sitter_python
   let coreResult = Control.Effect.run
                    . runFail
-                   . runReader (fromString @Py.SourcePath . Path.toString $ fp)
                    . runReader @Py.Bindings mempty
                    . Py.toplevelCompile
                    <$> result


### PR DESCRIPTION
This PR: 

- [x] generalizes `Ann` to arbitrary annotation type;
- [x] annotates core terms with `Span` only;
- [x] 🔥s the `Loc` type; and
- [x] updates the tests accordingly.
