### PR TITLE
Rename Core.File to Analysis.File

### DIFF
--- a/semantic-core/semantic-core.cabal
+++ b/semantic-core/semantic-core.cabal
@@ -42,6 +42,7 @@ library
   exposed-modules:
     Analysis.Analysis
     Analysis.Concrete
+    Analysis.File
     Analysis.FlowInsensitive
     Analysis.ImportGraph
     Analysis.ScopeGraph
@@ -53,7 +54,6 @@ library
     Core.Core.Parser
     Core.Core.Pretty
     Core.Eval
-    Core.File
     Core.Name
   build-depends:
       algebraic-graphs            ^>= 0.3

--- a/semantic-core/src/Analysis/Concrete.hs
+++ b/semantic-core/src/Analysis/Concrete.hs
@@ -12,6 +12,7 @@ module Analysis.Concrete
 import qualified Algebra.Graph as G
 import qualified Algebra.Graph.Export.Dot as G
 import           Analysis.Analysis
+import           Analysis.File
 import           Control.Applicative (Alternative (..))
 import           Control.Carrier.Fail.WithLoc
 import           Control.Effect
@@ -20,7 +21,6 @@ import           Control.Effect.NonDet
 import           Control.Effect.Reader hiding (Local)
 import           Control.Effect.State
 import           Control.Monad ((<=<), guard)
-import           Core.File
 import           Data.Function (fix)
 import qualified Data.IntMap as IntMap
 import qualified Data.IntSet as IntSet

--- a/semantic-core/src/Analysis/File.hs
+++ b/semantic-core/src/Analysis/File.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DeriveTraversable #-}
-module Core.File
+module Analysis.File
 ( File(..)
 , fromBody
 ) where

--- a/semantic-core/src/Analysis/ImportGraph.hs
+++ b/semantic-core/src/Analysis/ImportGraph.hs
@@ -6,6 +6,7 @@ module Analysis.ImportGraph
 ) where
 
 import           Analysis.Analysis
+import           Analysis.File
 import           Analysis.FlowInsensitive
 import           Control.Applicative (Alternative(..))
 import           Control.Carrier.Fail.WithLoc
@@ -14,7 +15,6 @@ import           Control.Effect.Fresh
 import           Control.Effect.Reader
 import           Control.Effect.State
 import           Control.Monad ((>=>))
-import           Core.File
 import           Data.Foldable (fold, for_)
 import           Data.Function (fix)
 import           Data.List.NonEmpty (nonEmpty)

--- a/semantic-core/src/Analysis/ScopeGraph.hs
+++ b/semantic-core/src/Analysis/ScopeGraph.hs
@@ -8,6 +8,7 @@ module Analysis.ScopeGraph
 ) where
 
 import           Analysis.Analysis
+import           Analysis.File
 import           Analysis.FlowInsensitive
 import           Control.Applicative (Alternative (..))
 import           Control.Carrier.Fail.WithLoc
@@ -16,7 +17,6 @@ import           Control.Effect.Fresh
 import           Control.Effect.Reader
 import           Control.Effect.State
 import           Control.Monad ((>=>))
-import           Core.File
 import           Data.Foldable (fold)
 import           Data.Function (fix)
 import           Data.List.NonEmpty

--- a/semantic-core/src/Analysis/Typecheck.hs
+++ b/semantic-core/src/Analysis/Typecheck.hs
@@ -8,6 +8,7 @@ module Analysis.Typecheck
 ) where
 
 import           Analysis.Analysis
+import           Analysis.File
 import           Analysis.FlowInsensitive
 import           Control.Applicative (Alternative (..))
 import           Control.Carrier.Fail.WithLoc
@@ -16,7 +17,6 @@ import           Control.Effect.Fresh as Fresh
 import           Control.Effect.Reader hiding (Local)
 import           Control.Effect.State
 import           Control.Monad ((>=>), unless)
-import           Core.File
 import           Data.Foldable (for_)
 import           Data.Function (fix)
 import           Data.Functor (($>))

--- a/semantic-core/src/Core/Core/Pretty.hs
+++ b/semantic-core/src/Core/Core/Pretty.hs
@@ -8,8 +8,8 @@ module Core.Core.Pretty
   , prettyCore
   ) where
 
+import           Analysis.File
 import           Core.Core
-import           Core.File
 import           Core.Name
 import           Data.Foldable (toList)
 import           Data.Text.Prettyprint.Doc

--- a/semantic-core/src/Core/Eval.hs
+++ b/semantic-core/src/Core/Eval.hs
@@ -11,13 +11,13 @@ module Core.Eval
 ) where
 
 import Analysis.Analysis
+import Analysis.File
 import Control.Applicative (Alternative (..))
 import Control.Effect.Carrier
 import Control.Effect.Fail
 import Control.Effect.Reader
 import Control.Monad ((>=>))
 import Core.Core as Core
-import Core.File
 import Core.Name
 import Data.Functor
 import Data.Maybe (fromMaybe)

--- a/semantic-core/test/Test.hs
+++ b/semantic-core/test/Test.hs
@@ -8,11 +8,11 @@ import           Test.Tasty
 import           Test.Tasty.Hedgehog
 import           Test.Tasty.HUnit
 
+import           Analysis.File
 import           Core.Core
 import           Core.Core.Pretty
 import           Core.Core.Parser as Parse
 import qualified Core.Eval as Eval
-import           Core.File
 import           Core.Name
 import qualified Generators as Gen
 import           Source.Span

--- a/semantic-python/test/Instances.hs
+++ b/semantic-python/test/Instances.hs
@@ -7,8 +7,8 @@ module Instances () where
 -- expose in semantic-core proper, yet are important enough that
 -- we should keep track of them in a dedicated file.
 
+import           Analysis.File
 import           Analysis.ScopeGraph
-import           Core.File
 import           Core.Name (Name (..))
 import           Data.Aeson
 import qualified Data.Map as Map

--- a/semantic-python/test/Test.hs
+++ b/semantic-python/test/Test.hs
@@ -2,6 +2,7 @@
 
 module Main (main) where
 
+import           Analysis.File
 import           Analysis.ScopeGraph
 import           Control.Effect
 import           Control.Effect.Fail
@@ -13,7 +14,6 @@ import           Control.Monad.Trans.Resource (ResourceT, runResourceT)
 import           Core.Core
 import           Core.Core.Pretty
 import qualified Core.Eval as Eval
-import           Core.File
 import           Core.Name
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Encode.Pretty as Aeson


### PR DESCRIPTION
This PR:

- [x] Renames `Core.File` to `Analysis.File`, because it relates to analysis rather than to the core language.
- [x] Depends on #327.
- [x] Depends on #329.
- [x] Depends on #332.