### PR TITLE
Generalize analysis over the name type

### DIFF
--- a/semantic-core/semantic-core.cabal
+++ b/semantic-core/semantic-core.cabal
@@ -42,7 +42,6 @@ library
   exposed-modules:
     Analysis.Analysis
     Analysis.Concrete
-    Analysis.Eval
     Analysis.FlowInsensitive
     Analysis.ImportGraph
     Analysis.ScopeGraph
@@ -53,6 +52,7 @@ library
     Core.Core
     Core.Core.Parser
     Core.Core.Pretty
+    Core.Eval
     Core.File
     Core.Name
   build-depends:

--- a/semantic-core/src/Analysis/Analysis.hs
+++ b/semantic-core/src/Analysis/Analysis.hs
@@ -3,25 +3,24 @@ module Analysis.Analysis
 ( Analysis(..)
 ) where
 
-import Core.Name
 import Data.Text (Text)
 
 -- | A record of functions necessary to perform analysis.
 --
 -- This is intended to be replaced with a selection of algebraic effects providing these interfaces and carriers providing reusable implementations.
-data Analysis term address value m = Analysis
-  { alloc     :: Name -> m address
-  , bind      :: forall a . Name -> address -> m a -> m a
-  , lookupEnv :: Name -> m (Maybe address)
+data Analysis term name address value m = Analysis
+  { alloc     :: name -> m address
+  , bind      :: forall a . name -> address -> m a -> m a
+  , lookupEnv :: name -> m (Maybe address)
   , deref     :: address -> m (Maybe value)
   , assign    :: address -> value -> m ()
-  , abstract  :: (term -> m value) -> Name -> term -> m value
+  , abstract  :: (term -> m value) -> name -> term -> m value
   , apply     :: (term -> m value) -> value -> value -> m value
   , unit      :: m value
   , bool      :: Bool -> m value
   , asBool    :: value -> m Bool
   , string    :: Text -> m value
   , asString  :: value -> m Text
-  , record    :: [(Name, value)] -> m value
-  , (...)     :: address -> Name -> m (Maybe address)
+  , record    :: [(name, value)] -> m value
+  , (...)     :: address -> name -> m (Maybe address)
   }

--- a/semantic-core/src/Analysis/Analysis.hs
+++ b/semantic-core/src/Analysis/Analysis.hs
@@ -14,8 +14,8 @@ data Analysis term name address value m = Analysis
   , lookupEnv :: name -> m (Maybe address)
   , deref     :: address -> m (Maybe value)
   , assign    :: address -> value -> m ()
-  , abstract  :: (term -> m value) -> name -> term -> m value
-  , apply     :: (term -> m value) -> value -> value -> m value
+  , abstract  :: (term name -> m value) -> name -> term name -> m value
+  , apply     :: (term name -> m value) -> value -> value -> m value
   , unit      :: m value
   , bool      :: Bool -> m value
   , asBool    :: value -> m Bool

--- a/semantic-core/src/Analysis/Concrete.hs
+++ b/semantic-core/src/Analysis/Concrete.hs
@@ -235,5 +235,5 @@ data EdgeType term name
 -- $setup
 -- >>> :seti -XFlexibleContexts
 -- >>> :seti -XOverloadedStrings
--- >>> import Analysis.Eval (eval)
+-- >>> import Core.Eval (eval)
 -- >>> import qualified Core.Core as Core

--- a/semantic-core/src/Analysis/Concrete.hs
+++ b/semantic-core/src/Analysis/Concrete.hs
@@ -21,7 +21,6 @@ import           Control.Effect.Reader hiding (Local)
 import           Control.Effect.State
 import           Control.Monad ((<=<), guard)
 import           Core.File
-import           Core.Name
 import           Data.Function (fix)
 import qualified Data.IntMap as IntMap
 import qualified Data.IntSet as IntSet
@@ -71,15 +70,20 @@ data Edge = Lexical | Import
 --   >>> map fileBody (snd (concrete eval [File (Path.AbsRelFile "bool") (Span (Pos 1 1) (Pos 1 5)) (Core.bool True)]))
 --   [Right (Bool True)]
 concrete
-  :: (Foldable term, Show (term Name))
+  :: ( Foldable term
+     , IsString name
+     , Ord name
+     , Show name
+     , Show (term name)
+     )
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
-     => Analysis (term Name) Name Precise (Concrete (term Name) Name) m
-     -> (term Name -> m (Concrete (term Name) Name))
-     -> (term Name -> m (Concrete (term Name) Name))
+     => Analysis (term name) name Precise (Concrete (term name) name) m
+     -> (term name -> m (Concrete (term name) name))
+     -> (term name -> m (Concrete (term name) name))
      )
-  -> [File (term Name)]
-  -> (Heap (term Name) Name, [File (Either (Path.AbsRelFile, Span, String) (Concrete (term Name) Name))])
+  -> [File (term name)]
+  -> (Heap (term name) name, [File (Either (Path.AbsRelFile, Span, String) (Concrete (term name) name))])
 concrete eval
   = run
   . runFresh

--- a/semantic-core/src/Analysis/Concrete.hs
+++ b/semantic-core/src/Analysis/Concrete.hs
@@ -195,7 +195,7 @@ heapValueGraph :: Heap term name -> G.Graph (Concrete term name)
 heapValueGraph h = heapGraph (const id) (const fromAddr) h
   where fromAddr addr = maybe G.empty G.vertex (IntMap.lookup addr h)
 
