### PR TITLE
Readline path types

### DIFF
--- a/semantic-analysis/semantic-analysis.cabal
+++ b/semantic-analysis/semantic-analysis.cabal
@@ -54,8 +54,6 @@ library
       algebraic-graphs            ^>= 0.3
     , base                         >= 4.12 && < 5
     , containers                  ^>= 0.6
-    , directory                   ^>= 1.3
-    , filepath                    ^>= 1.4
     , fused-effects               ^>= 0.5
     , fused-syntax
     , haskeline                   ^>= 0.7.5

--- a/semantic-analysis/src/Control/Carrier/Readline/Haskeline.hs
+++ b/semantic-analysis/src/Control/Carrier/Readline/Haskeline.hs
@@ -23,8 +23,9 @@ import Data.Text.Prettyprint.Doc
 import Data.Text.Prettyprint.Doc.Render.Terminal (renderIO)
 import System.Console.Haskeline hiding (Handler, handle)
 import System.Console.Terminal.Size as Size
-import System.Directory
-import System.FilePath
+import System.Path ((</>))
+import qualified System.Path as Path
+import System.Path.Directory
 import System.IO (stdout)
 
 runReadline :: MonadException m => Prefs -> Settings m -> ReadlineC m a -> m a
@@ -33,11 +34,11 @@ runReadline prefs settings = runInputTWithPrefs prefs (coerce settings) . runM .
 runReadlineWithHistory :: MonadException m => ReadlineC m a -> m a
 runReadlineWithHistory block = do
   homeDir <- liftIO getHomeDirectory
-  prefs <- liftIO $ readPrefs (homeDir </> ".haskeline")
-  let settingsDir = homeDir </> ".local/semantic-core"
+  prefs <- liftIO $ readPrefs (Path.toString (homeDir </> Path.relFile ".haskeline"))
+  let settingsDir = homeDir </> Path.relDir ".local" </> Path.relDir "semantic-core"
       settings = Settings
         { complete = noCompletion
-        , historyFile = Just (settingsDir <> "/repl_history")
+        , historyFile = Just (Path.toString (settingsDir </> Path.relFile "repl_history"))
         , autoAddHistory = True
         }
   liftIO $ createDirectoryIfMissing True settingsDir


### PR DESCRIPTION
This PR replaces the use of the `directory` & `filepath` packages in `semantic-analysis` with the type-safe `pathtype` package.

- [x] Depends on #332.
- [x] Depends on #334.
- [x] Depends on #335.