### PR TITLE
Build & test against 8.6.5 in CI & expire old compilers’ caches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ before_cache:
 
 matrix:
   include:
-    - compiler: "ghc-8.6.4"
-      addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.4], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.6.5"
+      addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.5], sources: [hvr-ghc]}}
 
 before_install:
 - mkdir -p $HOME/.local/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ before_cache:
 
   - rm -rfv $HOME/.cabal/packages/head.hackage
 
-  # remove files from old compilers
   - rm -rfv $HOME/.cabal/store/{!(ghc-8.6.5)}
   - rm -rfv $TRAVIS_BUILD_DIR/dist-newstyle/build/*/{!(ghc-8.6.5)}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ before_cache:
 
   - rm -rfv $HOME/.cabal/packages/head.hackage
 
+  - rm -rfv $TRAVIS_BUILD_DIR/dist-newstyle/build/*/{!(ghc-8.6.5)}
+
 matrix:
   include:
     - compiler: "ghc-8.6.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ before_cache:
 
   - rm -rfv $HOME/.cabal/packages/head.hackage
 
-  - rm -rfv $HOME/.cabal/store/{!(ghc-8.6.5)}
   - rm -rfv $TRAVIS_BUILD_DIR/dist-newstyle/build/*/{!(ghc-8.6.5)}
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ before_cache:
 
   - rm -rfv $HOME/.cabal/packages/head.hackage
 
-  - rm -rfv $TRAVIS_BUILD_DIR/dist-newstyle/build/*/{!(ghc-8.6.5)}
-
 matrix:
   include:
     - compiler: "ghc-8.6.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_cache:
 
   - rm -rfv $HOME/.cabal/packages/head.hackage
 
+  # remove files from old compilers
   - rm -rfv $HOME/.cabal/store/{!(ghc-8.6.5)}
   - rm -rfv $TRAVIS_BUILD_DIR/dist-newstyle/build/*/{!(ghc-8.6.5)}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_cache:
 
   - rm -rfv $HOME/.cabal/packages/head.hackage
 
+  - rm -rfv $HOME/.cabal/store/{!(ghc-8.6.5)}
   - rm -rfv $TRAVIS_BUILD_DIR/dist-newstyle/build/*/{!(ghc-8.6.5)}
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,19 +33,19 @@ before_install:
 - cabal --version
 
 install:
-- cabal new-update -v
-- cabal new-configure --enable-tests --enable-benchmarks --disable-optimization --write-ghc-environment-files=always --jobs=2
-- cabal new-build --only-dependencies
+- cabal v2-update -v
+- cabal v2-configure --enable-tests --enable-benchmarks --disable-optimization --write-ghc-environment-files=always --jobs=2
+- cabal v2-build --only-dependencies
 
 script:
-- cabal new-build
-- cabal new-run semantic:test
-- cabal new-run semantic-core:test
-- cabal new-run semantic-python:test
-- cabal new-run semantic-source:test
-- cabal new-run semantic-source:doctest
+- cabal v2-build
+- cabal v2-run semantic:test
+- cabal v2-run semantic-core:test
+- cabal v2-run semantic-python:test
+- cabal v2-run semantic-source:test
+- cabal v2-run semantic-source:doctest
 # parse-examples is disabled because it slaughters our CI
-# - cabal new-run semantic:parse-examples
+# - cabal v2-run semantic:parse-examples
 
 # Any branch linked with a pull request will be built, as well as the non-PR
 # branches listed below:

--- a/semantic-ast/semantic-ast.cabal
+++ b/semantic-ast/semantic-ast.cabal
@@ -16,6 +16,8 @@ copyright:           (c) 2019 GitHub, Inc.
 category:            Language
 extra-source-files:  CHANGELOG.md
 
+tested-with:         GHC == 8.6.5
+
 library
   exposed-modules:
   -- other-modules:

--- a/semantic-python/semantic-python.cabal
+++ b/semantic-python/semantic-python.cabal
@@ -16,7 +16,7 @@ build-type:          Simple
 stability:           alpha
 extra-source-files:  README.md
 
-tested-with:         GHC == 8.6.4
+tested-with:         GHC == 8.6.5
 
 common haskell
   default-language:    Haskell2010

--- a/semantic.cabal
+++ b/semantic.cabal
@@ -16,7 +16,7 @@ build-type:          Simple
 stability:           alpha
 extra-source-files:  README.md
 
-tested-with:         GHC == 8.6.4
+tested-with:         GHC == 8.6.5
 
 flag release
   description: Build with optimizations on (for CI or deployment builds)


### PR DESCRIPTION
This PR:

- [x] Bumps CI to use 8.6.5.
- [x] Updates the `tested-with` fields accordingly where needed.
- [x] 🔥s caches from older compilers.