-heapAddressGraph :: Heap term Name -> G.Graph (EdgeType term Name, Precise)
+heapAddressGraph :: Heap term name -> G.Graph (EdgeType term name, Precise)
 heapAddressGraph = heapGraph (\ addr v -> (Value v, addr)) (fmap G.vertex . (,) . either Edge Slot)
 
 addressStyle :: Heap term Name -> G.Style (EdgeType term Name, Precise) Text

--- a/semantic-core/src/Analysis/Concrete.hs
+++ b/semantic-core/src/Analysis/Concrete.hs
@@ -181,7 +181,7 @@ runHeap = runState mempty
 --   > λ let (heap, res) = concrete [ruby]
 --   > λ writeFile "/Users/rob/Desktop/heap.dot" (export (addressStyle heap) (heapAddressGraph heap))
 --   > λ :!dot -Tsvg < ~/Desktop/heap.dot > ~/Desktop/heap.svg
-heapGraph :: (Precise -> Concrete term Name -> a) -> (Either Edge Name -> Precise -> G.Graph a) -> Heap term Name -> G.Graph a
+heapGraph :: (Precise -> Concrete term name -> a) -> (Either Edge name -> Precise -> G.Graph a) -> Heap term name -> G.Graph a
 heapGraph vertex edge h = foldr (uncurry graph) G.empty (IntMap.toList h)
   where graph k v rest = (G.vertex (vertex k v) `G.connect` outgoing v) `G.overlay` rest
         outgoing = \case

--- a/semantic-core/src/Analysis/Concrete.hs
+++ b/semantic-core/src/Analysis/Concrete.hs
@@ -111,15 +111,18 @@ runFile eval file = traverse run file
 
 concreteAnalysis :: ( Carrier sig m
                     , Foldable term
+                    , IsString name
                     , Member Fresh sig
-                    , Member (Reader (Env Name)) sig
+                    , Member (Reader (Env name)) sig
                     , Member (Reader Path.AbsRelFile) sig
                     , Member (Reader Span) sig
-                    , Member (State (Heap (term Name) Name)) sig
+                    , Member (State (Heap (term name) name)) sig
                     , MonadFail m
-                    , Show (term Name)
+                    , Ord name
+                    , Show name
+                    , Show (term name)
                     )
-                 => Analysis (term Name) Name Precise (Concrete (term Name) Name) m
+                 => Analysis (term name) name Precise (Concrete (term name) name) m
 concreteAnalysis = Analysis{..}
   where alloc _ = fresh
         bind name addr m = local (Map.insert name addr) m

--- a/semantic-core/src/Analysis/Concrete.hs
+++ b/semantic-core/src/Analysis/Concrete.hs
@@ -73,7 +73,7 @@ concrete
   :: (Foldable term, Show (term Name))
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
-     => Analysis (term Name) Precise (Concrete (term Name)) m
+     => Analysis (term Name) Name Precise (Concrete (term Name)) m
      -> (term Name -> m (Concrete (term Name)))
      -> (term Name -> m (Concrete (term Name)))
      )
@@ -95,7 +95,7 @@ runFile
      )
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
-     => Analysis (term Name) Precise (Concrete (term Name)) m
+     => Analysis (term Name) Name Precise (Concrete (term Name)) m
      -> (term Name -> m (Concrete (term Name)))
      -> (term Name -> m (Concrete (term Name)))
      )
@@ -118,7 +118,7 @@ concreteAnalysis :: ( Carrier sig m
                     , MonadFail m
                     , Show (term Name)
                     )
-                 => Analysis (term Name) Precise (Concrete (term Name)) m
+                 => Analysis (term Name) Name Precise (Concrete (term Name)) m
 concreteAnalysis = Analysis{..}
   where alloc _ = fresh
         bind name addr m = local (Map.insert name addr) m

--- a/semantic-core/src/Analysis/Concrete.hs
+++ b/semantic-core/src/Analysis/Concrete.hs
@@ -198,8 +198,8 @@ heapValueGraph h = heapGraph (const id) (const fromAddr) h
 heapAddressGraph :: Heap term name -> G.Graph (EdgeType term name, Precise)
 heapAddressGraph = heapGraph (\ addr v -> (Value v, addr)) (fmap G.vertex . (,) . either Edge Slot)
 
-addressStyle :: Heap term Name -> G.Style (EdgeType term Name, Precise) Text
-addressStyle heap = (G.defaultStyle vertex) { G.edgeAttributes }
+addressStyle :: (name -> Text) -> Heap term name -> G.Style (EdgeType term name, Precise) Text
+addressStyle unName heap = (G.defaultStyle vertex) { G.edgeAttributes }
   where vertex (_, addr) = pack (show addr) <> " = " <> maybe "?" fromConcrete (IntMap.lookup addr heap)
         edgeAttributes _ (Slot name,    _) = ["label" G.:= unName name]
         edgeAttributes _ (Edge Import,  _) = ["color" G.:= "blue"]

--- a/semantic-core/src/Analysis/Concrete.hs
+++ b/semantic-core/src/Analysis/Concrete.hs
@@ -78,7 +78,7 @@ concrete
      )
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
-     => Analysis (term name) name Precise (Concrete term name) m
+     => Analysis term name Precise (Concrete term name) m
      -> (term name -> m (Concrete term name))
      -> (term name -> m (Concrete term name))
      )
@@ -104,7 +104,7 @@ runFile
      )
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
-     => Analysis (term name) name Precise (Concrete term name) m
+     => Analysis term name Precise (Concrete term name) m
      -> (term name -> m (Concrete term name))
      -> (term name -> m (Concrete term name))
      )
@@ -130,7 +130,7 @@ concreteAnalysis :: ( Carrier sig m
                     , Show name
                     , Show (term name)
                     )
