### PR TITLE
Make readProjectFromPaths use typed paths.

### DIFF
--- a/src/Data/Project.hs
+++ b/src/Data/Project.hs
@@ -23,7 +23,7 @@ data Project = Project
   { projectRootDir     :: FilePath
   , projectBlobs       :: [Blob]
   , projectLanguage    :: Language
-  , projectExcludeDirs :: [FilePath]
+  , projectExcludeDirs :: [Path.AbsRelDir]
   } deriving (Eq, Show, Generic)
 
 projectName :: Project -> Text
@@ -54,7 +54,7 @@ readProjectFromPaths maybeRoot path lang excludeDirs = do
 
   paths <- liftIO $ findFilesInDir rootDir exts excludeDirs
   blobs <- liftIO $ traverse (readBlobFromFile' . toFile) paths
-  pure $ Project (Path.toString rootDir) blobs lang (fmap Path.toString excludeDirs)
+  pure $ Project (Path.toString rootDir) blobs lang excludeDirs
   where
     toFile path = File (Path.toString path) lang
     exts = extensionsForLanguage lang

--- a/src/Data/Project.hs
+++ b/src/Data/Project.hs
@@ -23,7 +23,7 @@ data Project = Project
   { projectRootDir     :: FilePath
   , projectBlobs       :: [Blob]
   , projectLanguage    :: Language
-  , projectExcludeDirs :: [Path.AbsRelDir]
+  , projectExcludeDirs :: [FilePath]
   } deriving (Eq, Show, Generic)
 
 projectName :: Project -> Text
@@ -54,7 +54,7 @@ readProjectFromPaths maybeRoot path lang excludeDirs = do
 
   paths <- liftIO $ findFilesInDir rootDir exts excludeDirs
   blobs <- liftIO $ traverse (readBlobFromFile' . toFile) paths
-  pure $ Project (Path.toString rootDir) blobs lang excludeDirs
+  pure $ Project (Path.toString rootDir) blobs lang (fmap Path.toString excludeDirs)
   where
     toFile path = File (Path.toString path) lang
     exts = extensionsForLanguage lang

--- a/src/Data/Project.hs
+++ b/src/Data/Project.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ScopedTypeVariables #-}
 module Data.Project
   ( Project (..)
   , projectExtensions
@@ -43,7 +42,8 @@ readProjectFromPaths :: MonadIO m
                      -> [Path.AbsRelDir]     -- ^ Directories to exclude.
                      -> m Project
 readProjectFromPaths maybeRoot path lang excludeDirs = do
-  let (rootDir :: Path.AbsRelDir) = case maybeRoot >>= Path.fromAbsRel of
+  let rootDir :: Path.AbsRelDir
+      rootDir = case maybeRoot >>= Path.fromAbsRel of
         -- If we were provided a root directory, use that.
         Just root -> root
         Nothing   -> case Path.fileFromFileDir path of

--- a/src/Semantic/CLI.hs
+++ b/src/Semantic/CLI.hs
@@ -162,7 +162,7 @@ graphCommand = command "graph" (info graphArgumentsParser (progDesc "Compute a g
       <$> option auto (long "language" <> help "The language for the analysis.")
       <*> optional (pathOption (long "root" <> help "Root directory of project. Optional, defaults to entry file/directory." <> metavar "DIR"))
       <*> many (pathOption (long "exclude-dir" <> help "Exclude a directory (e.g. vendor)" <> metavar "DIR"))
-      <*> argument str (metavar "DIR")
+      <*> argument path (metavar "PATH")
     makeReadProjectRecursivelyTask language rootDir excludeDirs dir = Task.readProject rootDir dir language excludeDirs
     makeGraphTask graphType includePackages serializer projectTask = projectTask >>= Graph.runGraph graphType includePackages >>= serializer
 

--- a/src/Semantic/CLI.hs
+++ b/src/Semantic/CLI.hs
@@ -160,8 +160,8 @@ graphCommand = command "graph" (info graphArgumentsParser (progDesc "Compute a g
         _     -> pure $! Project "/" mempty Language.Unknown mempty
     readProjectRecursively = makeReadProjectRecursivelyTask
       <$> option auto (long "language" <> help "The language for the analysis.")
-      <*> optional (strOption (long "root" <> help "Root directory of project. Optional, defaults to entry file/directory." <> metavar "DIR"))
-      <*> many (strOption (long "exclude-dir" <> help "Exclude a directory (e.g. vendor)" <> metavar "DIR"))
+      <*> optional (pathOption (long "root" <> help "Root directory of project. Optional, defaults to entry file/directory." <> metavar "DIR"))
+      <*> many (pathOption (long "exclude-dir" <> help "Exclude a directory (e.g. vendor)" <> metavar "DIR"))
       <*> argument str (metavar "DIR")
     makeReadProjectRecursivelyTask language rootDir excludeDirs dir = Task.readProject rootDir dir language excludeDirs
     makeGraphTask graphType includePackages serializer projectTask = projectTask >>= Graph.runGraph graphType includePackages >>= serializer

--- a/src/Semantic/Resolution.hs
+++ b/src/Semantic/Resolution.hs
@@ -23,9 +23,9 @@ import           System.FilePath.Posix
 import qualified System.Path as Path
 
 
-nodeJSResolutionMap :: (Member Files sig, Carrier sig m, MonadIO m) => FilePath -> Text -> [Path.AbsRelDir] -> m (Map FilePath FilePath)
+nodeJSResolutionMap :: (Member Files sig, Carrier sig m, MonadIO m) => FilePath -> Text -> [FilePath] -> m (Map FilePath FilePath)
 nodeJSResolutionMap rootDir prop excludeDirs = do
-  files <- findFiles (Path.absRel rootDir) [".json"] excludeDirs
+  files <- findFiles (Path.absRel rootDir) [".json"] (fmap Path.absRel excludeDirs)
   let packageFiles = fileForTypedPath <$> filter ((==) (Path.relFile "package.json") . Path.takeFileName) files
   blobs <- readBlobs (FilesFromPaths packageFiles)
   pure $ fold (mapMaybe (lookup prop) blobs)
@@ -45,8 +45,8 @@ resolutionMap Project{..} = case projectLanguage of
   _          -> send (NoResolution pure)
 
 data Resolution (m :: * -> *) k
-  = NodeJSResolution FilePath Text [Path.AbsRelDir] (Map FilePath FilePath -> m k)
-  | NoResolution                                    (Map FilePath FilePath -> m k)
+  = NodeJSResolution FilePath Text [FilePath] (Map FilePath FilePath -> m k)
+  | NoResolution                              (Map FilePath FilePath -> m k)
   deriving stock (Functor, Generic1)
   deriving anyclass (HFunctor, Effect)
 

--- a/src/Semantic/Resolution.hs
+++ b/src/Semantic/Resolution.hs
@@ -23,9 +23,9 @@ import           System.FilePath.Posix
 import qualified System.Path as Path
 
 
-nodeJSResolutionMap :: (Member Files sig, Carrier sig m, MonadIO m) => FilePath -> Text -> [FilePath] -> m (Map FilePath FilePath)
+nodeJSResolutionMap :: (Member Files sig, Carrier sig m, MonadIO m) => FilePath -> Text -> [Path.AbsRelDir] -> m (Map FilePath FilePath)
 nodeJSResolutionMap rootDir prop excludeDirs = do
-  files <- findFiles (Path.absRel rootDir) [".json"] (fmap Path.absRel excludeDirs)
+  files <- findFiles (Path.absRel rootDir) [".json"] excludeDirs
   let packageFiles = fileForTypedPath <$> filter ((==) (Path.relFile "package.json") . Path.takeFileName) files
   blobs <- readBlobs (FilesFromPaths packageFiles)
   pure $ fold (mapMaybe (lookup prop) blobs)
@@ -45,8 +45,8 @@ resolutionMap Project{..} = case projectLanguage of
   _          -> send (NoResolution pure)
 
 data Resolution (m :: * -> *) k
-  = NodeJSResolution FilePath Text [FilePath] (Map FilePath FilePath -> m k)
-  | NoResolution                              (Map FilePath FilePath -> m k)
+  = NodeJSResolution FilePath Text [Path.AbsRelDir] (Map FilePath FilePath -> m k)
+  | NoResolution                                    (Map FilePath FilePath -> m k)
   deriving stock (Functor, Generic1)
   deriving anyclass (HFunctor, Effect)
 

--- a/src/Semantic/Task/Files.hs
+++ b/src/Semantic/Task/Files.hs
@@ -51,7 +51,7 @@ data PathFilter
 -- | An effect to read/write 'Blob's from 'Handle's or 'FilePath's.
 data Files (m :: * -> *) k
   = forall a . Read (Source a)                                     (a -> m k)
-  | ReadProject (Maybe FilePath) FilePath Language [FilePath] (Project -> m k)
+  | ReadProject (Maybe Path.AbsRelDir) FilePath Language [Path.AbsRelDir] (Project -> m k)
   | FindFiles Path.AbsRelDir [String] [Path.AbsRelDir] ([Path.AbsRelFile] -> m k)
   | Write Destination B.Builder                               (m k)
 
@@ -112,7 +112,7 @@ readBlobPairs :: (Member Files sig, Carrier sig m) => Either (Handle 'IO.ReadMod
 readBlobPairs (Left handle) = send (Read (FromPairHandle handle) pure)
 readBlobPairs (Right paths) = traverse (send . flip Read pure . uncurry FromPathPair) paths
 
-readProject :: (Member Files sig, Carrier sig m) => Maybe FilePath -> FilePath -> Language -> [FilePath] -> m Project
+readProject :: (Member Files sig, Carrier sig m) => Maybe Path.AbsRelDir -> FilePath -> Language -> [Path.AbsRelDir] -> m Project
 readProject rootDir dir lang excludeDirs = send (ReadProject rootDir dir lang excludeDirs pure)
 
 findFiles :: (Member Files sig, Carrier sig m) => Path.AbsRelDir -> [String] -> [Path.AbsRelDir] -> m [Path.AbsRelFile]

--- a/src/Semantic/Task/Files.hs
+++ b/src/Semantic/Task/Files.hs
@@ -51,7 +51,7 @@ data PathFilter
 -- | An effect to read/write 'Blob's from 'Handle's or 'FilePath's.
 data Files (m :: * -> *) k
   = forall a . Read (Source a)                                     (a -> m k)
-  | ReadProject (Maybe Path.AbsRelDir) FilePath Language [Path.AbsRelDir] (Project -> m k)
+  | ReadProject (Maybe Path.AbsRelDir) Path.AbsRelFileDir Language [Path.AbsRelDir] (Project -> m k)
   | FindFiles Path.AbsRelDir [String] [Path.AbsRelDir] ([Path.AbsRelFile] -> m k)
   | Write Destination B.Builder                               (m k)
 
@@ -112,7 +112,7 @@ readBlobPairs :: (Member Files sig, Carrier sig m) => Either (Handle 'IO.ReadMod
 readBlobPairs (Left handle) = send (Read (FromPairHandle handle) pure)
 readBlobPairs (Right paths) = traverse (send . flip Read pure . uncurry FromPathPair) paths
 
-readProject :: (Member Files sig, Carrier sig m) => Maybe Path.AbsRelDir -> FilePath -> Language -> [Path.AbsRelDir] -> m Project
+readProject :: (Member Files sig, Carrier sig m) => Maybe Path.AbsRelDir -> Path.AbsRelFileDir -> Language -> [Path.AbsRelDir] -> m Project
 readProject rootDir dir lang excludeDirs = send (ReadProject rootDir dir lang excludeDirs pure)
 
 findFiles :: (Member Files sig, Carrier sig m) => Path.AbsRelDir -> [String] -> [Path.AbsRelDir] -> m [Path.AbsRelFile]


### PR DESCRIPTION
- [x] Depends on #354.

This function has been a bête noire for some time; I’m glad to see it getting some type safety.