### PR TITLE
Support comments in the Core parser.

### DIFF
--- a/semantic-core/src/Core/Parser.hs
+++ b/semantic-core/src/Core/Parser.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, DerivingStrategies, FlexibleContexts, GeneralizedNewtypeDeriving, TypeOperators #-}
+{-# LANGUAGE FlexibleContexts, GeneralizedNewtypeDeriving, TypeOperators #-}
 module Core.Parser
   ( core
   , lit
@@ -27,8 +27,7 @@ import           Text.Trifecta hiding (ident)
 -- * Identifier styles and derived parsers
 
 newtype CoreParser m a = CoreParser { runCoreParser :: m a }
-  deriving stock Functor
-  deriving newtype (Alternative, Applicative, CharParsing, DeltaParsing, Errable, LookAheadParsing, Monad, MonadPlus, Parsing)
+  deriving (Alternative, Applicative, CharParsing, DeltaParsing, Errable, Functor, LookAheadParsing, Monad, MonadPlus, Parsing)
 
 instance TokenParsing m => TokenParsing (CoreParser m) where
   someSpace = Style.buildSomeSpaceParser (void (satisfy Char.isSpace)) Style.haskellCommentStyle

--- a/semantic-core/src/Core/Parser.hs
+++ b/semantic-core/src/Core/Parser.hs
@@ -5,7 +5,6 @@ module Core.Parser
   , expr
   , record
   , comp
-  , lvalue
   ) where
 
 -- Consult @doc/grammar.md@ for an EBNF grammar.
@@ -102,13 +101,6 @@ rec = Core.rec <$ reserved "rec" <*> name <* symbolic '=' <*> expr <?> "recursiv
 
 load :: (TokenParsing m, Carrier sig t, Member Core sig, Monad m) => m (t Name)
 load = Core.load <$ reserved "load" <*> expr
-
-lvalue :: (TokenParsing m, Carrier sig t, Member Core sig, Monad m) => m (t Name)
-lvalue = choice
-  [ projection
-  , ident
-  , parens expr
-  ]
 
 -- * Literals
 

--- a/semantic-core/src/Core/Parser.hs
+++ b/semantic-core/src/Core/Parser.hs
@@ -30,7 +30,8 @@ newtype CoreParser m a = CoreParser { runCoreParser :: m a }
   deriving (Alternative, Applicative, CharParsing, DeltaParsing, Errable, Functor, LookAheadParsing, Monad, MonadPlus, Parsing)
 
 instance TokenParsing m => TokenParsing (CoreParser m) where
-  someSpace = Style.buildSomeSpaceParser (void (satisfy Char.isSpace)) Style.haskellCommentStyle
+  someSpace = Style.buildSomeSpaceParser (void (satisfy Char.isSpace)) comments
+    where comments = Style.CommentStyle "" "" "//" False
 
 validIdentifierStart :: Char -> Bool
 validIdentifierStart c = not (Char.isDigit c) && isSimpleCharacter c


### PR DESCRIPTION
I went with the Haskell comment style: `--` for line comments, `{- -}`
for block comments, allowing nested multiline comments. This can be
changed pretty easily.