-                 => Analysis (term name) name Precise (Concrete term name) m
+                 => Analysis term name Precise (Concrete term name) m
 concreteAnalysis = Analysis{..}
   where alloc _ = fresh
         bind name addr m = local (Map.insert name addr) m

--- a/semantic-core/src/Analysis/Concrete.hs
+++ b/semantic-core/src/Analysis/Concrete.hs
@@ -28,6 +28,7 @@ import qualified Data.IntSet as IntSet
 import qualified Data.Map as Map
 import           Data.Semigroup (Last (..))
 import qualified Data.Set as Set
+import           Data.String (IsString)
 import           Data.Text (Text, pack)
 import           Data.Traversable (for)
 import           Prelude hiding (fail)
@@ -155,7 +156,7 @@ concreteAnalysis = Analysis{..}
           pure (val >>= lookupConcrete heap n)
 
 
-lookupConcrete :: Heap term Name -> Name -> Concrete term Name -> Maybe Precise
+lookupConcrete :: (IsString name, Ord name) => Heap term name -> name -> Concrete term name -> Maybe Precise
 lookupConcrete heap name = run . evalState IntSet.empty . runNonDet . inConcrete
   where -- look up the name in a concrete value
         inConcrete = inFrame <=< maybeA . recordFrame

--- a/semantic-core/src/Analysis/Concrete.hs
+++ b/semantic-core/src/Analysis/Concrete.hs
@@ -195,10 +195,10 @@ heapValueGraph :: Heap term Name -> G.Graph (Concrete term Name)
 heapValueGraph h = heapGraph (const id) (const fromAddr) h
   where fromAddr addr = maybe G.empty G.vertex (IntMap.lookup addr h)
 
-heapAddressGraph :: Heap term Name -> G.Graph (EdgeType term, Precise)
+heapAddressGraph :: Heap term Name -> G.Graph (EdgeType term Name, Precise)
 heapAddressGraph = heapGraph (\ addr v -> (Value v, addr)) (fmap G.vertex . (,) . either Edge Slot)
 
-addressStyle :: Heap term Name -> G.Style (EdgeType term, Precise) Text
+addressStyle :: Heap term Name -> G.Style (EdgeType term Name, Precise) Text
 addressStyle heap = (G.defaultStyle vertex) { G.edgeAttributes }
   where vertex (_, addr) = pack (show addr) <> " = " <> maybe "?" fromConcrete (IntMap.lookup addr heap)
         edgeAttributes _ (Slot name,    _) = ["label" G.:= unName name]
@@ -213,10 +213,10 @@ addressStyle heap = (G.defaultStyle vertex) { G.edgeAttributes }
           Record _ -> "{}"
         showPos (Pos l c) = pack (show l) <> ":" <> pack (show c)
 
-data EdgeType term
+data EdgeType term name
   = Edge Edge
-  | Slot Name
-  | Value (Concrete term Name)
+  | Slot name
+  | Value (Concrete term name)
   deriving (Eq, Ord, Show)
 
 

--- a/semantic-core/src/Analysis/Concrete.hs
+++ b/semantic-core/src/Analysis/Concrete.hs
@@ -191,7 +191,7 @@ heapGraph vertex edge h = foldr (uncurry graph) G.empty (IntMap.toList h)
           Closure _ _ _ _ env -> foldr (G.overlay . edge (Left Lexical)) G.empty env
           Record frame -> Map.foldrWithKey (\ k -> G.overlay . edge (Right k)) G.empty frame
 
-heapValueGraph :: Heap term Name -> G.Graph (Concrete term Name)
+heapValueGraph :: Heap term name -> G.Graph (Concrete term name)
 heapValueGraph h = heapGraph (const id) (const fromAddr) h
   where fromAddr addr = maybe G.empty G.vertex (IntMap.lookup addr h)
 

--- a/semantic-core/src/Analysis/ImportGraph.hs
+++ b/semantic-core/src/Analysis/ImportGraph.hs
@@ -41,7 +41,7 @@ instance Monoid (Value term name) where
   mempty = Value Abstract mempty
 
 data Semi term name
-  = Closure Path.AbsRelFile Span name term
+  = Closure Path.AbsRelFile Span name (term name)
   -- FIXME: Bound String values.
   | String Text
   | Abstract
@@ -49,14 +49,14 @@ data Semi term name
 
 
 importGraph
-  :: (Ord name, Ord term, Show name, Show term)
+  :: (Ord name, Ord (term name), Show name, Show (term name))
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
-     => Analysis term name name (Value term name) m
-     -> (term -> m (Value term name))
-     -> (term -> m (Value term name))
+     => Analysis (term name) name name (Value term name) m
+     -> (term name -> m (Value term name))
+     -> (term name -> m (Value term name))
      )
-  -> [File term]
+  -> [File (term name)]
   -> ( Heap name (Value term name)
      , [File (Either (Path.AbsRelFile, Span, String) (Value term name))]
      )
@@ -73,17 +73,17 @@ runFile
      , Member Fresh sig
      , Member (State (Heap name (Value term name))) sig
      , Ord  name
-     , Ord  term
+     , Ord  (term name)
      , Show name
-     , Show term
+     , Show (term name)
      )
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
-     => Analysis term name name (Value term name) m
-     -> (term -> m (Value term name))
-     -> (term -> m (Value term name))
+     => Analysis (term name) name name (Value term name) m
+     -> (term name -> m (Value term name))
+     -> (term name -> m (Value term name))
      )
-  -> File term
+  -> File (term name)
   -> m (File (Either (Path.AbsRelFile, Span, String) (Value term name)))
 runFile eval file = traverse run file
   where run = runReader (filePath file)
