### PR TITLE
Add membership query operator to Core

### DIFF
--- a/semantic-core/src/Core/Core.hs
+++ b/semantic-core/src/Core/Core.hs
@@ -108,7 +108,7 @@ instance RightModule Core where
   Load b     >>=* f = Load (b >>= f)
   Record fs  >>=* f = Record (map (fmap (>>= f)) fs)
   (a :. b)   >>=* f = (a >>= f) :. b
-  (a :? b)   >>=* f = (a >>= f) : b
+  (a :? b)   >>=* f = (a >>= f) :. b
   (a := b)   >>=* f = (a >>= f) := (b >>= f)
 
 

--- a/semantic-core/src/Core/Eval.hs
+++ b/semantic-core/src/Core/Eval.hs
@@ -21,8 +21,6 @@ import Core.Core as Core
 import Core.Name
 import Data.Functor
 import Data.Maybe (fromMaybe, isJust)
-import Data.Text (Text)
-import qualified Data.Text as Text
 import GHC.Stack
 import Prelude hiding (fail)
 import Source.Span

--- a/semantic-core/src/Core/Eval.hs
+++ b/semantic-core/src/Core/Eval.hs
@@ -15,7 +15,6 @@ import Analysis.File
 import Control.Applicative (Alternative (..))
 import Control.Effect.Carrier
 import Control.Effect.Fail
-import Control.Effect.Fresh
 import Control.Effect.Reader
 import Control.Monad ((>=>))
 import Core.Core as Core
@@ -31,11 +30,8 @@ import Syntax.Scope
 import Syntax.Term
 import qualified System.Path as Path
 
-type Gensym = Fresh
-
 eval :: ( Carrier sig m
         , Member (Reader Span) sig
-        , Member Fresh sig
         , MonadFail m
         , Semigroup value
         )
