### PR TITLE
Bump lingo to 0.3 and remove hack associated with #333.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -35,6 +35,11 @@ package semantic-tags
 
 source-repository-package
   type: git
+  location: https://github.com/tclem/lingo-haskell
+  tag: 59b19fd7251bd247245dbb67859507391764270f
+
+source-repository-package
+  type: git
   location: https://github.com/tclem/proto-lens-jsonpb
   tag: e4d10b77f57ee25beb759a33e63e2061420d3dc2
 

--- a/cabal.project
+++ b/cabal.project
@@ -35,11 +35,6 @@ package semantic-tags
 
 source-repository-package
   type: git
-  location: https://github.com/tclem/lingo-haskell
-  tag: 59b19fd7251bd247245dbb67859507391764270f
-
-source-repository-package
-  type: git
   location: https://github.com/tclem/proto-lens-jsonpb
   tag: e4d10b77f57ee25beb759a33e63e2061420d3dc2
 

--- a/semantic.cabal
+++ b/semantic.cabal
@@ -71,7 +71,7 @@ common dependencies
                      , text ^>= 1.2.3.1
                      , these >= 0.7 && <1
                      , unix ^>= 2.7.2.2
-                     , lingo >= 0.2.0.0
+                     , lingo >= 0.3.0.0
 
 common executable-flags
   ghc-options:         -threaded -rtsopts "-with-rtsopts=-N -A4m -n2m"

--- a/semantic.cabal
+++ b/semantic.cabal
@@ -71,7 +71,7 @@ common dependencies
                      , text ^>= 1.2.3.1
                      , these >= 0.7 && <1
                      , unix ^>= 2.7.2.2
-                     , lingo >= 0.3.0.0
+                     , lingo ^>= 0.3.0.0
 
 common executable-flags
   ghc-options:         -threaded -rtsopts "-with-rtsopts=-N -A4m -n2m"

--- a/src/Data/Language.hs
+++ b/src/Data/Language.hs
@@ -93,7 +93,15 @@ extensionsForLanguage language = T.unpack <$> maybe mempty Lingo.languageExtensi
 
 -- | Return a language based on a FilePath's extension.
 languageForFilePath :: FilePath -> Language
-languageForFilePath path = maybe Unknown (textToLanguage . Lingo.languageName) (Lingo.languageForPath path)
+languageForFilePath path =
+  let spurious lang = lang `elem` [ "Hack" -- .php files
+                                  , "GCC Machine Description" -- .md files
+                                  , "XML" -- .tsx files
+                                  ]
+      allResults = Lingo.languageName <$> Lingo.languagesForPath path
+  in case filter (not . spurious) allResults of
+    [result] -> textToLanguage result
+    _        -> Unknown
 
 supportedExts :: [String]
 supportedExts = foldr append mempty supportedLanguages
@@ -129,7 +137,6 @@ textToLanguage :: T.Text -> Language
 textToLanguage = \case
   "Go" -> Go
   "Haskell" -> Haskell
-  "Hack" -> PHP -- working around https://github.com/github/semantic/issues/330
   "Java" -> Java
   "JavaScript" -> JavaScript
   "JSON" -> JSON

--- a/test/Data/Language/Spec.hs
+++ b/test/Data/Language/Spec.hs
@@ -15,4 +15,5 @@ testTree = testGroup "Data.Language"
   , testCase "languageForFilePath works for languages with ambiguous lingo extensions" $ do
       languageForFilePath "foo.php" @=? PHP
       languageForFilePath "foo.md" @=? Markdown
+      languageForFilePath "foo.tsx" @=? TSX
   ]


### PR DESCRIPTION
- [x] Depends upon a release of lingo-0.3.0.0.

Now that lingo's language detection returns all possible results for a
given filename, we're able to abolish the workaround where we parsed
the string `"Hack"` into PHP. We have to check ourselves for spurious
results associated with Hack, TSX, and Markdown files, but that's
fitting and proper, rather than doing it behind the scenes in lingo.