@@ -100,11 +100,11 @@ importGraphAnalysis :: ( Alternative m
                        , Member (State (Heap name (Value term name))) sig
                        , MonadFail m
                        , Ord  name
-                       , Ord  term
+                       , Ord  (term name)
                        , Show name
-                       , Show term
+                       , Show (term name)
                        )
-                    => Analysis term name name (Value term name) m
+                    => Analysis (term name) name name (Value term name) m
 importGraphAnalysis = Analysis{..}
   where alloc = pure
         bind _ _ m = m

--- a/semantic-core/src/Analysis/ImportGraph.hs
+++ b/semantic-core/src/Analysis/ImportGraph.hs
@@ -15,7 +15,6 @@ import           Control.Effect.Reader
 import           Control.Effect.State
 import           Control.Monad ((>=>))
 import           Core.File
-import           Core.Name
 import           Data.Foldable (fold, for_)
 import           Data.Function (fix)
 import           Data.List.NonEmpty (nonEmpty)
@@ -50,16 +49,16 @@ data Semi term name
 
 
 importGraph
-  :: (Ord term, Show term)
+  :: (Ord name, Ord term, Show name, Show term)
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
-     => Analysis term Name Name (Value term Name) m
-     -> (term -> m (Value term Name))
-     -> (term -> m (Value term Name))
+     => Analysis term name name (Value term name) m
+     -> (term -> m (Value term name))
+     -> (term -> m (Value term name))
      )
   -> [File term]
-  -> ( Heap Name (Value term Name)
-     , [File (Either (Path.AbsRelFile, Span, String) (Value term Name))]
+  -> ( Heap name (Value term name)
+     , [File (Either (Path.AbsRelFile, Span, String) (Value term name))]
      )
 importGraph eval
   = run

--- a/semantic-core/src/Analysis/ImportGraph.hs
+++ b/semantic-core/src/Analysis/ImportGraph.hs
@@ -29,16 +29,16 @@ import qualified System.Path as Path
 
 type ImportGraph = Map.Map Text (Set.Set Text)
 
-data Value term = Value
-  { valueSemi  :: Semi term Name
+data Value term name = Value
+  { valueSemi  :: Semi term name
   , valueGraph :: ImportGraph
   }
   deriving (Eq, Ord, Show)
 
-instance Semigroup (Value term) where
+instance Semigroup (Value term name) where
   Value _ g1 <> Value _ g2 = Value Abstract (Map.unionWith (<>) g1 g2)
 
-instance Monoid (Value term) where
+instance Monoid (Value term name) where
   mempty = Value Abstract mempty
 
 data Semi term name
@@ -53,13 +53,13 @@ importGraph
   :: (Ord term, Show term)
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
-     => Analysis term Name Name (Value term) m
-     -> (term -> m (Value term))
-     -> (term -> m (Value term))
+     => Analysis term Name Name (Value term Name) m
+     -> (term -> m (Value term Name))
+     -> (term -> m (Value term Name))
      )
   -> [File term]
-  -> ( Heap Name (Value term)
-     , [File (Either (Path.AbsRelFile, Span, String) (Value term))]
+  -> ( Heap Name (Value term Name)
+     , [File (Either (Path.AbsRelFile, Span, String) (Value term Name))]
      )
 importGraph eval
   = run
@@ -71,18 +71,18 @@ runFile
   :: ( Carrier sig m
      , Effect sig
      , Member Fresh sig
-     , Member (State (Heap Name (Value term))) sig
+     , Member (State (Heap Name (Value term Name))) sig
      , Ord  term
      , Show term
      )
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
-     => Analysis term Name Name (Value term) m
-     -> (term -> m (Value term))
-     -> (term -> m (Value term))
+     => Analysis term Name Name (Value term Name) m
+     -> (term -> m (Value term Name))
+     -> (term -> m (Value term Name))
      )
   -> File term
-  -> m (File (Either (Path.AbsRelFile, Span, String) (Value term)))
+  -> m (File (Either (Path.AbsRelFile, Span, String) (Value term Name)))
 runFile eval file = traverse run file
   where run = runReader (filePath file)
             . runReader (fileSpan file)
@@ -95,12 +95,12 @@ importGraphAnalysis :: ( Alternative m
                        , Carrier sig m
                        , Member (Reader Path.AbsRelFile) sig
                        , Member (Reader Span) sig
-                       , Member (State (Heap Name (Value term))) sig
+                       , Member (State (Heap Name (Value term Name))) sig
                        , MonadFail m
                        , Ord  term
                        , Show term
                        )
-                    => Analysis term Name Name (Value term) m
+                    => Analysis term Name Name (Value term Name) m
 importGraphAnalysis = Analysis{..}
   where alloc = pure
         bind _ _ m = m

--- a/semantic-core/src/Analysis/ImportGraph.hs
+++ b/semantic-core/src/Analysis/ImportGraph.hs
@@ -95,12 +95,14 @@ importGraphAnalysis :: ( Alternative m
                        , Carrier sig m
                        , Member (Reader Path.AbsRelFile) sig
                        , Member (Reader Span) sig
-                       , Member (State (Heap Name (Value term Name))) sig
+                       , Member (State (Heap name (Value term name))) sig
                        , MonadFail m
+                       , Ord  name
                        , Ord  term
+                       , Show name
                        , Show term
                        )
-                    => Analysis term Name Name (Value term Name) m
+                    => Analysis term name name (Value term name) m
 importGraphAnalysis = Analysis{..}
   where alloc = pure
         bind _ _ m = m

--- a/semantic-core/src/Analysis/ImportGraph.hs
+++ b/semantic-core/src/Analysis/ImportGraph.hs
@@ -30,7 +30,7 @@ import qualified System.Path as Path
 type ImportGraph = Map.Map Text (Set.Set Text)
 
 data Value term = Value
-  { valueSemi  :: Semi term
+  { valueSemi  :: Semi term Name
   , valueGraph :: ImportGraph
   }
   deriving (Eq, Ord, Show)
@@ -41,8 +41,8 @@ instance Semigroup (Value term) where
 instance Monoid (Value term) where
   mempty = Value Abstract mempty
 
-data Semi term
-  = Closure Path.AbsRelFile Span Name term
+data Semi term name
+  = Closure Path.AbsRelFile Span name term
   -- FIXME: Bound String values.
   | String Text
   | Abstract

--- a/semantic-core/src/Analysis/ImportGraph.hs
+++ b/semantic-core/src/Analysis/ImportGraph.hs
@@ -53,7 +53,7 @@ importGraph
   :: (Ord term, Show term)
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
-     => Analysis term Name (Value term) m
+     => Analysis term Name Name (Value term) m
      -> (term -> m (Value term))
      -> (term -> m (Value term))
      )
@@ -77,7 +77,7 @@ runFile
      )
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
-     => Analysis term Name (Value term) m
+     => Analysis term Name Name (Value term) m
      -> (term -> m (Value term))
      -> (term -> m (Value term))
      )