@@ -82,9 +78,7 @@ eval Analysis{..} eval = \case
           eval . Core.lam (named' "nothing")
                . Core.lam (named' "just")
                $ pure "nothing"
-        Just item -> do
-          value <- deref' b item
-          abstract eval "nothing" (instantiate1 (pure "nothing") (Syntax.Scope.abstract _ _))
+        Just item -> undefined
 
 
     a := b -> do

--- a/semantic-core/src/Core/Eval.hs
+++ b/semantic-core/src/Core/Eval.hs
@@ -20,7 +20,7 @@ import Control.Monad ((>=>))
 import Core.Core as Core
 import Core.Name
 import Data.Functor
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import GHC.Stack
@@ -73,13 +73,7 @@ eval Analysis{..} eval = \case
     a :? b -> do
       a' <- ref a
       mFound <- a' ... b
-      case mFound of
-        Nothing ->
-          eval . Core.lam (named' "nothing")
-               . Core.lam (named' "just")
-               $ pure "nothing"
-        Just item -> undefined
-
+      bool (isJust mFound)
 
     a := b -> do
       b' <- eval b

--- a/semantic-core/src/Core/Parser.hs
+++ b/semantic-core/src/Core/Parser.hs
@@ -93,9 +93,13 @@ rec = Core.rec <$ reserved "rec" <*> name <* symbolic '=' <*> expr <?> "recursiv
 load :: (TokenParsing m, Carrier sig t, Member Core sig, Monad m) => m (t Name)
 load = Core.load <$ reserved "load" <*> expr
 
+query :: (TokenParsing m, Carrier sig t, Member Core sig, Monad m) => m (t Name)
+query = (Core..?) <$> atom <*> (namedValue <$ symbol ".?" <*> name)
+
 lvalue :: (TokenParsing m, Carrier sig t, Member Core sig, Monad m) => m (t Name)
 lvalue = choice
-  [ projection
+  [ query
+  , projection
   , ident
   , parens expr
   ]

--- a/semantic-core/src/Core/Parser.hs
+++ b/semantic-core/src/Core/Parser.hs
@@ -11,12 +11,13 @@ module Core.Parser
 -- Consult @doc/grammar.md@ for an EBNF grammar.
 
 import           Control.Applicative
-import           Control.Category ((>>>))
 import           Control.Effect.Carrier
 import           Core.Core ((:<-) (..), Core)
 import qualified Core.Core as Core
 import           Core.Name
 import qualified Data.Char as Char
+import           Data.Foldable (foldl')
+import           Data.Function
 import           Data.String
 import qualified Text.Parser.Token as Token
 import qualified Text.Parser.Token.Highlight as Highlight
@@ -61,12 +62,9 @@ application :: (TokenParsing m, Carrier sig t, Member Core sig, Monad m) => m (t
 application = projection `chainl1` (pure (Core.$$))
 
 projection :: (TokenParsing m, Carrier sig t, Member Core sig, Monad m) => m (t Name)
-projection = let a <$$> b = flip a <$> b in do
-  head <- atom
-  res <- many (choice [ (Core..?)  <$$> (symbol ".?" *> identifier)
-                      , (Core....) <$$> (dot *> identifier)
-                      ])
-  pure (foldr (>>>) id res head)
+projection = foldl' (&) <$> atom <*> many (choice [ flip (Core..?)  <$ symbol ".?" <*> identifier
+                                                  , flip (Core....) <$ dot         <*> identifier
+                                                  ])
 
 atom :: (TokenParsing m, Carrier sig t, Member Core sig, Monad m) => m (t Name)
 atom = choice

--- a/semantic-core/src/Core/Pretty.hs
+++ b/semantic-core/src/Core/Pretty.hs
@@ -74,6 +74,7 @@ prettyCore style = unPrec . go . fmap name
 
             Load p -> prec 3 (keyword "load" <+> withPrec 9 (go p))
             item :. body -> prec 9 (withPrec 9 (go item) <> symbol "." <> name body)
+            item :? body -> prec 9 (withPrec 9 (go item) <> symbol ".?" <> name body)
 
             lhs := rhs -> prec 3 . group . nest 2 $ vsep
               [ withPrec 4 (go lhs)

--- a/semantic-core/test/Generators.hs
+++ b/semantic-core/test/Generators.hs
@@ -70,5 +70,6 @@ expr = Gen.recursive Gen.choice atoms
   , Gen.subterm expr Core.load
   , record expr
   , Gen.subtermM expr (\ x -> (x Core....) . namedValue <$> name)
+  , Gen.subtermM expr (\ x -> (x Core..?)  . namedValue <$> name)
   , Gen.subterm2 expr expr (Core..=)
   ]

--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -100,9 +100,7 @@ instance (Compile l, Compile r) => Compile (l :+: r) where
   compile (R1 r) cc = compile r cc
 
 instance Compile Py.AssertStatement
-
-instance Compile Py.Attribute where
-  compile it@Py.Attribute { extraChildren = [L1 lhs, R1 rhs]} = _
+instance Compile Py.Attribute
 
 -- Assignment compilation. Assignments are an uneasy hybrid of expressions
 -- (since they appear to have values, i.e. `a = b = c`) and statements (because

--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -100,7 +100,9 @@ instance (Compile l, Compile r) => Compile (l :+: r) where
   compile (R1 r) cc = compile r cc
 
 instance Compile Py.AssertStatement
-instance Compile Py.Attribute
+
+instance Compile Py.Attribute where
+  compile it@Py.Attribute { extraChildren = [L1 lhs, R1 rhs]} = _
 
 -- Assignment compilation. Assignments are an uneasy hybrid of expressions
 -- (since they appear to have values, i.e. `a = b = c`) and statements (because

--- a/semantic-python/src/Prelude.score
+++ b/semantic-python/src/Prelude.score
@@ -1,11 +1,12 @@
 {
-  type <- \name -> \bases -> \dict ->
-    #record { __name: name, __bases: bases, __dict: dict };
+  type <- \name -> \super -> \slots ->
+    #record { __name: name, __super: super, __slots: slots };
 
   object <- type "object" #unit #record{};
 
-  #record { type: type, object: object }
+  getitem <- rec getitem = \item -> \attr ->
+    if item.slots.?attr then item.slots.attr else #unit;
 
+  #record { type: type, object: object, getitem: getitem }
 
-  lookup <- \item -> \name -> if item.?name then item.name else item.class.name
 }

--- a/semantic-python/src/Prelude.score
+++ b/semantic-python/src/Prelude.score
@@ -5,4 +5,7 @@
   object <- type "object" #unit #record{};
 
   #record { type: type, object: object }
+
+
+  lookup <- \item -> \name -> if item.?name then item.name else item.class.name
 }


### PR DESCRIPTION
Because Core doesn’t have data types yet, ~we return a Church-encoded `Maybe`.~ We can’t return a Church-encoded `Maybe` due to type considerations (see #358), so we instead return a boolean value. This will enable conditional lookup via `if a.?b then a.b else something`.

We hope to eliminate this eventually; a `Maybe`-based operator would be way better.