### PR TITLE
Don't depend on local semantic-source package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,8 @@ script:
 - cabal v2-run semantic:test
 - cabal v2-run semantic-core:test
 - cabal v2-run semantic-python:test
-- cd semantic-source; cabal v2-run semantic-source:test
-- cd semantic-source; cabal v2-run semantic-source:doctest
+- cd semantic-source; cabal v2-run semantic-source:test; cd ..
+- cd semantic-source; cabal v2-run semantic-source:doctest; cd ..
 # parse-examples is disabled because it slaughters our CI
 # - cabal v2-run semantic:parse-examples
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,8 @@ script:
 - cabal v2-run semantic:test
 - cabal v2-run semantic-core:test
 - cabal v2-run semantic-python:test
-- cabal v2-run semantic-source:test
-- cabal v2-run semantic-source:doctest
+- cd semantic-source; cabal v2-run semantic-source:test
+- cd semantic-source; cabal v2-run semantic-source:doctest
 # parse-examples is disabled because it slaughters our CI
 # - cabal v2-run semantic:parse-examples
 

--- a/cabal.project
+++ b/cabal.project
@@ -5,6 +5,7 @@ packages: .
           semantic-java
           semantic-json
           semantic-python
+          semantic-source
           semantic-tags
 
 jobs: $ncpus

--- a/cabal.project
+++ b/cabal.project
@@ -5,7 +5,6 @@ packages: .
           semantic-java
           semantic-json
           semantic-python
-          semantic-source
           semantic-tags
 
 jobs: $ncpus

--- a/cabal.project
+++ b/cabal.project
@@ -5,7 +5,6 @@ packages: .
           semantic-java
           semantic-json
           semantic-python
-          semantic-source
           semantic-tags
 
 jobs: $ncpus
@@ -26,9 +25,6 @@ package semantic-json
   ghc-options: -Werror
 
 package semantic-python
-  ghc-options: -Werror
-
-package semantic-source
   ghc-options: -Werror
 
 package semantic-tags

--- a/semantic-source/cabal.project
+++ b/semantic-source/cabal.project
@@ -1,0 +1,4 @@
+packages: .
+
+package semantic-source
+  ghc-options: -Werror

--- a/semantic-source/semantic-source.cabal
+++ b/semantic-source/semantic-source.cabal
@@ -22,7 +22,7 @@ tested-with:
   GHC == 8.6.5
   GHC == 8.8.1
 
-common common
+common haskell
   default-language: Haskell2010
   ghc-options:
     -Weverything
@@ -40,7 +40,7 @@ common common
     ghc-options: -Wno-missing-deriving-strategies
 
 library
-  import: common
+  import: haskell
   exposed-modules:
     Source.Loc
     Source.Range
@@ -58,7 +58,7 @@ library
   hs-source-dirs: src
 
 test-suite doctest
-  import: common
+  import: haskell
   type: exitcode-stdio-1.0
   main-is: Doctest.hs
   build-depends:
@@ -69,8 +69,9 @@ test-suite doctest
   hs-source-dirs: test
 
 test-suite test
-  import: common
+  import: haskell
   type: exitcode-stdio-1.0
+  hs-source-dirs: test
   main-is: Test.hs
   other-modules:
     Source.Test
@@ -82,7 +83,6 @@ test-suite test
     , tasty-hedgehog  ^>= 1.0.0.1
     , tasty-hunit      >= 0.10 && <1
     , text
-  hs-source-dirs: test
 
 source-repository head
   type:     git


### PR DESCRIPTION
Semantic is already depending on an external `semantic-source` package from hackage. Also including it as a local package dependency can sometimes create non-deterministic build failures (e.g. `cabal new-build exe:semantic`). To help prevent this potential friction for users, we should depend on the external package only.