@@ -100,7 +100,7 @@ importGraphAnalysis :: ( Alternative m
                        , Ord  term
                        , Show term
                        )
-                    => Analysis term Name (Value term) m
+                    => Analysis term Name Name (Value term) m
 importGraphAnalysis = Analysis{..}
   where alloc = pure
         bind _ _ m = m

--- a/semantic-core/src/Analysis/ImportGraph.hs
+++ b/semantic-core/src/Analysis/ImportGraph.hs
@@ -52,7 +52,7 @@ importGraph
   :: (Ord name, Ord (term name), Show name, Show (term name))
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
-     => Analysis (term name) name name (Value term name) m
+     => Analysis term name name (Value term name) m
      -> (term name -> m (Value term name))
      -> (term name -> m (Value term name))
      )
@@ -79,7 +79,7 @@ runFile
      )
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
-     => Analysis (term name) name name (Value term name) m
+     => Analysis term name name (Value term name) m
      -> (term name -> m (Value term name))
      -> (term name -> m (Value term name))
      )
@@ -104,7 +104,7 @@ importGraphAnalysis :: ( Alternative m
                        , Show name
                        , Show (term name)
                        )
-                    => Analysis (term name) name name (Value term name) m
+                    => Analysis term name name (Value term name) m
 importGraphAnalysis = Analysis{..}
   where alloc = pure
         bind _ _ m = m

--- a/semantic-core/src/Analysis/ScopeGraph.hs
+++ b/semantic-core/src/Analysis/ScopeGraph.hs
@@ -117,7 +117,7 @@ scopeGraphAnalysis = Analysis{..}
           modify (Map.insertWith (<>) addr (Set.singleton (extendBinding addr ref bindRef <> v)))
         abstract eval name body = do
           addr <- alloc name
-          assign name (mempty @ScopeGraph)
+          assign name mempty
           bind name addr (eval body)
         apply _ f a = pure (f <> a)
         unit = pure mempty

--- a/semantic-core/src/Analysis/ScopeGraph.hs
+++ b/semantic-core/src/Analysis/ScopeGraph.hs
@@ -55,7 +55,7 @@ scopeGraph
   :: Ord term
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
-     => Analysis term Name ScopeGraph m
+     => Analysis term Name Name ScopeGraph m
      -> (term -> m ScopeGraph)
      -> (term -> m ScopeGraph)
      )
@@ -76,7 +76,7 @@ runFile
      )
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
-     => Analysis term Name ScopeGraph m
+     => Analysis term Name Name ScopeGraph m
      -> (term -> m ScopeGraph)
      -> (term -> m ScopeGraph)
      )
@@ -98,7 +98,7 @@ scopeGraphAnalysis
      , Member (Reader (Map.Map Name Ref)) sig
      , Member (State (Heap Name ScopeGraph)) sig
      )
-  => Analysis term Name ScopeGraph m
+  => Analysis term Name Name ScopeGraph m
 scopeGraphAnalysis = Analysis{..}
   where alloc = pure
         bind name _ m = do

--- a/semantic-core/src/Analysis/ScopeGraph.hs
+++ b/semantic-core/src/Analysis/ScopeGraph.hs
@@ -29,8 +29,8 @@ import           Prelude hiding (fail)
 import           Source.Span
 import qualified System.Path as Path
 
-data Decl = Decl
-  { declSymbol :: Name
+data Decl name = Decl
+  { declSymbol :: name
   , declPath   :: Path.AbsRelFile
   , declSpan   :: Span
   }
@@ -42,7 +42,7 @@ data Ref = Ref
   }
   deriving (Eq, Ord, Show)
 
-newtype ScopeGraph = ScopeGraph { unScopeGraph :: Map.Map Decl (Set.Set Ref) }
+newtype ScopeGraph = ScopeGraph { unScopeGraph :: Map.Map (Decl Name) (Set.Set Ref) }
   deriving (Eq, Ord, Show)
 
 instance Semigroup ScopeGraph where

--- a/semantic-core/src/Analysis/ScopeGraph.hs
+++ b/semantic-core/src/Analysis/ScopeGraph.hs
@@ -17,7 +17,6 @@ import           Control.Effect.Reader
 import           Control.Effect.State
 import           Control.Monad ((>=>))
 import           Core.File
-import           Core.Name
 import           Data.Foldable (fold)
 import           Data.Function (fix)
 import           Data.List.NonEmpty
@@ -52,15 +51,15 @@ instance Ord name => Monoid (ScopeGraph name) where
   mempty = ScopeGraph Map.empty
 
 scopeGraph
-  :: Ord (term Name)
+  :: (Ord name, Ord (term name))
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
-     => Analysis term Name Name (ScopeGraph Name) m
-     -> (term Name -> m (ScopeGraph Name))
-     -> (term Name -> m (ScopeGraph Name))
+     => Analysis term name name (ScopeGraph name) m
+     -> (term name -> m (ScopeGraph name))
+     -> (term name -> m (ScopeGraph name))
      )
-  -> [File (term Name)]
-  -> (Heap Name (ScopeGraph Name), [File (Either (Path.AbsRelFile, Span, String) (ScopeGraph Name))])
+  -> [File (term name)]
+  -> (Heap name (ScopeGraph name), [File (Either (Path.AbsRelFile, Span, String) (ScopeGraph name))])
 scopeGraph eval
   = run
   . runFresh

--- a/semantic-core/src/Analysis/ScopeGraph.hs
+++ b/semantic-core/src/Analysis/ScopeGraph.hs
@@ -52,14 +52,14 @@ instance Monoid ScopeGraph where
   mempty = ScopeGraph Map.empty
 
 scopeGraph
-  :: Ord term
+  :: Ord (term Name)
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
      => Analysis term Name Name ScopeGraph m
-     -> (term -> m ScopeGraph)
-     -> (term -> m ScopeGraph)
+     -> (term Name -> m ScopeGraph)
+     -> (term Name -> m ScopeGraph)
      )
-  -> [File term]
+  -> [File (term Name)]
   -> (Heap Name ScopeGraph, [File (Either (Path.AbsRelFile, Span, String) ScopeGraph)])
 scopeGraph eval
   = run
@@ -72,15 +72,15 @@ runFile
      , Effect sig
      , Member Fresh sig
      , Member (State (Heap Name ScopeGraph)) sig
-     , Ord term
+     , Ord (term Name)
      )
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
      => Analysis term Name Name ScopeGraph m
-     -> (term -> m ScopeGraph)
-     -> (term -> m ScopeGraph)
+     -> (term Name -> m ScopeGraph)
+     -> (term Name -> m ScopeGraph)
      )
-  -> File term
+  -> File (term Name)
   -> m (File (Either (Path.AbsRelFile, Span, String) ScopeGraph))
 runFile eval file = traverse run file
   where run = runReader (filePath file)

--- a/semantic-core/src/Analysis/ScopeGraph.hs
+++ b/semantic-core/src/Analysis/ScopeGraph.hs
@@ -95,10 +95,11 @@ scopeGraphAnalysis
      , Carrier sig m
      , Member (Reader Path.AbsRelFile) sig
      , Member (Reader Span) sig
-     , Member (Reader (Map.Map Name Ref)) sig
-     , Member (State (Heap Name (ScopeGraph Name))) sig
+     , Member (Reader (Map.Map name Ref)) sig
+     , Member (State (Heap name (ScopeGraph name))) sig
+     , Ord name
      )
-  => Analysis term Name Name (ScopeGraph Name) m
+  => Analysis term name name (ScopeGraph name) m
 scopeGraphAnalysis = Analysis{..}
   where alloc = pure
         bind name _ m = do

--- a/semantic-core/src/Analysis/Typecheck.hs
+++ b/semantic-core/src/Analysis/Typecheck.hs
@@ -133,7 +133,7 @@ runFile eval file = traverse run file
               (subst, t) <- m
               modify @(Heap Name (Type Name)) (fmap (Set.map (substAll subst)))
               pure (substAll subst <$> t))
-          . runState (mempty :: Substitution)
+          . runState (mempty :: (Substitution Name))
           . runReader (filePath file)
           . runReader (fileSpan file)
           . runFail
@@ -207,9 +207,9 @@ unify t1 t2
   | t1 == t2  = pure ()
   | otherwise = modify (<> Set.singleton (t1 :===: t2))
 
-type Substitution = IntMap.IntMap (Type Name)
+type Substitution name = IntMap.IntMap (Type name)
 
-solve :: (Carrier sig m, Member (State Substitution) sig, MonadFail m) => Set.Set Constraint -> m ()
+solve :: (Carrier sig m, Member (State (Substitution Name)) sig, MonadFail m) => Set.Set Constraint -> m ()
 solve cs = for_ cs solve
   where solve = \case
           -- FIXME: how do we enforce proper subtyping? row polymorphism or something?

--- a/semantic-core/src/Analysis/Typecheck.hs
+++ b/semantic-core/src/Analysis/Typecheck.hs
@@ -17,7 +17,6 @@ import           Control.Effect.Reader hiding (Local)
 import           Control.Effect.State
 import           Control.Monad ((>=>), unless)
 import           Core.File
-import           Core.Name as Name
 import           Data.Foldable (for_)
 import           Data.Function (fix)
 import           Data.Functor (($>))
@@ -94,16 +93,16 @@ generalize ty = fromJust (closed (forAlls (IntSet.toList (mvs ty)) (hoistTerm R 
 
 
 typecheckingFlowInsensitive
-  :: Ord (term Name)
+  :: (Ord name, Ord (term name), Show name)
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
-     => Analysis term Name Name (Type Name) m
-     -> (term Name -> m (Type Name))
-     -> (term Name -> m (Type Name))
+     => Analysis term name name (Type name) m
+     -> (term name -> m (Type name))
+     -> (term name -> m (Type name))
      )
-  -> [File (term Name)]
-  -> ( Heap Name (Type Name)
-     , [File (Either (Path.AbsRelFile, Span, String) (Term (Polytype :+: Monotype Name) Void))]
+  -> [File (term name)]
+  -> ( Heap name (Type name)
+     , [File (Either (Path.AbsRelFile, Span, String) (Term (Polytype :+: Monotype name) Void))]
      )
 typecheckingFlowInsensitive eval
   = run

--- a/semantic-core/src/Analysis/Typecheck.hs
+++ b/semantic-core/src/Analysis/Typecheck.hs
@@ -139,7 +139,7 @@ runFile eval file = traverse run file
           . runFail
           . (\ m -> do
             (cs, t) <- m
-            t <$ solve cs)
+            t <$ solve @Name cs)
           . runState (Set.empty :: Set.Set (Constraint name))
           . (\ m -> do
               v <- meta
@@ -209,7 +209,7 @@ unify t1 t2
 
 type Substitution name = IntMap.IntMap (Type name)
 
-solve :: (Carrier sig m, Member (State (Substitution Name)) sig, MonadFail m) => Set.Set (Constraint Name) -> m ()
+solve :: (Member (State (Substitution name)) sig, MonadFail m, Ord name, Show name, Carrier sig m) => Set.Set (Constraint name) -> m ()
 solve cs = for_ cs solve
   where solve = \case
           -- FIXME: how do we enforce proper subtyping? row polymorphism or something?

--- a/semantic-core/src/Analysis/Typecheck.hs
+++ b/semantic-core/src/Analysis/Typecheck.hs
@@ -94,14 +94,14 @@ generalize ty = fromJust (closed (forAlls (IntSet.toList (mvs ty)) (hoistTerm R 
 
 
 typecheckingFlowInsensitive
-  :: Ord term
+  :: Ord (term Name)
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
      => Analysis term Name Name Type m
-     -> (term -> m Type)
-     -> (term -> m Type)
+     -> (term Name -> m Type)
+     -> (term Name -> m Type)
      )
-  -> [File term]
+  -> [File (term Name)]
   -> ( Heap Name Type
      , [File (Either (Path.AbsRelFile, Span, String) (Term (Polytype :+: Monotype) Void))]
      )
@@ -117,15 +117,15 @@ runFile
      , Effect sig
      , Member Fresh sig
      , Member (State (Heap Name Type)) sig
-     , Ord term
+     , Ord (term Name)
      )
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
      => Analysis term Name Name Type m
-     -> (term -> m Type)
-     -> (term -> m Type)
+     -> (term Name -> m Type)
+     -> (term Name -> m Type)
      )
-  -> File term
+  -> File (term Name)
   -> m (File (Either (Path.AbsRelFile, Span, String) Type))
 runFile eval file = traverse run file
   where run

--- a/semantic-core/src/Analysis/Typecheck.hs
+++ b/semantic-core/src/Analysis/Typecheck.hs
@@ -188,13 +188,13 @@ typecheckingAnalysis = Analysis{..}
         _ ... m = pure (Just m)
 
 
-data Constraint = Term Monotype Meta :===: Term Monotype Meta
+data Constraint = Type :===: Type
   deriving (Eq, Ord, Show)
 
 infix 4 :===:
 
 data Solution
-  = Int := Term Monotype Meta
+  = Int := Type
   deriving (Eq, Ord, Show)
 
 infix 5 :=
@@ -202,7 +202,7 @@ infix 5 :=
 meta :: (Carrier sig m, Member Fresh sig) => m Type
 meta = pure <$> Fresh.fresh
 
-unify :: (Carrier sig m, Member (State (Set.Set Constraint)) sig) => Term Monotype Meta -> Term Monotype Meta -> m ()
+unify :: (Carrier sig m, Member (State (Set.Set Constraint)) sig) => Type -> Type -> m ()
 unify t1 t2
   | t1 == t2  = pure ()
   | otherwise = modify (<> Set.singleton (t1 :===: t2))

--- a/semantic-core/src/Analysis/Typecheck.hs
+++ b/semantic-core/src/Analysis/Typecheck.hs
@@ -202,7 +202,7 @@ infix 5 :=
 meta :: (Carrier sig m, Member Fresh sig) => m (Type name)
 meta = pure <$> Fresh.fresh
 
-unify :: (Carrier sig m, Member (State (Set.Set (Constraint Name))) sig) => Type Name -> Type Name -> m ()
+unify :: (Carrier sig m, Member (State (Set.Set (Constraint name))) sig, Ord name) => Type name -> Type name -> m ()
 unify t1 t2
   | t1 == t2  = pure ()
   | otherwise = modify (<> Set.singleton (t1 :===: t2))

--- a/semantic-core/src/Analysis/Typecheck.hs
+++ b/semantic-core/src/Analysis/Typecheck.hs
@@ -193,8 +193,8 @@ data Constraint name = Type name :===: Type name
 
 infix 4 :===:
 
-data Solution
-  = Int := Type Name
+data Solution name
+  = Int := Type name
   deriving (Eq, Ord, Show)
 
 infix 5 :=

--- a/semantic-core/src/Analysis/Typecheck.hs
+++ b/semantic-core/src/Analysis/Typecheck.hs
@@ -151,10 +151,11 @@ typecheckingAnalysis
   :: ( Alternative m
      , Carrier sig m
      , Member Fresh sig
-     , Member (State (Set.Set (Constraint Name))) sig
-     , Member (State (Heap Name (Type Name))) sig
+     , Member (State (Set.Set (Constraint name))) sig
+     , Member (State (Heap name (Type name))) sig
+     , Ord name
      )
-  => Analysis term Name Name (Type Name) m
+  => Analysis term name name (Type name) m
 typecheckingAnalysis = Analysis{..}
   where alloc = pure
         bind _ _ m = m

--- a/semantic-core/src/Analysis/Typecheck.hs
+++ b/semantic-core/src/Analysis/Typecheck.hs
@@ -97,7 +97,7 @@ typecheckingFlowInsensitive
   :: Ord term
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
-     => Analysis term Name Type m
+     => Analysis term Name Name Type m
      -> (term -> m Type)
      -> (term -> m Type)
      )
@@ -121,7 +121,7 @@ runFile
      )
   => (forall sig m
      .  (Carrier sig m, Member (Reader Path.AbsRelFile) sig, Member (Reader Span) sig, MonadFail m)
-     => Analysis term Name Type m
+     => Analysis term Name Name Type m
      -> (term -> m Type)
      -> (term -> m Type)
      )
@@ -154,7 +154,7 @@ typecheckingAnalysis
      , Member (State (Set.Set Constraint)) sig
      , Member (State (Heap Name Type)) sig
      )
-  => Analysis term Name Type m
+  => Analysis term Name Name Type m
 typecheckingAnalysis = Analysis{..}
   where alloc = pure
         bind _ _ m = m

--- a/semantic-core/src/Analysis/Typecheck.hs
+++ b/semantic-core/src/Analysis/Typecheck.hs
@@ -199,7 +199,7 @@ data Solution
 
 infix 5 :=
 
-meta :: (Carrier sig m, Member Fresh sig) => m (Type Name)
+meta :: (Carrier sig m, Member Fresh sig) => m (Type name)
 meta = pure <$> Fresh.fresh
 
 unify :: (Carrier sig m, Member (State (Set.Set (Constraint Name))) sig) => Type Name -> Type Name -> m ()

--- a/semantic-core/src/Core/Eval.hs
+++ b/semantic-core/src/Core/Eval.hs
@@ -33,7 +33,7 @@ eval :: ( Carrier sig m
         , MonadFail m
         , Semigroup value
         )
-     => Analysis (Term (Ann Span :+: Core) Name) Name address value m
+     => Analysis (Term (Ann Span :+: Core)) Name address value m
      -> (Term (Ann Span :+: Core) Name -> m value)
      -> (Term (Ann Span :+: Core) Name -> m value)
 eval Analysis{..} eval = \case

--- a/semantic-core/src/Core/Eval.hs
+++ b/semantic-core/src/Core/Eval.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE FlexibleContexts, LambdaCase, OverloadedStrings, RankNTypes, RecordWildCards, TypeOperators #-}
-module Analysis.Eval
+module Core.Eval
 ( eval
 , prog1
 , prog2

--- a/semantic-core/src/Core/Eval.hs
+++ b/semantic-core/src/Core/Eval.hs
@@ -33,7 +33,7 @@ eval :: ( Carrier sig m
         , MonadFail m
         , Semigroup value
         )
-     => Analysis (Term (Ann Span :+: Core) Name) address value m
+     => Analysis (Term (Ann Span :+: Core) Name) Name address value m
      -> (Term (Ann Span :+: Core) Name -> m value)
      -> (Term (Ann Span :+: Core) Name -> m value)
 eval Analysis{..} eval = \case

--- a/semantic-core/test/Test.hs
+++ b/semantic-core/test/Test.hs
@@ -8,10 +8,10 @@ import           Test.Tasty
 import           Test.Tasty.Hedgehog
 import           Test.Tasty.HUnit
 
-import qualified Analysis.Eval as Eval
 import           Core.Core
 import           Core.Core.Pretty
 import           Core.Core.Parser as Parse
+import qualified Core.Eval as Eval
 import           Core.File
 import           Core.Name
 import qualified Generators as Gen

--- a/semantic-python/test/Instances.hs
+++ b/semantic-python/test/Instances.hs
@@ -35,7 +35,7 @@ instance ToJSON Ref where
     , "span" .= span
     ]
 
-instance ToJSON Decl where
+instance ToJSON (Decl Name) where
   toJSON Decl{declSymbol, declPath, declSpan} = object
     [ "kind"   .= ("decl" :: Text)
     , "symbol" .= declSymbol
@@ -43,5 +43,5 @@ instance ToJSON Decl where
     , "span" .= declSpan
     ]
 
-instance ToJSON ScopeGraph where
+instance ToJSON (ScopeGraph Name) where
   toJSON (ScopeGraph sc) = toJSON . Map.mapKeys declSymbol $ sc

--- a/semantic-python/test/Test.hs
+++ b/semantic-python/test/Test.hs
@@ -2,7 +2,6 @@
 
 module Main (main) where
 
-import qualified Analysis.Eval as Eval
 import           Analysis.ScopeGraph
 import           Control.Effect
 import           Control.Effect.Fail
@@ -13,6 +12,7 @@ import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Resource (ResourceT, runResourceT)
 import           Core.Core
 import           Core.Core.Pretty
+import qualified Core.Eval as Eval
 import           Core.File
 import           Core.Name
 import qualified Data.Aeson as Aeson


### PR DESCRIPTION
This PR generalizes a bunch of things to eliminate the dependencies of the `Analysis.*` modules on `Core.Name`.

- [x] Renames `Analysis.Eval` to `Core.Eval`.
- [x] Generalizes `Analysis.Analysis`, `.Typecheck`, `.ScopeGraph`, `.ImportGraph`, and `.Concrete` over the name type.
- [x] Generalizes the `term` type parameter of `Analysis`, `Semi`, and `Concrete` to `* -> *`.
- [x] Depends on #327.
- [x] Depends on #329.