### PR TITLE
We can’t have nice things

### DIFF
--- a/bench/Evaluation.hs
+++ b/bench/Evaluation.hs
@@ -38,14 +38,14 @@ callGraphProject' :: ( Language.SLanguage lang
                   => TaskSession
                   -> Proxy lang
                   -> Path.RelFile
-                  -> IO (Either String (Data.Graph.Graph ControlFlowVertex))
+                  -> IO (Either String ())
 callGraphProject' session proxy path
   | let lang = Language.reflect proxy
   , Just (SomeParser parser) <- parserForLanguage analysisParsers lang = fmap (first show) . runTask session $ do
   blob <- readBlobFromFile' (fileForTypedPath path)
   package <- fmap snd <$> runParse (Duration.fromSeconds 10) (parsePackage parser (Project (Path.toString (Path.takeDirectory path)) [blob] lang []))
   modules <- topologicalSort <$> runImportGraphToModules proxy package
-  runCallGraph proxy False modules package
+  (() <$) <$> runCallGraph proxy False modules package
 
 callGraphProject proxy paths = withOptions defaultOptions $ \ config logger statter ->
   callGraphProject' (TaskSession config "" False logger statter) proxy paths

--- a/bench/Evaluation.hs
+++ b/bench/Evaluation.hs
@@ -41,11 +41,11 @@ callGraphProject' :: ( Language.SLanguage lang
                   -> IO (Either String ())
 callGraphProject' session proxy path
   | let lang = Language.reflect proxy
-  , Just (SomeParser parser) <- parserForLanguage analysisParsers lang = fmap (first show) . runTask session $ do
+  , Just (SomeParser parser) <- parserForLanguage analysisParsers lang = bimap (first show) (const ()) . runTask session $ do
   blob <- readBlobFromFile' (fileForTypedPath path)
   package <- fmap snd <$> runParse (Duration.fromSeconds 10) (parsePackage parser (Project (Path.toString (Path.takeDirectory path)) [blob] lang []))
   modules <- topologicalSort <$> runImportGraphToModules proxy package
-  (() <$) <$> runCallGraph proxy False modules package
+  runCallGraph proxy False modules package
 
 callGraphProject proxy paths = withOptions defaultOptions $ \ config logger statter ->
   callGraphProject' (TaskSession config "" False logger statter) proxy paths

--- a/bench/Evaluation.hs
+++ b/bench/Evaluation.hs
@@ -41,7 +41,7 @@ callGraphProject' :: ( Language.SLanguage lang
                   -> IO (Either String ())
 callGraphProject' session proxy path
   | let lang = Language.reflect proxy
-  , Just (SomeParser parser) <- parserForLanguage analysisParsers lang = bimap (first show) (const ()) . runTask session $ do
+  , Just (SomeParser parser) <- parserForLanguage analysisParsers lang = fmap (bimap show (const ())) . runTask session $ do
   blob <- readBlobFromFile' (fileForTypedPath path)
   package <- fmap snd <$> runParse (Duration.fromSeconds 10) (parsePackage parser (Project (Path.toString (Path.takeDirectory path)) [blob] lang []))
   modules <- topologicalSort <$> runImportGraphToModules proxy package

--- a/src/Control/Abstract/Heap.hs
+++ b/src/Control/Abstract/Heap.hs
@@ -452,17 +452,6 @@ instance Eq address => Eq1 (HeapError address) where
   liftEq _ (LookupFrameError a) (LookupFrameError b)     = a == b
   liftEq _ _ _                                           = False
 
-instance NFData address => NFData1 (HeapError address) where
-  liftRnf _ x = case x of
-    CurrentFrameError    -> ()
-    LookupAddressError a -> rnf a
-    LookupFrameError a   -> a `seq` ()
-    LookupLinksError a   -> rnf a
-    LookupLinkError p    -> rnf p
-
-instance (NFData address, NFData resume) => NFData (HeapError address resume) where
-  rnf = liftRnf rnf
-
 throwHeapError  :: ( Member (Resumable (BaseError (HeapError address))) sig
                    , Member (Reader ModuleInfo) sig
                    , Member (Reader Span) sig
@@ -484,14 +473,6 @@ runHeapErrorWith f = raiseHandler $ runResumableWith (runEvaluator . f)
 data AddressError address value resume where
   UnallocatedSlot   :: Slot address -> AddressError address value (Set value)
   UninitializedSlot :: Slot address -> AddressError address value value
-
-instance (NFData address) => NFData1 (AddressError address value) where
-  liftRnf _ x = case x of
-    UnallocatedSlot a   -> rnf a
-    UninitializedSlot a -> rnf a
-
-instance (NFData address, NFData resume) => NFData (AddressError address value resume) where
-  rnf = liftRnf rnf
 
 deriving instance Eq address => Eq (AddressError address value resume)
 deriving instance Show address => Show (AddressError address value resume)

--- a/src/Control/Abstract/Modules.hs
+++ b/src/Control/Abstract/Modules.hs
@@ -112,9 +112,6 @@ instance Show1 (LoadError address value) where
 instance Eq1 (LoadError address value) where
   liftEq _ (ModuleNotFoundError a) (ModuleNotFoundError b) = a == b
 
-instance NFData1 (LoadError address value) where
-  liftRnf _ (ModuleNotFoundError p) = rnf p
-
 runLoadError :: Evaluator term address value (ResumableC (BaseError (LoadError address value)) m) a
              -> Evaluator term address value m (Either (SomeError (BaseError (LoadError address value))) a)
 runLoadError = raiseHandler runResumable
@@ -147,10 +144,6 @@ instance Eq1 ResolutionError where
   liftEq _ (NotFoundError a _ l1) (NotFoundError b _ l2) = a == b && l1 == l2
   liftEq _ (GoImportError a) (GoImportError b) = a == b
   liftEq _ _ _ = False
-instance NFData1 ResolutionError where
-  liftRnf _ x = case x of
-    NotFoundError p ps l -> rnf p `seq` rnf ps `seq` rnf l
-    GoImportError p      -> rnf p
 
 runResolutionError :: Evaluator term address value (ResumableC (BaseError ResolutionError) m) a
                    -> Evaluator term address value m (Either (SomeError (BaseError ResolutionError)) a)

--- a/src/Control/Abstract/ScopeGraph.hs
+++ b/src/Control/Abstract/ScopeGraph.hs
@@ -362,19 +362,6 @@ instance Eq1 (ScopeError address) where
   liftEq _ CurrentScopeError                    CurrentScopeError                   = True
   liftEq _ _                                    _                                   = False
 
-instance NFData1 (ScopeError address) where
-  liftRnf _ x = case x of
-    DeclarationByNameError n      -> rnf n
-    ScopeError d s                -> rnf d `seq` rnf s
-    LookupScopeError              -> ()
-    ImportReferenceError          -> ()
-    LookupPathError d             -> rnf d
-    LookupDeclarationScopeError d -> rnf d
-    CurrentScopeError             -> ()
-
-instance NFData return => NFData (ScopeError address return) where
-  rnf = liftRnf rnf
-
 alloc :: (Member (Allocator address) sig, Carrier sig m) => Name -> Evaluator term address value m address
 alloc = send . flip Alloc pure
 

--- a/src/Control/Abstract/Value.hs
+++ b/src/Control/Abstract/Value.hs
@@ -114,7 +114,7 @@ function name params body scope = sendFunction (Function name params body scope 
 data BuiltIn
   = Print
   | Show
-  deriving (Eq, Ord, Show, Generic, NFData)
+  deriving (Eq, Ord, Show, Generic)
 
 builtIn :: (Member (Function term address value) sig, Carrier sig m) => address -> BuiltIn -> Evaluator term address value m value
 builtIn address = sendFunction . flip (BuiltIn address) pure

--- a/src/Data/Abstract/Address/Precise.hs
+++ b/src/Data/Abstract/Address/Precise.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE TypeOperators, UndecidableInstances #-}
 module Data.Abstract.Address.Precise
 ( Precise(..)
 ) where

--- a/src/Data/Abstract/Address/Precise.hs
+++ b/src/Data/Abstract/Address/Precise.hs
@@ -11,7 +11,7 @@ import Prologue
 
 -- | 'Precise' models precise store semantics where only the 'Latest' value is taken. Everything gets it's own address (always makes a new allocation) which makes for a larger store.
 newtype Precise = Precise { unPrecise :: Int }
-  deriving (Eq, Ord, NFData)
+  deriving (Eq, Ord)
 
 instance Show Precise where
   showsPrec d = showsUnaryWith showsPrec "Precise" d . unPrecise

--- a/src/Data/Abstract/BaseError.hs
+++ b/src/Data/Abstract/BaseError.hs
@@ -29,12 +29,6 @@ instance (Eq1 exc) => Eq1 (BaseError exc) where
 instance Show1 exc => Show1 (BaseError exc) where
   liftShowsPrec sl sp d (BaseError info span exc) = showParen (d > 10) $ showString "BaseError" . showChar ' ' . showsPrec 11 info . showChar ' ' . showsPrec 11 span . showChar ' ' . liftShowsPrec sl sp 11 exc
 
-instance (NFData1 exc, NFData resume) => NFData (BaseError exc resume) where
-  rnf = liftRnf rnf
-
-instance (NFData1 exc) => NFData1 (BaseError exc) where
-  liftRnf rnf' (BaseError i s e) = rnf i `seq` rnf s `seq` liftRnf rnf' e
-
 throwBaseError :: ( Member (Resumable (BaseError exc)) sig
                   , Member (Reader M.ModuleInfo) sig
                   , Member (Reader S.Span) sig

--- a/src/Data/Abstract/Evaluatable.hs
+++ b/src/Data/Abstract/Evaluatable.hs
@@ -225,23 +225,6 @@ throwNoNameError = throwEvalError . NoNameError
 deriving instance (Eq term, Eq value) => Eq (EvalError term address value return)
 deriving instance (Show term, Show value) => Show (EvalError term address value return)
 
-instance (NFData term, NFData value) => NFData1 (EvalError term address value) where
-  liftRnf _ x = case x of
-    AccessControlError requester requested v -> rnf requester `seq` rnf requested `seq` rnf v
-    ConstructorError n -> rnf n
-    DefaultExportError -> ()
-    DerefError v -> rnf v
-    ExportError p n -> rnf p `seq` rnf n
-    FloatFormatError i -> rnf i
-    IntegerFormatError i -> rnf i
-    NoNameError term -> rnf term
-    RationalFormatError i -> rnf i
-    ReferenceError v n -> rnf v `seq` rnf n
-    ScopedEnvError v -> rnf v
-
-instance (NFData term, NFData value, NFData return) => NFData (EvalError term address value return) where
-  rnf = liftRnf rnf
-
 instance (Eq term, Eq value) => Eq1 (EvalError term address value) where
   liftEq _ (AccessControlError a b c) (AccessControlError a' b' c') = a == a' && b == b' && c == c'
   liftEq _ (DerefError v) (DerefError v2)                           = v == v2
@@ -279,13 +262,6 @@ throwEvalError = throwBaseError
 data UnspecializedError address value resume where
   UnspecializedError    :: String -> UnspecializedError address value value
   RefUnspecializedError :: String -> UnspecializedError address value (Slot address)
-
-instance NFData1 (UnspecializedError address value) where
-  liftRnf _ (UnspecializedError s)    = rnf s
-  liftRnf _ (RefUnspecializedError s) = rnf s
-
-instance NFData (UnspecializedError address value resume) where
-  rnf = liftRnf (const ())
 
 deriving instance Eq   (UnspecializedError address value resume)
 deriving instance Show (UnspecializedError address value resume)

--- a/src/Data/Abstract/Heap.hs
+++ b/src/Data/Abstract/Heap.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveAnyClass, DerivingStrategies, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Data.Abstract.Heap
   ( Heap(..)
   , Frame(..)
@@ -52,15 +52,11 @@ data Frame scopeAddress frameAddress value = Frame
   , slots        :: IntMap (Set value)
   -- ^ An IntMap of values that are declared in the frame.
   }
-  deriving (Eq, Ord, Show, Generic, NFData)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | A Heap is a Map from frame addresses to frames.
 newtype Heap scopeAddress frameAddress value = Heap { unHeap :: Map frameAddress (Frame scopeAddress frameAddress value) }
-  deriving stock (Eq, Generic, Ord)
-  deriving newtype (NFData)
-
-instance Lower (Heap scopeAddress frameAddress value) where
-  lowerBound = Heap lowerBound
+  deriving (Eq, Generic, Lower, Ord)
 
 
 -- | Look up the frame for an 'address' in a 'Heap', if any.

--- a/src/Data/Abstract/Module.hs
+++ b/src/Data/Abstract/Module.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass, DerivingStrategies #-}
-
 module Data.Abstract.Module
 ( Module(..)
 , moduleForBlob
@@ -16,8 +14,7 @@ import Prologue
 import System.FilePath.Posix
 
 data Module body = Module { moduleInfo :: ModuleInfo, moduleBody :: body }
-  deriving stock (Eq, Foldable, Functor, Ord, Traversable, Generic)
-  deriving anyclass (NFData)
+  deriving (Eq, Foldable, Functor, Ord, Traversable, Generic)
 
 instance Show body => Show (Module body) where
   showsPrec d Module{..} = showsBinaryWith showsPrec showsPrec "Module" d (modulePath moduleInfo) moduleBody
@@ -36,8 +33,7 @@ moduleForBlob rootDir b = Module info
 type ModulePath = FilePath
 
 data ModuleInfo = ModuleInfo { modulePath :: ModulePath, moduleLanguage :: Language, moduleOid :: Text }
-  deriving stock (Eq, Ord, Generic)
-  deriving anyclass (NFData)
+  deriving (Eq, Ord, Generic)
 
 instance Lower ModuleInfo where
   lowerBound = ModuleInfo mempty Unknown mempty

--- a/src/Data/Abstract/ModuleTable.hs
+++ b/src/Data/Abstract/ModuleTable.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveAnyClass, DerivingStrategies, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Data.Abstract.ModuleTable
 ( ModulePath
 , ModuleTable (..)
@@ -21,9 +21,7 @@ import Prologue
 import System.FilePath.Posix
 
 newtype ModuleTable a = ModuleTable { unModuleTable :: Map.Map ModulePath a }
-  deriving stock (Eq, Foldable, Functor, Generic1, Generic, Ord, Traversable)
-  deriving newtype (Lower, Monoid, Semigroup)
-  deriving anyclass (NFData)
+  deriving (Eq, Foldable, Functor, Generic1, Generic, Lower, Monoid, Ord, Semigroup, Traversable)
 
 singleton :: ModulePath -> a -> ModuleTable a
 singleton name = ModuleTable . Map.singleton name

--- a/src/Data/Abstract/Name.hs
+++ b/src/Data/Abstract/Name.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
 module Data.Abstract.Name
 ( Name
 -- * Constructors
@@ -20,7 +19,7 @@ import           Prologue
 data Name
   = Name Text
   | I Int
-  deriving (Eq, Ord, Generic, NFData)
+  deriving (Eq, Ord, Generic)
 
 -- | Generate a fresh (unused) name for use in synthesized variables/closures/etc.
 gensym :: (Member Fresh sig, Carrier sig m) => m Name

--- a/src/Data/Abstract/Number.hs
+++ b/src/Data/Abstract/Number.hs
@@ -32,12 +32,6 @@ data Number a where
 
 deriving instance Eq a => Eq (Number a)
 
-instance NFData (Number a) where
-  rnf a = case a of
-    Integer i -> rnf i
-    Ratio   r -> rnf r
-    Decimal d -> rnf d
-
 instance Show (Number a) where
   show (Integer i) = show i
   show (Ratio r) = show r

--- a/src/Data/Abstract/Package.hs
+++ b/src/Data/Abstract/Package.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-
 module Data.Abstract.Package
   ( Package (..)
   , PackageInfo (..)
@@ -11,7 +9,6 @@ import Data.Abstract.Module
 import Data.Abstract.ModuleTable as ModuleTable
 import qualified Data.Map as Map
 import Data.Abstract.Name
-import Prologue
 
 type PackageName = Name
 
@@ -20,7 +17,7 @@ data PackageInfo = PackageInfo
   { packageName        :: PackageName
   , packageResolutions :: Map.Map FilePath FilePath
   }
-  deriving (Eq, Ord, Show, Generic, NFData)
+  deriving (Eq, Ord, Show)
 
 -- | A package represents the unit of dependency, i.e. something which can depend upon, or be depended upon by, other packages. Packages have modules and may have entry points from which evaluation can proceed.
 data Package term = Package

--- a/src/Data/Abstract/ScopeGraph.hs
+++ b/src/Data/Abstract/ScopeGraph.hs
@@ -55,13 +55,13 @@ import Source.Span
 
 -- A slot is a location in the heap where a value is stored.
 data Slot address = Slot { frameAddress :: address, position :: Position }
-    deriving (Eq, Show, Ord, Generic, NFData)
+    deriving (Eq, Show, Ord)
 
 
 data AccessControl = Public
                    | Protected
                    | Private
-                   deriving (Bounded, Enum, Eq, Generic, Hashable, ToJSON, NFData, Show)
+                   deriving (Bounded, Enum, Eq, Generic, Hashable, ToJSON, Show)
 
 instance ToJSONFields AccessControl where
   toJSONFields accessControl = ["accessControl" .= accessControl]
@@ -87,7 +87,7 @@ instance Ord AccessControl where
 
 
 data Relation = Default | Instance | Prelude | Gensym
-  deriving (Bounded, Enum, Eq, Show, Ord, Generic, NFData)
+  deriving (Bounded, Enum, Eq, Show, Ord)
 
 instance Lower Relation where
   lowerBound = Default
@@ -100,7 +100,7 @@ data Info scopeAddress = Info
   , infoSpan            :: Span
   , infoKind            :: Kind
   , infoAssociatedScope :: Maybe scopeAddress
-  } deriving (Eq, Show, Ord, Generic, NFData)
+  } deriving (Eq, Show, Ord)
 
 instance HasSpan (Info scopeAddress) where
   span_ = lens infoSpan (\i s -> i { infoSpan = s })
@@ -113,7 +113,7 @@ data ReferenceInfo = ReferenceInfo
   { refSpan   :: Span
   , refKind   :: Kind
   , refModule :: ModuleInfo
-  } deriving (Eq, Show, Ord, Generic, NFData)
+  } deriving (Eq, Show, Ord)
 
 instance HasSpan ReferenceInfo where
   span_ = lens refSpan (\r s -> r { refSpan = s })
@@ -143,7 +143,7 @@ data Kind = AbstractClass
           | Unknown
           | UnqualifiedImport
           | VariableDeclaration
-  deriving (Bounded, Enum, Eq, Show, Ord, Generic, NFData)
+  deriving (Bounded, Enum, Eq, Show, Ord)
 
 instance Lower Kind where
   lowerBound = Unknown
@@ -160,7 +160,7 @@ data Scope address =
     , references   :: Map Reference ([ReferenceInfo], Path address)
     , declarations :: Seq (Info address)
     }
-  deriving (Eq, Show, Ord, Generic, NFData)
+  deriving (Eq, Show, Ord)
 
 instance Lower (Scope scopeAddress) where
   lowerBound = Scope mempty mempty mempty
@@ -175,10 +175,10 @@ instance AbstractHole (Info address) where
   hole = lowerBound
 
 newtype Position = Position { unPosition :: Int }
-  deriving (Eq, Show, Ord, Generic, NFData)
+  deriving (Eq, Show, Ord)
 
 newtype ScopeGraph scope = ScopeGraph { unScopeGraph :: Map scope (Scope scope) }
-  deriving (Eq, Generic, NFData, Ord, Show)
+  deriving (Eq, Ord, Show)
 
 instance Ord scope => Lower (ScopeGraph scope) where
   lowerBound = ScopeGraph mempty
@@ -189,7 +189,7 @@ data Path scope
   | DPath Declaration Position
   -- | Construct an edge from a scope to another declaration path.
   | EPath EdgeLabel scope (Path scope)
-  deriving (Eq, Functor, Generic, NFData, Ord, Show)
+  deriving (Eq, Functor, Ord, Show)
 
 instance AbstractHole (Path scope) where
   hole = Hole
@@ -399,13 +399,13 @@ associatedScope Declaration{..} g@(ScopeGraph graph) = go (Map.keys graph)
     lookupAssociatedScope scope = ((lookupDeclaration unDeclaration scope g >>= infoAssociatedScope . fst) <|>)
 
 newtype Reference = Reference { unReference :: Name }
-  deriving (Eq, Ord, Show, Generic, NFData)
+  deriving (Eq, Ord, Show)
 
 instance Lower Reference where
   lowerBound = Reference $ name ""
 
 newtype Declaration = Declaration { unDeclaration :: Name }
-  deriving (Eq, Ord, Show, Generic, NFData)
+  deriving (Eq, Ord, Show)
 
 instance Lower Declaration where
   lowerBound = Declaration $ name ""
@@ -416,4 +416,4 @@ formatDeclaration = formatName . unDeclaration
 -- | The type of edge from a scope to its parent scopes.
 -- Either a lexical edge or an import edge in the case of non-lexical edges.
 data EdgeLabel = Lexical | Import | Export | Superclass
-  deriving (Bounded, Enum, Eq, Ord, Show, Generic, NFData)
+  deriving (Bounded, Enum, Eq, Ord, Show)

--- a/src/Data/Abstract/Value/Concrete.hs
+++ b/src/Data/Abstract/Value/Concrete.hs
@@ -44,7 +44,7 @@ data Value term address
   | Hash [Value term address]
   | Null
   | Hole
-  deriving (Eq, Ord, Show, Generic, NFData)
+  deriving (Eq, Ord, Show, Generic)
 
 
 instance ValueRoots address (Value term address) where
@@ -381,25 +381,6 @@ data ValueError term address resume where
   ArithmeticError        :: ArithException                           -> ValueError term address (Value term address)
   -- Out-of-bounds error
   BoundsError            :: [Value term address] -> Prelude.Integer  -> ValueError term address (Value term address)
-
-instance (NFData term, NFData address) => NFData1 (ValueError term address) where
-  liftRnf _ x = case x of
-    StringError i       -> rnf i
-    BoolError   i       -> rnf i
-    IndexError  i j     -> rnf i `seq` rnf j
-    CallError i         -> rnf i
-    NumericError i      -> rnf i
-    Numeric2Error i j   -> rnf i `seq` rnf j
-    ComparisonError i j -> rnf i `seq` rnf j
-    BitwiseError i      -> rnf i
-    Bitwise2Error i j   -> rnf i `seq` rnf j
-    KeyValueError i     -> rnf i
-    ArrayError i        -> rnf i
-    ArithmeticError i   -> i `seq` ()
-    BoundsError i j     -> rnf i `seq` rnf j
-
-instance (NFData term, NFData address, NFData resume) => NFData (ValueError term address resume) where
-  rnf = liftRnf rnf
 
 instance (Eq address, Eq term) => Eq1 (ValueError term address) where
   liftEq _ (StringError a) (StringError b)                       = a == b

--- a/src/Data/Abstract/Value/Concrete.hs
+++ b/src/Data/Abstract/Value/Concrete.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveAnyClass, GADTs, LambdaCase, RankNTypes, TypeOperators, UndecidableInstances, ScopedTypeVariables #-}
+{-# LANGUAGE GADTs, LambdaCase, RankNTypes, ScopedTypeVariables, TypeOperators, UndecidableInstances #-}
 module Data.Abstract.Value.Concrete
   ( Value (..)
   , ValueError (..)

--- a/src/Data/Flag.hs
+++ b/src/Data/Flag.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DerivingStrategies, GeneralizedNewtypeDeriving, RankNTypes, KindSignatures #-}
-
 -- | -- This technique is due to Oleg Grenrus: <http://oleg.fi/gists/posts/2019-03-21-flag.html>
 -- The implementation is clean-room due to unclear licensing of the original post.
 module Data.Flag
@@ -18,9 +16,8 @@ import Prologue
 -- This is more verbose than using 'Bool' for everything but prevents classes of errors when
 -- working with multiple flag values in flight, as the 'toBool' deconstructor provides a witness
 -- that you really want the given semantic flag value from the flag datum.
-newtype Flag (t :: *) = Flag Bool
-  deriving stock (Eq, Show)
-  deriving newtype NFData
+newtype Flag t = Flag Bool
+  deriving (Eq, Show)
 
 -- | The constructor for a 'Flag'. You specify @t@ with a visible type application.
 flag :: t -> Bool -> Flag t

--- a/src/Data/Functor/Classes/Generic.hs
+++ b/src/Data/Functor/Classes/Generic.hs
@@ -9,7 +9,6 @@ module Data.Functor.Classes.Generic
 , defaultGShow1Options
 , genericLiftShowsPrec
 , genericLiftShowsPrecWithOptions
-, Generically (..)
 ) where
 
 import Data.Functor.Classes
@@ -180,11 +179,3 @@ instance (Show1 f, GShow1 g) => GShow1 (f :.: g) where
 
 showBraces :: Bool -> ShowS -> ShowS
 showBraces should rest = if should then showChar '{' . rest . showChar '}' else rest
-
--- | Used with the `DerivingVia` extension to provide fast derivations for
--- 'Eq1', 'Show1', and 'Ord1'.
-newtype Generically f a = Generically { unGenerically :: f a }
-
-instance (Generic1 f, GEq1 (Rep1 f)) => Eq1 (Generically f) where liftEq eq (Generically a1) (Generically a2) = genericLiftEq eq a1 a2
-instance (Generic1 f, GEq1 (Rep1 f), GOrd1 (Rep1 f)) => Ord1  (Generically f) where liftCompare compare (Generically a1) (Generically a2) = genericLiftCompare compare a1 a2
-instance (Generic1 f, GShow1 (Rep1 f)) => Show1 (Generically f) where liftShowsPrec d sp sl = genericLiftShowsPrec d sp sl . unGenerically

--- a/src/Data/Graph.hs
+++ b/src/Data/Graph.hs
@@ -29,7 +29,7 @@ import           Proto.Semantic_Fields as P
 
 -- | An algebraic graph with 'Ord', 'Semigroup', and 'Monoid' instances.
 newtype Graph vertex = Graph { unGraph :: G.Graph vertex }
-  deriving (Alternative, Applicative, Eq, Functor, Monad, Show, Class.Graph, NFData)
+  deriving (Alternative, Applicative, Eq, Functor, Monad, Show, Class.Graph)
 
 instance Ord t => Class.ToGraph (Graph t) where
   type ToVertex (Graph t) = t

--- a/src/Data/Graph/ControlFlowVertex.hs
+++ b/src/Data/Graph/ControlFlowVertex.hs
@@ -40,7 +40,7 @@ data ControlFlowVertex
   | Variable      { vertexName :: Text, vertexModuleName :: Text, vertexSpan :: Span }
   | Method        { vertexName :: Text, vertexModuleName :: Text, vertexSpan :: Span }
   | Function      { vertexName :: Text, vertexModuleName :: Text, vertexSpan :: Span }
-  deriving (Eq, Ord, Show, Generic, Hashable, NFData)
+  deriving (Eq, Ord, Show, Generic, Hashable)
 
 packageVertex :: PackageInfo -> ControlFlowVertex
 packageVertex (PackageInfo name _) = Package (formatName name)

--- a/src/Data/ImportPath.hs
+++ b/src/Data/ImportPath.hs
@@ -10,10 +10,10 @@ import qualified Data.Text as T
 import           System.FilePath.Posix
 
 data IsRelative = Unknown | Relative | NonRelative
-  deriving (Bounded, Enum, Eq, Generic, Hashable, Ord, Show, ToJSON, NFData)
+  deriving (Bounded, Enum, Eq, Generic, Hashable, Ord, Show, ToJSON)
 
 data ImportPath = ImportPath { unPath :: FilePath, pathIsRelative :: IsRelative }
-  deriving (Eq, Generic, Hashable, Ord, Show, ToJSON, NFData)
+  deriving (Eq, Generic, Hashable, Ord, Show, ToJSON)
 
 -- TODO: fix the duplication present in this and Python
 importPath :: Text -> ImportPath

--- a/src/Data/JSON/Fields.hs
+++ b/src/Data/JSON/Fields.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DefaultSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances, GADTs #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-} -- FIXME
 module Data.JSON.Fields
   ( JSONFields (..)
   , JSONFields1 (..)

--- a/src/Data/Language.hs
+++ b/src/Data/Language.hs
@@ -39,7 +39,7 @@ data Language
     | TypeScript
     | PHP
     | TSX
-    deriving (Eq, Generic, Ord, Read, Show, Bounded, Hashable, ToJSON, Enum, NFData)
+    deriving (Eq, Generic, Ord, Read, Show, Bounded, Hashable, ToJSON, Enum)
 
 class SLanguage (lang :: Language) where
   reflect :: proxy lang -> Language

--- a/src/Data/Map/Monoidal.hs
+++ b/src/Data/Map/Monoidal.hs
@@ -22,7 +22,7 @@ import Prelude hiding (lookup)
 import Prologue hiding (Map, empty)
 
 newtype Map key value = Map { unMap :: Map.Map key value }
-  deriving (Eq, Eq1, Eq2, Foldable, Functor, Ord, Ord1, Ord2, Show, Show1, Show2, ToJSON, Traversable, NFData, Lower)
+  deriving (Eq, Eq1, Eq2, Foldable, Functor, Ord, Ord1, Ord2, Show, Show1, Show2, ToJSON, Traversable, Lower)
 
 
 singleton :: key -> value -> Map key value

--- a/src/Data/Quieterm.hs
+++ b/src/Data/Quieterm.hs
@@ -5,7 +5,6 @@ module Data.Quieterm
 ) where
 
 import Control.Lens
-import Control.DeepSeq
 import Data.Abstract.Declarations (Declarations)
 import Data.Abstract.FreeVariables (FreeVariables)
 import Data.Functor.Classes
@@ -38,12 +37,6 @@ instance Show1 syntax => Show1 (Quieterm syntax) where
 
 instance Show1 syntax => Show (Quieterm syntax ann) where
   showsPrec = liftShowsPrec (const (const id)) (const id)
-
-instance NFData1 f => NFData1 (Quieterm f) where
-  liftRnf rnf = go where go x = liftRnf2 rnf go (unQuieterm x)
-
-instance (NFData1 f, NFData a) => NFData (Quieterm f a) where
-  rnf = liftRnf rnf
 
 instance HasSpan ann => HasSpan (Quieterm syntax ann) where
   span_ = lens (view span_ . unQuieterm) (\(Quieterm i) s -> Quieterm (set span_ s i))

--- a/src/Data/Syntax.hs
+++ b/src/Data/Syntax.hs
@@ -115,7 +115,6 @@ instance (Element f all, c f, Generate c all fs) => Generate c all (f ': fs) whe
 
 -- | An identifier of some other construct, whether a containing declaration (e.g. a class name) or a reference (e.g. a variable).
 newtype Identifier a = Identifier { name :: Name }
-  deriving newtype (Eq, Ord, Show)
   deriving stock (Foldable, Functor, Generic1, Traversable)
   deriving anyclass (Diffable, Hashable1, ToJSONFields1, NFData1)
 
@@ -143,7 +142,6 @@ instance Declarations1 Identifier where
 
 -- | An accessibility modifier, e.g. private, public, protected, etc.
 newtype AccessibilityModifier a = AccessibilityModifier { contents :: Text }
-  deriving newtype (Eq, Ord, Show)
   deriving stock (Foldable, Functor, Generic1, Traversable)
   deriving anyclass (Declarations1, Diffable, FreeVariables1, Hashable1, ToJSONFields1, NFData1)
 
@@ -158,7 +156,7 @@ instance Evaluatable AccessibilityModifier
 --
 --   This can be used to represent an implicit no-op, e.g. the alternative in an 'if' statement without an 'else'.
 data Empty a = Empty
-  deriving (Eq, Ord, Show, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving (Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
 
 instance Eq1 Empty where liftEq = genericLiftEq
 instance Ord1 Empty where liftCompare = genericLiftCompare
@@ -234,7 +232,7 @@ instance (Error :< fs, Apply Foldable fs, Apply Functor fs) => HasErrors (Term (
 
 
 data Context a = Context { contextTerms :: NonEmpty a, contextSubject :: a }
-  deriving (Eq, Foldable, FreeVariables1, Functor, Generic1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Foldable, FreeVariables1, Functor, Generic1, ToJSONFields1, Traversable, NFData1)
 
 instance Eq1 Context where liftEq = genericLiftEq
 instance Ord1 Context where liftCompare = genericLiftCompare

--- a/src/Data/Syntax.hs
+++ b/src/Data/Syntax.hs
@@ -154,7 +154,7 @@ instance Evaluatable AccessibilityModifier
 --
 --   This can be used to represent an implicit no-op, e.g. the alternative in an 'if' statement without an 'else'.
 data Empty a = Empty
-  deriving (Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
 
 instance Eq1 Empty where liftEq = genericLiftEq
 instance Ord1 Empty where liftCompare = genericLiftCompare
@@ -165,7 +165,7 @@ instance Evaluatable Empty where
 
 -- | Syntax representing a parsing or assignment error.
 data Error a = Error { errorCallStack :: ErrorStack, errorExpected :: [String], errorActual :: Maybe String, errorChildren :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
 
 instance Eq1 Error where liftEq = genericLiftEq
 instance Ord1 Error where liftCompare = genericLiftCompare
@@ -229,7 +229,7 @@ instance (Error :< fs, Apply Foldable fs, Apply Functor fs) => HasErrors (Term (
 
 
 data Context a = Context { contextTerms :: NonEmpty a, contextSubject :: a }
-  deriving (Foldable, FreeVariables1, Functor, Generic1, ToJSONFields1, Traversable, NFData1)
+  deriving (Foldable, FreeVariables1, Functor, Generic1, NFData1, ToJSONFields1, Traversable)
 
 instance Eq1 Context where liftEq = genericLiftEq
 instance Ord1 Context where liftCompare = genericLiftCompare

--- a/src/Data/Syntax.hs
+++ b/src/Data/Syntax.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE AllowAmbiguousTypes, ConstraintKinds, DeriveAnyClass, GADTs, KindSignatures, MultiParamTypeClasses, RankNTypes, ScopedTypeVariables, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes, ConstraintKinds, DeriveAnyClass, RankNTypes, ScopedTypeVariables, TypeFamilies, TypeOperators, UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-missing-export-lists -Wno-redundant-constraints #-} -- For HasCallStack
 module Data.Syntax where
 

--- a/src/Data/Syntax.hs
+++ b/src/Data/Syntax.hs
@@ -118,7 +118,10 @@ newtype Identifier a = Identifier { name :: Name }
   deriving newtype (Eq, Ord, Show)
   deriving stock (Foldable, Functor, Generic1, Traversable)
   deriving anyclass (Diffable, Hashable1, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Identifier
+
+instance Eq1 Identifier where liftEq = genericLiftEq
+instance Ord1 Identifier where liftCompare = genericLiftCompare
+instance Show1 Identifier where liftShowsPrec = genericLiftShowsPrec
 
 
 instance Evaluatable Identifier where
@@ -143,7 +146,10 @@ newtype AccessibilityModifier a = AccessibilityModifier { contents :: Text }
   deriving newtype (Eq, Ord, Show)
   deriving stock (Foldable, Functor, Generic1, Traversable)
   deriving anyclass (Declarations1, Diffable, FreeVariables1, Hashable1, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically AccessibilityModifier
+
+instance Eq1 AccessibilityModifier where liftEq = genericLiftEq
+instance Ord1 AccessibilityModifier where liftCompare = genericLiftCompare
+instance Show1 AccessibilityModifier where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for AccessibilityModifier
 instance Evaluatable AccessibilityModifier
@@ -153,7 +159,10 @@ instance Evaluatable AccessibilityModifier
 --   This can be used to represent an implicit no-op, e.g. the alternative in an 'if' statement without an 'else'.
 data Empty a = Empty
   deriving (Eq, Ord, Show, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Empty
+
+instance Eq1 Empty where liftEq = genericLiftEq
+instance Ord1 Empty where liftCompare = genericLiftCompare
+instance Show1 Empty where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Empty where
   eval _ _ _ = unit
@@ -161,7 +170,10 @@ instance Evaluatable Empty where
 -- | Syntax representing a parsing or assignment error.
 data Error a = Error { errorCallStack :: ErrorStack, errorExpected :: [String], errorActual :: Maybe String, errorChildren :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Error
+
+instance Eq1 Error where liftEq = genericLiftEq
+instance Ord1 Error where liftCompare = genericLiftCompare
+instance Show1 Error where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Error
 
@@ -223,7 +235,10 @@ instance (Error :< fs, Apply Foldable fs, Apply Functor fs) => HasErrors (Term (
 
 data Context a = Context { contextTerms :: NonEmpty a, contextSubject :: a }
   deriving (Eq, Foldable, FreeVariables1, Functor, Generic1, Ord, Show, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Context
+
+instance Eq1 Context where liftEq = genericLiftEq
+instance Ord1 Context where liftCompare = genericLiftCompare
+instance Show1 Context where liftShowsPrec = genericLiftShowsPrec
 
 instance Diffable Context where
   subalgorithmFor blur focus (Context n s) = Context <$> traverse blur n <*> focus s

--- a/src/Data/Syntax.hs
+++ b/src/Data/Syntax.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE AllowAmbiguousTypes, DeriveAnyClass, GADTs, TypeOperators, MultiParamTypeClasses, UndecidableInstances, ScopedTypeVariables, KindSignatures, RankNTypes, ConstraintKinds #-}
+{-# LANGUAGE AllowAmbiguousTypes, ConstraintKinds, DeriveAnyClass, GADTs, KindSignatures, MultiParamTypeClasses, RankNTypes, ScopedTypeVariables, TypeOperators, UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-missing-export-lists -Wno-redundant-constraints #-} -- For HasCallStack
 module Data.Syntax where
 

--- a/src/Data/Syntax.hs
+++ b/src/Data/Syntax.hs
@@ -115,7 +115,7 @@ instance (Element f all, c f, Generate c all fs) => Generate c all (f ': fs) whe
 
 -- | An identifier of some other construct, whether a containing declaration (e.g. a class name) or a reference (e.g. a variable).
 newtype Identifier a = Identifier { name :: Name }
-  deriving (Diffable, Foldable, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Diffable, Foldable, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Identifier where liftEq = genericLiftEq
 instance Ord1 Identifier where liftCompare = genericLiftCompare
@@ -141,7 +141,7 @@ instance Declarations1 Identifier where
 
 -- | An accessibility modifier, e.g. private, public, protected, etc.
 newtype AccessibilityModifier a = AccessibilityModifier { contents :: Text }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 AccessibilityModifier where liftEq = genericLiftEq
 instance Ord1 AccessibilityModifier where liftCompare = genericLiftCompare
@@ -154,7 +154,7 @@ instance Evaluatable AccessibilityModifier
 --
 --   This can be used to represent an implicit no-op, e.g. the alternative in an 'if' statement without an 'else'.
 data Empty a = Empty
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Empty where liftEq = genericLiftEq
 instance Ord1 Empty where liftCompare = genericLiftCompare
@@ -165,7 +165,7 @@ instance Evaluatable Empty where
 
 -- | Syntax representing a parsing or assignment error.
 data Error a = Error { errorCallStack :: ErrorStack, errorExpected :: [String], errorActual :: Maybe String, errorChildren :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Error where liftEq = genericLiftEq
 instance Ord1 Error where liftCompare = genericLiftCompare
@@ -181,7 +181,7 @@ unError span Error{..} = Error.Error span errorExpected errorActual stack
   where stack = fromCallSiteList $ unErrorSite <$> unErrorStack errorCallStack
 
 data ErrorSite = ErrorSite { errorMessage :: String, errorLocation :: SrcLoc }
-  deriving (Eq, Show, Generic, NFData)
+  deriving (Eq, Show, Generic)
 
 errorSite :: (String, SrcLoc) -> ErrorSite
 errorSite = uncurry ErrorSite
@@ -190,7 +190,7 @@ unErrorSite :: ErrorSite -> (String, SrcLoc)
 unErrorSite ErrorSite{..} = (errorMessage, errorLocation)
 
 newtype ErrorStack = ErrorStack { unErrorStack :: [ErrorSite] }
-  deriving (Eq, Show, Generic, NFData)
+  deriving (Eq, Show, Generic)
 
 instance ToJSON ErrorStack where
   toJSON (ErrorStack es) = toJSON (jSite <$> es) where
@@ -229,7 +229,7 @@ instance (Error :< fs, Apply Foldable fs, Apply Functor fs) => HasErrors (Term (
 
 
 data Context a = Context { contextTerms :: NonEmpty a, contextSubject :: a }
-  deriving (Foldable, FreeVariables1, Functor, Generic1, NFData1, ToJSONFields1, Traversable)
+  deriving (Foldable, FreeVariables1, Functor, Generic1, ToJSONFields1, Traversable)
 
 instance Eq1 Context where liftEq = genericLiftEq
 instance Ord1 Context where liftCompare = genericLiftCompare

--- a/src/Data/Syntax.hs
+++ b/src/Data/Syntax.hs
@@ -160,7 +160,7 @@ instance Evaluatable Empty where
 
 -- | Syntax representing a parsing or assignment error.
 data Error a = Error { errorCallStack :: ErrorStack, errorExpected :: [String], errorActual :: Maybe String, errorChildren :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Error
 
 instance Evaluatable Error

--- a/src/Data/Syntax.hs
+++ b/src/Data/Syntax.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE AllowAmbiguousTypes, DeriveAnyClass, DerivingVia, GADTs, TypeOperators, MultiParamTypeClasses, UndecidableInstances, ScopedTypeVariables, KindSignatures, RankNTypes, ConstraintKinds, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE AllowAmbiguousTypes, DeriveAnyClass, GADTs, TypeOperators, MultiParamTypeClasses, UndecidableInstances, ScopedTypeVariables, KindSignatures, RankNTypes, ConstraintKinds #-}
 {-# OPTIONS_GHC -Wno-missing-export-lists -Wno-redundant-constraints #-} -- For HasCallStack
 module Data.Syntax where
 
@@ -115,8 +115,7 @@ instance (Element f all, c f, Generate c all fs) => Generate c all (f ': fs) whe
 
 -- | An identifier of some other construct, whether a containing declaration (e.g. a class name) or a reference (e.g. a variable).
 newtype Identifier a = Identifier { name :: Name }
-  deriving stock (Foldable, Functor, Generic1, Traversable)
-  deriving anyclass (Diffable, Hashable1, ToJSONFields1, NFData1)
+  deriving (Diffable, Foldable, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
 
 instance Eq1 Identifier where liftEq = genericLiftEq
 instance Ord1 Identifier where liftCompare = genericLiftCompare
@@ -142,8 +141,7 @@ instance Declarations1 Identifier where
 
 -- | An accessibility modifier, e.g. private, public, protected, etc.
 newtype AccessibilityModifier a = AccessibilityModifier { contents :: Text }
-  deriving stock (Foldable, Functor, Generic1, Traversable)
-  deriving anyclass (Declarations1, Diffable, FreeVariables1, Hashable1, ToJSONFields1, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
 
 instance Eq1 AccessibilityModifier where liftEq = genericLiftEq
 instance Ord1 AccessibilityModifier where liftCompare = genericLiftCompare
@@ -192,8 +190,7 @@ unErrorSite :: ErrorSite -> (String, SrcLoc)
 unErrorSite ErrorSite{..} = (errorMessage, errorLocation)
 
 newtype ErrorStack = ErrorStack { unErrorStack :: [ErrorSite] }
-  deriving stock (Eq, Show, Generic)
-  deriving anyclass (NFData)
+  deriving (Eq, Show, Generic, NFData)
 
 instance ToJSON ErrorStack where
   toJSON (ErrorStack es) = toJSON (jSite <$> es) where

--- a/src/Data/Syntax/Comment.hs
+++ b/src/Data/Syntax/Comment.hs
@@ -10,7 +10,7 @@ import Diffing.Algorithm
 
 -- | An unnested comment (line or block).
 newtype Comment a = Comment { commentContent :: Text }
-  deriving (Diffable, Eq, Foldable, Functor, Generic1, Hashable1, Ord, Show, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Comment
 
 instance Evaluatable Comment where
@@ -23,7 +23,7 @@ instance Evaluatable Comment where
 
 -- | HashBang line (e.g. `#!/usr/bin/env node`)
 newtype HashBang a = HashBang { value :: Text }
-  deriving (Diffable, Eq, Foldable, Functor, Generic1, Hashable1, Ord, Show, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically HashBang
 
 -- TODO: Implement Eval instance for HashBang

--- a/src/Data/Syntax/Comment.hs
+++ b/src/Data/Syntax/Comment.hs
@@ -11,7 +11,10 @@ import Diffing.Algorithm
 -- | An unnested comment (line or block).
 newtype Comment a = Comment { commentContent :: Text }
   deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Comment
+
+instance Eq1 Comment where liftEq = genericLiftEq
+instance Ord1 Comment where liftCompare = genericLiftCompare
+instance Show1 Comment where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Comment where
   eval _ _ _ = unit
@@ -24,7 +27,10 @@ instance Evaluatable Comment where
 -- | HashBang line (e.g. `#!/usr/bin/env node`)
 newtype HashBang a = HashBang { value :: Text }
   deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically HashBang
+
+instance Eq1 HashBang where liftEq = genericLiftEq
+instance Ord1 HashBang where liftCompare = genericLiftCompare
+instance Show1 HashBang where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for HashBang
 instance Evaluatable HashBang

--- a/src/Data/Syntax/Comment.hs
+++ b/src/Data/Syntax/Comment.hs
@@ -10,7 +10,7 @@ import Diffing.Algorithm
 
 -- | An unnested comment (line or block).
 newtype Comment a = Comment { commentContent :: Text }
-  deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1)
 
 instance Eq1 Comment where liftEq = genericLiftEq
 instance Ord1 Comment where liftCompare = genericLiftCompare
@@ -26,7 +26,7 @@ instance Evaluatable Comment where
 
 -- | HashBang line (e.g. `#!/usr/bin/env node`)
 newtype HashBang a = HashBang { value :: Text }
-  deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1)
 
 instance Eq1 HashBang where liftEq = genericLiftEq
 instance Ord1 HashBang where liftCompare = genericLiftCompare

--- a/src/Data/Syntax/Declaration.hs
+++ b/src/Data/Syntax/Declaration.hs
@@ -17,7 +17,7 @@ import           Diffing.Algorithm
 import           Source.Span
 
 data Function a = Function { functionContext :: ![a], functionName :: !a, functionParameters :: ![a], functionBody :: !a }
-  deriving (Foldable, Traversable, Functor, Generic1, Hashable1, ToJSONFields1, NFData1)
+  deriving (Foldable, Traversable, Functor, Generic1, Hashable1, ToJSONFields1)
 
 instance Eq1 Function where liftEq = genericLiftEq
 instance Ord1 Function where liftCompare = genericLiftCompare
@@ -75,7 +75,7 @@ data Method a = Method
   , methodBody :: a
   , methodAccessControl :: ScopeGraph.AccessControl
   }
-  deriving (Foldable, Traversable, Functor, Generic1, Hashable1, ToJSONFields1, NFData1)
+  deriving (Foldable, Traversable, Functor, Generic1, Hashable1, ToJSONFields1)
 
 instance Eq1 Method where liftEq = genericLiftEq
 instance Ord1 Method where liftCompare = genericLiftCompare
@@ -114,7 +114,7 @@ data MethodSignature a = MethodSignature
   , methodSignatureParameters :: [a]
   , methodSignatureAccessControl :: ScopeGraph.AccessControl
   }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 MethodSignature where liftEq = genericLiftEq
 instance Ord1 MethodSignature where liftCompare = genericLiftCompare
@@ -125,7 +125,7 @@ instance Evaluatable MethodSignature
 
 
 newtype RequiredParameter a = RequiredParameter { requiredParameter :: a }
-  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 RequiredParameter where liftEq = genericLiftEq
 instance Ord1 RequiredParameter where liftCompare = genericLiftCompare
@@ -143,7 +143,7 @@ instance Evaluatable RequiredParameter where
 
 
 newtype OptionalParameter a = OptionalParameter { optionalParameter :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 OptionalParameter where liftEq = genericLiftEq
 instance Ord1 OptionalParameter where liftCompare = genericLiftCompare
@@ -158,7 +158,7 @@ instance Evaluatable OptionalParameter
 -- TODO: It would be really nice to have a more meaningful type contained in here than [a]
 -- | A declaration of possibly many variables such as var foo = 5, bar = 6 in JavaScript.
 newtype VariableDeclaration a = VariableDeclaration { variableDeclarations :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 VariableDeclaration where liftEq = genericLiftEq
 instance Ord1 VariableDeclaration where liftCompare = genericLiftCompare
@@ -181,7 +181,7 @@ instance Declarations a => Declarations (VariableDeclaration a) where
 -- | A TypeScript/Java style interface declaration to implement.
 
 data InterfaceDeclaration a = InterfaceDeclaration { interfaceDeclarationContext :: ![a], interfaceDeclarationIdentifier :: !a, interfaceDeclarationSuperInterfaces :: ![a], interfaceDeclarationBody :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 InterfaceDeclaration where liftEq = genericLiftEq
 instance Ord1 InterfaceDeclaration where liftCompare = genericLiftCompare
@@ -201,7 +201,7 @@ data PublicFieldDefinition a = PublicFieldDefinition
   , publicFieldValue :: a
   , publicFieldAccessControl :: ScopeGraph.AccessControl
   }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 PublicFieldDefinition where liftEq = genericLiftEq
 instance Ord1 PublicFieldDefinition where liftCompare = genericLiftCompare
@@ -218,7 +218,7 @@ instance Evaluatable PublicFieldDefinition where
     unit
 
 data Variable a = Variable { variableName :: !a, variableType :: !a, variableValue :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Variable where liftEq = genericLiftEq
 instance Ord1 Variable where liftCompare = genericLiftCompare
@@ -228,7 +228,7 @@ instance Show1 Variable where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Variable
 
 data Class a = Class { classContext :: ![a], classIdentifier :: !a, classSuperclasses :: ![a], classBody :: !a }
-  deriving (Foldable, Traversable, Functor, Generic1, Hashable1, FreeVariables1, ToJSONFields1, NFData1)
+  deriving (Foldable, Traversable, Functor, Generic1, Hashable1, FreeVariables1, ToJSONFields1)
 
 instance Eq1 Class where liftEq = genericLiftEq
 instance Ord1 Class where liftCompare = genericLiftCompare
@@ -276,7 +276,7 @@ instance Declarations1 Class where
 
 -- | A decorator in Python
 data Decorator a = Decorator { decoratorIdentifier :: !a, decoratorParamaters :: ![a], decoratorBody :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Decorator where liftEq = genericLiftEq
 instance Ord1 Decorator where liftCompare = genericLiftCompare
@@ -290,7 +290,7 @@ instance Evaluatable Decorator
 
 -- | An ADT, i.e. a disjoint sum of products, like 'data' in Haskell, or 'enum' in Rust or Swift.
 data Datatype a = Datatype { datatypeContext :: a, datatypeName :: a, datatypeConstructors :: [a], datatypeDeriving :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Datatype where liftEq = genericLiftEq
 instance Ord1 Datatype where liftCompare = genericLiftCompare
@@ -302,7 +302,7 @@ instance Evaluatable Data.Syntax.Declaration.Datatype
 
 -- | A single constructor in a datatype, or equally a 'struct' in C, Rust, or Swift.
 data Constructor a = Constructor { constructorContext :: [a], constructorName :: a, constructorFields :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Constructor where liftEq = genericLiftEq
 instance Ord1 Constructor where liftCompare = genericLiftCompare
@@ -314,7 +314,7 @@ instance Evaluatable Data.Syntax.Declaration.Constructor
 
 -- | Comprehension (e.g. ((a for b in c if a()) in Python)
 data Comprehension a = Comprehension { comprehensionValue :: !a, comprehensionBody :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Comprehension where liftEq = genericLiftEq
 instance Ord1 Comprehension where liftCompare = genericLiftCompare
@@ -326,7 +326,7 @@ instance Evaluatable Comprehension
 
 -- | A declared type (e.g. `a []int` in Go).
 data Type a = Type { typeName :: !a, typeKind :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Type where liftEq = genericLiftEq
 instance Ord1 Type where liftCompare = genericLiftCompare
@@ -338,7 +338,7 @@ instance Evaluatable Type
 
 -- | Type alias declarations in Javascript/Haskell, etc.
 data TypeAlias a = TypeAlias { typeAliasContext :: ![a], typeAliasIdentifier :: !a, typeAliasKind :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 TypeAlias where liftEq = genericLiftEq
 instance Ord1 TypeAlias where liftCompare = genericLiftCompare

--- a/src/Data/Syntax/Declaration.hs
+++ b/src/Data/Syntax/Declaration.hs
@@ -18,7 +18,10 @@ import           Source.Span
 
 data Function a = Function { functionContext :: ![a], functionName :: !a, functionParameters :: ![a], functionBody :: !a }
   deriving (Foldable, Traversable, Functor, Generic1, Hashable1, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Function
+
+instance Eq1 Function where liftEq = genericLiftEq
+instance Ord1 Function where liftCompare = genericLiftCompare
+instance Show1 Function where liftShowsPrec = genericLiftShowsPrec
 
 instance Diffable Function where
   equivalentBySubterm = Just . functionName
@@ -73,7 +76,10 @@ data Method a = Method
   , methodAccessControl :: ScopeGraph.AccessControl
   }
   deriving (Foldable, Traversable, Functor, Generic1, Hashable1, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Method
+
+instance Eq1 Method where liftEq = genericLiftEq
+instance Ord1 Method where liftCompare = genericLiftCompare
+instance Show1 Method where liftShowsPrec = genericLiftShowsPrec
 
 instance Diffable Method where
   equivalentBySubterm = Just . methodName
@@ -109,7 +115,10 @@ data MethodSignature a = MethodSignature
   , methodSignatureAccessControl :: ScopeGraph.AccessControl
   }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically MethodSignature
+
+instance Eq1 MethodSignature where liftEq = genericLiftEq
+instance Ord1 MethodSignature where liftCompare = genericLiftCompare
+instance Show1 MethodSignature where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for MethodSignature
 instance Evaluatable MethodSignature
@@ -117,7 +126,10 @@ instance Evaluatable MethodSignature
 
 newtype RequiredParameter a = RequiredParameter { requiredParameter :: a }
   deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically RequiredParameter
+
+instance Eq1 RequiredParameter where liftEq = genericLiftEq
+instance Ord1 RequiredParameter where liftCompare = genericLiftCompare
+instance Show1 RequiredParameter where liftShowsPrec = genericLiftShowsPrec
 
 instance Declarations1 RequiredParameter where
   liftDeclaredName declaredName = declaredName . requiredParameter
@@ -132,7 +144,10 @@ instance Evaluatable RequiredParameter where
 
 newtype OptionalParameter a = OptionalParameter { optionalParameter :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically OptionalParameter
+
+instance Eq1 OptionalParameter where liftEq = genericLiftEq
+instance Ord1 OptionalParameter where liftCompare = genericLiftCompare
+instance Show1 OptionalParameter where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for OptionalParameter
 instance Evaluatable OptionalParameter
@@ -144,7 +159,10 @@ instance Evaluatable OptionalParameter
 -- | A declaration of possibly many variables such as var foo = 5, bar = 6 in JavaScript.
 newtype VariableDeclaration a = VariableDeclaration { variableDeclarations :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically VariableDeclaration
+
+instance Eq1 VariableDeclaration where liftEq = genericLiftEq
+instance Ord1 VariableDeclaration where liftCompare = genericLiftCompare
+instance Show1 VariableDeclaration where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable VariableDeclaration where
   eval _    _ (VariableDeclaration [])   = unit
@@ -164,7 +182,10 @@ instance Declarations a => Declarations (VariableDeclaration a) where
 
 data InterfaceDeclaration a = InterfaceDeclaration { interfaceDeclarationContext :: ![a], interfaceDeclarationIdentifier :: !a, interfaceDeclarationSuperInterfaces :: ![a], interfaceDeclarationBody :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically InterfaceDeclaration
+
+instance Eq1 InterfaceDeclaration where liftEq = genericLiftEq
+instance Ord1 InterfaceDeclaration where liftCompare = genericLiftCompare
+instance Show1 InterfaceDeclaration where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for InterfaceDeclaration
 instance Evaluatable InterfaceDeclaration
@@ -181,7 +202,10 @@ data PublicFieldDefinition a = PublicFieldDefinition
   , publicFieldAccessControl :: ScopeGraph.AccessControl
   }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically PublicFieldDefinition
+
+instance Eq1 PublicFieldDefinition where liftEq = genericLiftEq
+instance Ord1 PublicFieldDefinition where liftCompare = genericLiftCompare
+instance Show1 PublicFieldDefinition where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for PublicFieldDefinition
 instance Evaluatable PublicFieldDefinition where
@@ -195,14 +219,20 @@ instance Evaluatable PublicFieldDefinition where
 
 data Variable a = Variable { variableName :: !a, variableType :: !a, variableValue :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Variable
+
+instance Eq1 Variable where liftEq = genericLiftEq
+instance Ord1 Variable where liftCompare = genericLiftCompare
+instance Show1 Variable where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Variable
 instance Evaluatable Variable
 
 data Class a = Class { classContext :: ![a], classIdentifier :: !a, classSuperclasses :: ![a], classBody :: !a }
   deriving (Foldable, Traversable, Functor, Generic1, Hashable1, FreeVariables1, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Class
+
+instance Eq1 Class where liftEq = genericLiftEq
+instance Ord1 Class where liftCompare = genericLiftCompare
+instance Show1 Class where liftShowsPrec = genericLiftShowsPrec
 
 instance Declarations a => Declarations (Class a) where
   declaredName (Class _ name _ _) = declaredName name
@@ -247,7 +277,10 @@ instance Declarations1 Class where
 -- | A decorator in Python
 data Decorator a = Decorator { decoratorIdentifier :: !a, decoratorParamaters :: ![a], decoratorBody :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Decorator
+
+instance Eq1 Decorator where liftEq = genericLiftEq
+instance Ord1 Decorator where liftCompare = genericLiftCompare
+instance Show1 Decorator where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Decorator
 instance Evaluatable Decorator
@@ -258,7 +291,10 @@ instance Evaluatable Decorator
 -- | An ADT, i.e. a disjoint sum of products, like 'data' in Haskell, or 'enum' in Rust or Swift.
 data Datatype a = Datatype { datatypeContext :: a, datatypeName :: a, datatypeConstructors :: [a], datatypeDeriving :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Datatype
+
+instance Eq1 Datatype where liftEq = genericLiftEq
+instance Ord1 Datatype where liftCompare = genericLiftCompare
+instance Show1 Datatype where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Datatype
 instance Evaluatable Data.Syntax.Declaration.Datatype
@@ -267,7 +303,10 @@ instance Evaluatable Data.Syntax.Declaration.Datatype
 -- | A single constructor in a datatype, or equally a 'struct' in C, Rust, or Swift.
 data Constructor a = Constructor { constructorContext :: [a], constructorName :: a, constructorFields :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Constructor
+
+instance Eq1 Constructor where liftEq = genericLiftEq
+instance Ord1 Constructor where liftCompare = genericLiftCompare
+instance Show1 Constructor where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Constructor
 instance Evaluatable Data.Syntax.Declaration.Constructor
@@ -276,7 +315,10 @@ instance Evaluatable Data.Syntax.Declaration.Constructor
 -- | Comprehension (e.g. ((a for b in c if a()) in Python)
 data Comprehension a = Comprehension { comprehensionValue :: !a, comprehensionBody :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Comprehension
+
+instance Eq1 Comprehension where liftEq = genericLiftEq
+instance Ord1 Comprehension where liftCompare = genericLiftCompare
+instance Show1 Comprehension where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Comprehension
 instance Evaluatable Comprehension
@@ -285,7 +327,10 @@ instance Evaluatable Comprehension
 -- | A declared type (e.g. `a []int` in Go).
 data Type a = Type { typeName :: !a, typeKind :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Type
+
+instance Eq1 Type where liftEq = genericLiftEq
+instance Ord1 Type where liftCompare = genericLiftCompare
+instance Show1 Type where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Type
 instance Evaluatable Type
@@ -294,7 +339,10 @@ instance Evaluatable Type
 -- | Type alias declarations in Javascript/Haskell, etc.
 data TypeAlias a = TypeAlias { typeAliasContext :: ![a], typeAliasIdentifier :: !a, typeAliasKind :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically TypeAlias
+
+instance Eq1 TypeAlias where liftEq = genericLiftEq
+instance Ord1 TypeAlias where liftCompare = genericLiftCompare
+instance Show1 TypeAlias where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable TypeAlias where
   eval _ _ TypeAlias{..} = do

--- a/src/Data/Syntax/Declaration.hs
+++ b/src/Data/Syntax/Declaration.hs
@@ -17,7 +17,7 @@ import           Diffing.Algorithm
 import           Source.Span
 
 data Function a = Function { functionContext :: ![a], functionName :: !a, functionParameters :: ![a], functionBody :: !a }
-  deriving (Eq, Ord, Show, Foldable, Traversable, Functor, Generic1, Hashable1, ToJSONFields1, NFData1)
+  deriving (Foldable, Traversable, Functor, Generic1, Hashable1, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Function
 
 instance Diffable Function where
@@ -72,7 +72,7 @@ data Method a = Method
   , methodBody :: a
   , methodAccessControl :: ScopeGraph.AccessControl
   }
-  deriving (Eq, Ord, Show, Foldable, Traversable, Functor, Generic1, Hashable1, ToJSONFields1, NFData1)
+  deriving (Foldable, Traversable, Functor, Generic1, Hashable1, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Method
 
 instance Diffable Method where
@@ -108,7 +108,7 @@ data MethodSignature a = MethodSignature
   , methodSignatureParameters :: [a]
   , methodSignatureAccessControl :: ScopeGraph.AccessControl
   }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically MethodSignature
 
 -- TODO: Implement Eval instance for MethodSignature
@@ -116,7 +116,7 @@ instance Evaluatable MethodSignature
 
 
 newtype RequiredParameter a = RequiredParameter { requiredParameter :: a }
-  deriving (Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically RequiredParameter
 
 instance Declarations1 RequiredParameter where
@@ -131,7 +131,7 @@ instance Evaluatable RequiredParameter where
 
 
 newtype OptionalParameter a = OptionalParameter { optionalParameter :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically OptionalParameter
 
 -- TODO: Implement Eval instance for OptionalParameter
@@ -143,7 +143,7 @@ instance Evaluatable OptionalParameter
 -- TODO: It would be really nice to have a more meaningful type contained in here than [a]
 -- | A declaration of possibly many variables such as var foo = 5, bar = 6 in JavaScript.
 newtype VariableDeclaration a = VariableDeclaration { variableDeclarations :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically VariableDeclaration
 
 instance Evaluatable VariableDeclaration where
@@ -163,7 +163,7 @@ instance Declarations a => Declarations (VariableDeclaration a) where
 -- | A TypeScript/Java style interface declaration to implement.
 
 data InterfaceDeclaration a = InterfaceDeclaration { interfaceDeclarationContext :: ![a], interfaceDeclarationIdentifier :: !a, interfaceDeclarationSuperInterfaces :: ![a], interfaceDeclarationBody :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically InterfaceDeclaration
 
 -- TODO: Implement Eval instance for InterfaceDeclaration
@@ -180,7 +180,7 @@ data PublicFieldDefinition a = PublicFieldDefinition
   , publicFieldValue :: a
   , publicFieldAccessControl :: ScopeGraph.AccessControl
   }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically PublicFieldDefinition
 
 -- TODO: Implement Eval instance for PublicFieldDefinition
@@ -194,14 +194,14 @@ instance Evaluatable PublicFieldDefinition where
     unit
 
 data Variable a = Variable { variableName :: !a, variableType :: !a, variableValue :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Variable
 
 -- TODO: Implement Eval instance for Variable
 instance Evaluatable Variable
 
 data Class a = Class { classContext :: ![a], classIdentifier :: !a, classSuperclasses :: ![a], classBody :: !a }
-  deriving (Eq, Ord, Show, Foldable, Traversable, Functor, Generic1, Hashable1, FreeVariables1, ToJSONFields1, NFData1)
+  deriving (Foldable, Traversable, Functor, Generic1, Hashable1, FreeVariables1, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Class
 
 instance Declarations a => Declarations (Class a) where
@@ -246,7 +246,7 @@ instance Declarations1 Class where
 
 -- | A decorator in Python
 data Decorator a = Decorator { decoratorIdentifier :: !a, decoratorParamaters :: ![a], decoratorBody :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Decorator
 
 -- TODO: Implement Eval instance for Decorator
@@ -257,7 +257,7 @@ instance Evaluatable Decorator
 
 -- | An ADT, i.e. a disjoint sum of products, like 'data' in Haskell, or 'enum' in Rust or Swift.
 data Datatype a = Datatype { datatypeContext :: a, datatypeName :: a, datatypeConstructors :: [a], datatypeDeriving :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Datatype
 
 -- TODO: Implement Eval instance for Datatype
@@ -266,7 +266,7 @@ instance Evaluatable Data.Syntax.Declaration.Datatype
 
 -- | A single constructor in a datatype, or equally a 'struct' in C, Rust, or Swift.
 data Constructor a = Constructor { constructorContext :: [a], constructorName :: a, constructorFields :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Constructor
 
 -- TODO: Implement Eval instance for Constructor
@@ -275,7 +275,7 @@ instance Evaluatable Data.Syntax.Declaration.Constructor
 
 -- | Comprehension (e.g. ((a for b in c if a()) in Python)
 data Comprehension a = Comprehension { comprehensionValue :: !a, comprehensionBody :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Comprehension
 
 -- TODO: Implement Eval instance for Comprehension
@@ -284,7 +284,7 @@ instance Evaluatable Comprehension
 
 -- | A declared type (e.g. `a []int` in Go).
 data Type a = Type { typeName :: !a, typeKind :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Type
 
 -- TODO: Implement Eval instance for Type
@@ -293,7 +293,7 @@ instance Evaluatable Type
 
 -- | Type alias declarations in Javascript/Haskell, etc.
 data TypeAlias a = TypeAlias { typeAliasContext :: ![a], typeAliasIdentifier :: !a, typeAliasKind :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically TypeAlias
 
 instance Evaluatable TypeAlias where

--- a/src/Data/Syntax/Directive.hs
+++ b/src/Data/Syntax/Directive.hs
@@ -14,7 +14,10 @@ import           Source.Span
 -- A file directive like the Ruby constant `__FILE__`.
 data File a = File
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically File
+
+instance Eq1 File where liftEq = genericLiftEq
+instance Ord1 File where liftCompare = genericLiftCompare
+instance Show1 File where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable File where
   eval _ _ File = currentModule >>= string . T.pack . modulePath
@@ -23,7 +26,10 @@ instance Evaluatable File where
 -- A line directive like the Ruby constant `__LINE__`.
 data Line a = Line
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Line
+
+instance Eq1 Line where liftEq = genericLiftEq
+instance Ord1 Line where liftCompare = genericLiftCompare
+instance Show1 Line where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Line where
   eval _ _ Line = currentSpan >>= integer . fromIntegral . line . start

--- a/src/Data/Syntax/Directive.hs
+++ b/src/Data/Syntax/Directive.hs
@@ -13,7 +13,7 @@ import           Source.Span
 
 -- A file directive like the Ruby constant `__FILE__`.
 data File a = File
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically File
 
 instance Evaluatable File where
@@ -22,7 +22,7 @@ instance Evaluatable File where
 
 -- A line directive like the Ruby constant `__LINE__`.
 data Line a = Line
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Line
 
 instance Evaluatable Line where

--- a/src/Data/Syntax/Directive.hs
+++ b/src/Data/Syntax/Directive.hs
@@ -13,7 +13,7 @@ import           Source.Span
 
 -- A file directive like the Ruby constant `__FILE__`.
 data File a = File
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 File where liftEq = genericLiftEq
 instance Ord1 File where liftCompare = genericLiftCompare
@@ -25,7 +25,7 @@ instance Evaluatable File where
 
 -- A line directive like the Ruby constant `__LINE__`.
 data Line a = Line
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Line where liftEq = genericLiftEq
 instance Ord1 Line where liftCompare = genericLiftCompare

--- a/src/Data/Syntax/Expression.hs
+++ b/src/Data/Syntax/Expression.hs
@@ -19,7 +19,10 @@ import qualified Data.Abstract.ScopeGraph as ScopeGraph
 -- | Typical prefix function application, like `f(x)` in many languages, or `f x` in Haskell.
 data Call a = Call { callContext :: ![a], callFunction :: !a, callParams :: ![a], callBlock :: !a }
   deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Call
+
+instance Eq1 Call where liftEq = genericLiftEq
+instance Ord1 Call where liftCompare = genericLiftCompare
+instance Show1 Call where liftShowsPrec = genericLiftShowsPrec
 
 instance Declarations1 Call where
   liftDeclaredName declaredName Call{..} = declaredName callFunction
@@ -32,7 +35,10 @@ instance Evaluatable Call where
 
 data LessThan a = LessThan { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically LessThan
+
+instance Eq1 LessThan where liftEq = genericLiftEq
+instance Ord1 LessThan where liftCompare = genericLiftCompare
+instance Show1 LessThan where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable LessThan where
   eval eval _ t = traverse eval t >>= go where
@@ -40,7 +46,10 @@ instance Evaluatable LessThan where
 
 data LessThanEqual a = LessThanEqual { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically LessThanEqual
+
+instance Eq1 LessThanEqual where liftEq = genericLiftEq
+instance Ord1 LessThanEqual where liftCompare = genericLiftCompare
+instance Show1 LessThanEqual where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable LessThanEqual where
   eval eval _ t = traverse eval t >>= go where
@@ -48,7 +57,10 @@ instance Evaluatable LessThanEqual where
 
 data GreaterThan a = GreaterThan { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically GreaterThan
+
+instance Eq1 GreaterThan where liftEq = genericLiftEq
+instance Ord1 GreaterThan where liftCompare = genericLiftCompare
+instance Show1 GreaterThan where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable GreaterThan where
   eval eval _ t = traverse eval t >>= go where
@@ -56,7 +68,10 @@ instance Evaluatable GreaterThan where
 
 data GreaterThanEqual a = GreaterThanEqual { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically GreaterThanEqual
+
+instance Eq1 GreaterThanEqual where liftEq = genericLiftEq
+instance Ord1 GreaterThanEqual where liftCompare = genericLiftCompare
+instance Show1 GreaterThanEqual where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable GreaterThanEqual where
   eval eval _ t = traverse eval t >>= go where
@@ -64,7 +79,10 @@ instance Evaluatable GreaterThanEqual where
 
 data Equal a = Equal { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Equal
+
+instance Eq1 Equal where liftEq = genericLiftEq
+instance Ord1 Equal where liftCompare = genericLiftCompare
+instance Show1 Equal where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Equal where
   eval eval _ t = traverse eval t >>= go where
@@ -74,7 +92,10 @@ instance Evaluatable Equal where
 
 data StrictEqual a = StrictEqual { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically StrictEqual
+
+instance Eq1 StrictEqual where liftEq = genericLiftEq
+instance Ord1 StrictEqual where liftCompare = genericLiftCompare
+instance Show1 StrictEqual where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable StrictEqual where
   eval eval _ t = traverse eval t >>= go where
@@ -84,7 +105,10 @@ instance Evaluatable StrictEqual where
 
 data Comparison a = Comparison { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Comparison
+
+instance Eq1 Comparison where liftEq = genericLiftEq
+instance Ord1 Comparison where liftCompare = genericLiftCompare
+instance Show1 Comparison where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Comparison where
   eval eval _ t = traverse eval t >>= go where
@@ -92,7 +116,10 @@ instance Evaluatable Comparison where
 
 data Plus a = Plus { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Plus
+
+instance Eq1 Plus where liftEq = genericLiftEq
+instance Ord1 Plus where liftCompare = genericLiftCompare
+instance Show1 Plus where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Plus where
   eval eval _ t = traverse eval t >>= go where
@@ -100,7 +127,10 @@ instance Evaluatable Plus where
 
 data Minus a = Minus { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Minus
+
+instance Eq1 Minus where liftEq = genericLiftEq
+instance Ord1 Minus where liftCompare = genericLiftCompare
+instance Show1 Minus where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Minus where
   eval eval _ t = traverse eval t >>= go where
@@ -108,7 +138,10 @@ instance Evaluatable Minus where
 
 data Times a = Times { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Times
+
+instance Eq1 Times where liftEq = genericLiftEq
+instance Ord1 Times where liftCompare = genericLiftCompare
+instance Show1 Times where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Times where
   eval eval _ t = traverse eval t >>= go where
@@ -116,7 +149,10 @@ instance Evaluatable Times where
 
 data DividedBy a = DividedBy { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically DividedBy
+
+instance Eq1 DividedBy where liftEq = genericLiftEq
+instance Ord1 DividedBy where liftCompare = genericLiftCompare
+instance Show1 DividedBy where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable DividedBy where
   eval eval _ t = traverse eval t >>= go where
@@ -124,7 +160,10 @@ instance Evaluatable DividedBy where
 
 data Modulo a = Modulo { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Modulo
+
+instance Eq1 Modulo where liftEq = genericLiftEq
+instance Ord1 Modulo where liftCompare = genericLiftCompare
+instance Show1 Modulo where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Modulo where
   eval eval _ t = traverse eval t >>= go where
@@ -132,7 +171,10 @@ instance Evaluatable Modulo where
 
 data Power a = Power { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Power
+
+instance Eq1 Power where liftEq = genericLiftEq
+instance Ord1 Power where liftCompare = genericLiftCompare
+instance Show1 Power where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Power where
   eval eval _ t = traverse eval t >>= go where
@@ -140,7 +182,10 @@ instance Evaluatable Power where
 
 newtype Negate a = Negate { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Negate
+
+instance Eq1 Negate where liftEq = genericLiftEq
+instance Ord1 Negate where liftCompare = genericLiftCompare
+instance Show1 Negate where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Negate where
   eval eval _ t = traverse eval t >>= go where
@@ -148,7 +193,10 @@ instance Evaluatable Negate where
 
 data FloorDivision a = FloorDivision { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically FloorDivision
+
+instance Eq1 FloorDivision where liftEq = genericLiftEq
+instance Ord1 FloorDivision where liftCompare = genericLiftCompare
+instance Show1 FloorDivision where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable FloorDivision where
   eval eval _ t = traverse eval t >>= go where
@@ -157,19 +205,28 @@ instance Evaluatable FloorDivision where
 -- | Regex matching operators (Ruby's =~ and ~!)
 data Matches a = Matches { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Matches
+
+instance Eq1 Matches where liftEq = genericLiftEq
+instance Ord1 Matches where liftCompare = genericLiftCompare
+instance Show1 Matches where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Matches
 
 data NotMatches a = NotMatches { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically NotMatches
+
+instance Eq1 NotMatches where liftEq = genericLiftEq
+instance Ord1 NotMatches where liftCompare = genericLiftCompare
+instance Show1 NotMatches where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable NotMatches
 
 data Or a = Or { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Or
+
+instance Eq1 Or where liftEq = genericLiftEq
+instance Ord1 Or where liftCompare = genericLiftCompare
+instance Show1 Or where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Or where
   eval eval _ (Or a b) = do
@@ -178,7 +235,10 @@ instance Evaluatable Or where
 
 data And a = And { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically And
+
+instance Eq1 And where liftEq = genericLiftEq
+instance Ord1 And where liftCompare = genericLiftCompare
+instance Show1 And where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable And where
   eval eval _ (And a b) = do
@@ -187,14 +247,20 @@ instance Evaluatable And where
 
 newtype Not a = Not { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Not
+
+instance Eq1 Not where liftEq = genericLiftEq
+instance Ord1 Not where liftCompare = genericLiftCompare
+instance Show1 Not where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Not where
   eval eval _ (Not a) = eval a >>= asBool >>= boolean . not
 
 data XOr a = XOr { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically XOr
+
+instance Eq1 XOr where liftEq = genericLiftEq
+instance Ord1 XOr where liftCompare = genericLiftCompare
+instance Show1 XOr where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable XOr where
   -- N.B. we have to use Monad rather than Applicative/Traversable on 'And' and 'Or' so that we don't evaluate both operands
@@ -203,7 +269,10 @@ instance Evaluatable XOr where
 -- | Javascript delete operator
 newtype Delete a = Delete { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Delete
+
+instance Eq1 Delete where liftEq = genericLiftEq
+instance Ord1 Delete where liftCompare = genericLiftCompare
+instance Show1 Delete where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Delete where
   eval _ ref (Delete a) = ref a >>= dealloc >> unit
@@ -211,7 +280,10 @@ instance Evaluatable Delete where
 -- | A sequence expression such as Javascript or C's comma operator.
 data SequenceExpression a = SequenceExpression { firstExpression :: !a, secondExpression :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically SequenceExpression
+
+instance Eq1 SequenceExpression where liftEq = genericLiftEq
+instance Ord1 SequenceExpression where liftCompare = genericLiftCompare
+instance Show1 SequenceExpression where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable SequenceExpression where
   eval eval _ (SequenceExpression a b) =
@@ -220,7 +292,10 @@ instance Evaluatable SequenceExpression where
 -- | Javascript void operator
 newtype Void a = Void { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Void
+
+instance Eq1 Void where liftEq = genericLiftEq
+instance Ord1 Void where liftCompare = genericLiftCompare
+instance Show1 Void where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Void where
   eval eval _ (Void a) =
@@ -229,7 +304,10 @@ instance Evaluatable Void where
 -- | Javascript typeof operator
 newtype Typeof a = Typeof { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Typeof
+
+instance Eq1 Typeof where liftEq = genericLiftEq
+instance Ord1 Typeof where liftCompare = genericLiftCompare
+instance Show1 Typeof where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Typeof
 instance Evaluatable Typeof
@@ -237,7 +315,10 @@ instance Evaluatable Typeof
 -- | Bitwise operators.
 data BOr a = BOr { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically BOr
+
+instance Eq1 BOr where liftEq = genericLiftEq
+instance Ord1 BOr where liftCompare = genericLiftCompare
+instance Show1 BOr where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable BOr where
   eval eval _ (BOr a b) = do
@@ -247,7 +328,10 @@ instance Evaluatable BOr where
 
 data BAnd a = BAnd { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically BAnd
+
+instance Eq1 BAnd where liftEq = genericLiftEq
+instance Ord1 BAnd where liftCompare = genericLiftCompare
+instance Show1 BAnd where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable BAnd where
   eval eval _ (BAnd a b) = do
@@ -257,7 +341,10 @@ instance Evaluatable BAnd where
 
 data BXOr a = BXOr { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically BXOr
+
+instance Eq1 BXOr where liftEq = genericLiftEq
+instance Ord1 BXOr where liftCompare = genericLiftCompare
+instance Show1 BXOr where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable BXOr where
   eval eval _ (BXOr a b) = do
@@ -267,7 +354,10 @@ instance Evaluatable BXOr where
 
 data LShift a = LShift { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically LShift
+
+instance Eq1 LShift where liftEq = genericLiftEq
+instance Ord1 LShift where liftCompare = genericLiftCompare
+instance Show1 LShift where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable LShift where
   eval eval _ (LShift a b) = do
@@ -279,7 +369,10 @@ instance Evaluatable LShift where
 
 data RShift a = RShift { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically RShift
+
+instance Eq1 RShift where liftEq = genericLiftEq
+instance Ord1 RShift where liftCompare = genericLiftCompare
+instance Show1 RShift where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable RShift where
   eval eval _ (RShift a b) = do
@@ -291,7 +384,10 @@ instance Evaluatable RShift where
 
 data UnsignedRShift a = UnsignedRShift { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically UnsignedRShift
+
+instance Eq1 UnsignedRShift where liftEq = genericLiftEq
+instance Ord1 UnsignedRShift where liftCompare = genericLiftCompare
+instance Show1 UnsignedRShift where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable UnsignedRShift where
   eval eval _ (UnsignedRShift a b) = do
@@ -301,7 +397,10 @@ instance Evaluatable UnsignedRShift where
 
 newtype Complement a = Complement { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Complement
+
+instance Eq1 Complement where liftEq = genericLiftEq
+instance Ord1 Complement where liftCompare = genericLiftCompare
+instance Show1 Complement where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Complement where
   eval eval _ (Complement a) = do
@@ -311,7 +410,10 @@ instance Evaluatable Complement where
 -- | Member Access (e.g. a.b)
 data MemberAccess a = MemberAccess { lhs :: a, rhs :: a }
   deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically MemberAccess
+
+instance Eq1 MemberAccess where liftEq = genericLiftEq
+instance Ord1 MemberAccess where liftCompare = genericLiftCompare
+instance Show1 MemberAccess where liftShowsPrec = genericLiftShowsPrec
 
 instance Declarations1 MemberAccess where
   liftDeclaredName declaredName MemberAccess{..} = declaredName rhs
@@ -359,7 +461,10 @@ instance Evaluatable MemberAccess where
 -- | Subscript (e.g a[1])
 data Subscript a = Subscript { lhs :: a, rhs :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Subscript
+
+instance Eq1 Subscript where liftEq = genericLiftEq
+instance Ord1 Subscript where liftCompare = genericLiftCompare
+instance Show1 Subscript where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Finish Eval instance for Subscript
 -- TODO return a special LvalSubscript instance here
@@ -369,14 +474,20 @@ instance Evaluatable Subscript where
 
 data Member a = Member { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Member
+
+instance Eq1 Member where liftEq = genericLiftEq
+instance Ord1 Member where liftCompare = genericLiftCompare
+instance Show1 Member where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Member where
 
 -- | Enumeration (e.g. a[1:10:1] in Python (start at index 1, stop at index 10, step 1 element from start to stop))
 data Enumeration a = Enumeration { enumerationStart :: !a, enumerationEnd :: !a, enumerationStep :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Enumeration
+
+instance Eq1 Enumeration where liftEq = genericLiftEq
+instance Ord1 Enumeration where liftCompare = genericLiftCompare
+instance Show1 Enumeration where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Enumeration
 instance Evaluatable Enumeration
@@ -384,7 +495,10 @@ instance Evaluatable Enumeration
 -- | InstanceOf (e.g. a instanceof b in JavaScript
 data InstanceOf a = InstanceOf { instanceOfSubject :: !a, instanceOfObject :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically InstanceOf
+
+instance Eq1 InstanceOf where liftEq = genericLiftEq
+instance Ord1 InstanceOf where liftCompare = genericLiftCompare
+instance Show1 InstanceOf where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for InstanceOf
 instance Evaluatable InstanceOf
@@ -393,7 +507,10 @@ instance Evaluatable InstanceOf
 -- | ScopeResolution (e.g. import a.b in Python or a::b in C++)
 newtype ScopeResolution a = ScopeResolution { scopes :: NonEmpty a }
   deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically ScopeResolution
+
+instance Eq1 ScopeResolution where liftEq = genericLiftEq
+instance Ord1 ScopeResolution where liftCompare = genericLiftCompare
+instance Show1 ScopeResolution where liftShowsPrec = genericLiftShowsPrec
 
 instance Hashable1 ScopeResolution where liftHashWithSalt = foldl
 
@@ -405,7 +522,10 @@ instance Declarations1 ScopeResolution where
 -- | A non-null expression such as Typescript or Swift's ! expression.
 newtype NonNullExpression a = NonNullExpression { nonNullExpression :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically NonNullExpression
+
+instance Eq1 NonNullExpression where liftEq = genericLiftEq
+instance Ord1 NonNullExpression where liftCompare = genericLiftCompare
+instance Show1 NonNullExpression where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for NonNullExpression
 instance Evaluatable NonNullExpression
@@ -414,7 +534,10 @@ instance Evaluatable NonNullExpression
 -- | An await expression in Javascript or C#.
 newtype Await a = Await { awaitSubject :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Await
+
+instance Eq1 Await where liftEq = genericLiftEq
+instance Ord1 Await where liftCompare = genericLiftCompare
+instance Show1 Await where liftShowsPrec = genericLiftShowsPrec
 -- TODO: Improve this to model asynchrony or capture some data suggesting async calls are not a problem.
 --       We are currently dealing with an asynchronous construct synchronously.
 instance Evaluatable Await where
@@ -423,7 +546,10 @@ instance Evaluatable Await where
 -- | An object constructor call in Javascript, Java, etc.
 data New a = New { newSubject :: a , newTypeParameters :: a, newArguments :: [a] }
   deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically New
+
+instance Eq1 New where liftEq = genericLiftEq
+instance Ord1 New where liftCompare = genericLiftCompare
+instance Show1 New where liftShowsPrec = genericLiftShowsPrec
 
 instance Declarations1 New where
   liftDeclaredName declaredName New{..} = declaredName newSubject
@@ -466,19 +592,28 @@ instance Evaluatable New where
 -- | A cast expression to a specified type.
 data Cast a =  Cast { castSubject :: !a, castType :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Cast
+
+instance Eq1 Cast where liftEq = genericLiftEq
+instance Ord1 Cast where liftCompare = genericLiftCompare
+instance Show1 Cast where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Cast
 
 data Super a = Super
   deriving (Diffable, Foldable, Functor,  Generic1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, Hashable1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Super
+
+instance Eq1 Super where liftEq = genericLiftEq
+instance Ord1 Super where liftCompare = genericLiftCompare
+instance Show1 Super where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Super
 
 data This a = This
   deriving (Diffable, Foldable, Functor,  Generic1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, Hashable1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically This
+
+instance Eq1 This where liftEq = genericLiftEq
+instance Ord1 This where liftCompare = genericLiftCompare
+instance Show1 This where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable This where
   eval _ _ This = do

--- a/src/Data/Syntax/Expression.hs
+++ b/src/Data/Syntax/Expression.hs
@@ -18,7 +18,7 @@ import qualified Data.Abstract.ScopeGraph as ScopeGraph
 
 -- | Typical prefix function application, like `f(x)` in many languages, or `f x` in Haskell.
 data Call a = Call { callContext :: ![a], callFunction :: !a, callParams :: ![a], callBlock :: !a }
-  deriving (Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Call
 
 instance Declarations1 Call where
@@ -31,7 +31,7 @@ instance Evaluatable Call where
     call op args
 
 data LessThan a = LessThan { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically LessThan
 
 instance Evaluatable LessThan where
@@ -39,7 +39,7 @@ instance Evaluatable LessThan where
     go (LessThan a b) = liftComparison (Concrete (<)) a b
 
 data LessThanEqual a = LessThanEqual { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically LessThanEqual
 
 instance Evaluatable LessThanEqual where
@@ -47,7 +47,7 @@ instance Evaluatable LessThanEqual where
     go (LessThanEqual a b) = liftComparison (Concrete (<=)) a b
 
 data GreaterThan a = GreaterThan { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically GreaterThan
 
 instance Evaluatable GreaterThan where
@@ -55,7 +55,7 @@ instance Evaluatable GreaterThan where
     go (GreaterThan a b) = liftComparison (Concrete (>)) a b
 
 data GreaterThanEqual a = GreaterThanEqual { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically GreaterThanEqual
 
 instance Evaluatable GreaterThanEqual where
@@ -63,7 +63,7 @@ instance Evaluatable GreaterThanEqual where
     go (GreaterThanEqual a b) = liftComparison (Concrete (>=)) a b
 
 data Equal a = Equal { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Equal
 
 instance Evaluatable Equal where
@@ -73,7 +73,7 @@ instance Evaluatable Equal where
     go (Equal a b) = liftComparison (Concrete (==)) a b
 
 data StrictEqual a = StrictEqual { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically StrictEqual
 
 instance Evaluatable StrictEqual where
@@ -83,7 +83,7 @@ instance Evaluatable StrictEqual where
     go (StrictEqual a b) = liftComparison (Concrete (==)) a b
 
 data Comparison a = Comparison { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Comparison
 
 instance Evaluatable Comparison where
@@ -91,7 +91,7 @@ instance Evaluatable Comparison where
     go (Comparison a b) = liftComparison (Concrete (==)) a b
 
 data Plus a = Plus { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Plus
 
 instance Evaluatable Plus where
@@ -99,7 +99,7 @@ instance Evaluatable Plus where
     go (Plus a b) = liftNumeric2 add a b  where add    = liftReal (+)
 
 data Minus a = Minus { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Minus
 
 instance Evaluatable Minus where
@@ -107,7 +107,7 @@ instance Evaluatable Minus where
     go (Minus a b) = liftNumeric2 (liftReal (-)) a b
 
 data Times a = Times { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Times
 
 instance Evaluatable Times where
@@ -115,7 +115,7 @@ instance Evaluatable Times where
     go (Times a b) = liftNumeric2 (liftReal (*)) a b
 
 data DividedBy a = DividedBy { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically DividedBy
 
 instance Evaluatable DividedBy where
@@ -123,7 +123,7 @@ instance Evaluatable DividedBy where
     go (DividedBy a b) = liftNumeric2 (liftIntegralFrac div (/)) a b
 
 data Modulo a = Modulo { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Modulo
 
 instance Evaluatable Modulo where
@@ -131,7 +131,7 @@ instance Evaluatable Modulo where
     go (Modulo a b) = liftNumeric2 (liftIntegralFrac mod mod') a b
 
 data Power a = Power { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Power
 
 instance Evaluatable Power where
@@ -139,7 +139,7 @@ instance Evaluatable Power where
     go (Power a b) = liftNumeric2 liftedExponent a b
 
 newtype Negate a = Negate { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Negate
 
 instance Evaluatable Negate where
@@ -147,7 +147,7 @@ instance Evaluatable Negate where
     go (Negate a) = liftNumeric negate a
 
 data FloorDivision a = FloorDivision { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically FloorDivision
 
 instance Evaluatable FloorDivision where
@@ -156,19 +156,19 @@ instance Evaluatable FloorDivision where
 
 -- | Regex matching operators (Ruby's =~ and ~!)
 data Matches a = Matches { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Matches
 
 instance Evaluatable Matches
 
 data NotMatches a = NotMatches { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically NotMatches
 
 instance Evaluatable NotMatches
 
 data Or a = Or { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Or
 
 instance Evaluatable Or where
@@ -177,7 +177,7 @@ instance Evaluatable Or where
     ifthenelse a' (pure a') (eval b)
 
 data And a = And { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically And
 
 instance Evaluatable And where
@@ -186,14 +186,14 @@ instance Evaluatable And where
     ifthenelse a' (eval b) (pure a')
 
 newtype Not a = Not { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Not
 
 instance Evaluatable Not where
   eval eval _ (Not a) = eval a >>= asBool >>= boolean . not
 
 data XOr a = XOr { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically XOr
 
 instance Evaluatable XOr where
@@ -202,7 +202,7 @@ instance Evaluatable XOr where
 
 -- | Javascript delete operator
 newtype Delete a = Delete { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Delete
 
 instance Evaluatable Delete where
@@ -210,7 +210,7 @@ instance Evaluatable Delete where
 
 -- | A sequence expression such as Javascript or C's comma operator.
 data SequenceExpression a = SequenceExpression { firstExpression :: !a, secondExpression :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically SequenceExpression
 
 instance Evaluatable SequenceExpression where
@@ -219,7 +219,7 @@ instance Evaluatable SequenceExpression where
 
 -- | Javascript void operator
 newtype Void a = Void { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Void
 
 instance Evaluatable Void where
@@ -228,7 +228,7 @@ instance Evaluatable Void where
 
 -- | Javascript typeof operator
 newtype Typeof a = Typeof { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Typeof
 
 -- TODO: Implement Eval instance for Typeof
@@ -236,7 +236,7 @@ instance Evaluatable Typeof
 
 -- | Bitwise operators.
 data BOr a = BOr { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically BOr
 
 instance Evaluatable BOr where
@@ -246,7 +246,7 @@ instance Evaluatable BOr where
     liftBitwise2 (.|.) a' b'
 
 data BAnd a = BAnd { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically BAnd
 
 instance Evaluatable BAnd where
@@ -256,7 +256,7 @@ instance Evaluatable BAnd where
     liftBitwise2 (.&.) a' b'
 
 data BXOr a = BXOr { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically BXOr
 
 instance Evaluatable BXOr where
@@ -266,7 +266,7 @@ instance Evaluatable BXOr where
     liftBitwise2 xor a' b'
 
 data LShift a = LShift { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically LShift
 
 instance Evaluatable LShift where
@@ -278,7 +278,7 @@ instance Evaluatable LShift where
       shiftL' a b = shiftL a (fromIntegral (toInteger b))
 
 data RShift a = RShift { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically RShift
 
 instance Evaluatable RShift where
@@ -290,7 +290,7 @@ instance Evaluatable RShift where
       shiftR' a b = shiftR a (fromIntegral (toInteger b))
 
 data UnsignedRShift a = UnsignedRShift { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically UnsignedRShift
 
 instance Evaluatable UnsignedRShift where
@@ -300,7 +300,7 @@ instance Evaluatable UnsignedRShift where
     unsignedRShift a' b'
 
 newtype Complement a = Complement { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Complement
 
 instance Evaluatable Complement where
@@ -310,7 +310,7 @@ instance Evaluatable Complement where
 
 -- | Member Access (e.g. a.b)
 data MemberAccess a = MemberAccess { lhs :: a, rhs :: a }
-  deriving (Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically MemberAccess
 
 instance Declarations1 MemberAccess where
@@ -358,7 +358,7 @@ instance Evaluatable MemberAccess where
 
 -- | Subscript (e.g a[1])
 data Subscript a = Subscript { lhs :: a, rhs :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Subscript
 
 -- TODO: Finish Eval instance for Subscript
@@ -368,14 +368,14 @@ instance Evaluatable Subscript where
   eval _    _ (Subscript _ _)   = throwUnspecializedError (UnspecializedError "Eval unspecialized for subscript with slices")
 
 data Member a = Member { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Member
 
 instance Evaluatable Member where
 
 -- | Enumeration (e.g. a[1:10:1] in Python (start at index 1, stop at index 10, step 1 element from start to stop))
 data Enumeration a = Enumeration { enumerationStart :: !a, enumerationEnd :: !a, enumerationStep :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Enumeration
 
 -- TODO: Implement Eval instance for Enumeration
@@ -383,7 +383,7 @@ instance Evaluatable Enumeration
 
 -- | InstanceOf (e.g. a instanceof b in JavaScript
 data InstanceOf a = InstanceOf { instanceOfSubject :: !a, instanceOfObject :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically InstanceOf
 
 -- TODO: Implement Eval instance for InstanceOf
@@ -392,7 +392,7 @@ instance Evaluatable InstanceOf
 
 -- | ScopeResolution (e.g. import a.b in Python or a::b in C++)
 newtype ScopeResolution a = ScopeResolution { scopes :: NonEmpty a }
-  deriving (Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically ScopeResolution
 
 instance Hashable1 ScopeResolution where liftHashWithSalt = foldl
@@ -404,7 +404,7 @@ instance Declarations1 ScopeResolution where
 
 -- | A non-null expression such as Typescript or Swift's ! expression.
 newtype NonNullExpression a = NonNullExpression { nonNullExpression :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically NonNullExpression
 
 -- TODO: Implement Eval instance for NonNullExpression
@@ -413,7 +413,7 @@ instance Evaluatable NonNullExpression
 
 -- | An await expression in Javascript or C#.
 newtype Await a = Await { awaitSubject :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Await
 -- TODO: Improve this to model asynchrony or capture some data suggesting async calls are not a problem.
 --       We are currently dealing with an asynchronous construct synchronously.
@@ -422,7 +422,7 @@ instance Evaluatable Await where
 
 -- | An object constructor call in Javascript, Java, etc.
 data New a = New { newSubject :: a , newTypeParameters :: a, newArguments :: [a] }
-  deriving (Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically New
 
 instance Declarations1 New where
@@ -465,19 +465,19 @@ instance Evaluatable New where
 
 -- | A cast expression to a specified type.
 data Cast a =  Cast { castSubject :: !a, castType :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Cast
 
 instance Evaluatable Cast
 
 data Super a = Super
-  deriving (Diffable, Eq, Foldable, Functor,  Generic1, Ord, Show, Traversable, FreeVariables1, Declarations1, ToJSONFields1, Hashable1, NFData1)
+  deriving (Diffable, Foldable, Functor,  Generic1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, Hashable1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Super
 
 instance Evaluatable Super
 
 data This a = This
-  deriving (Diffable, Eq, Foldable, Functor,  Generic1, Ord, Show, Traversable, FreeVariables1, Declarations1, ToJSONFields1, Hashable1, NFData1)
+  deriving (Diffable, Foldable, Functor,  Generic1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, Hashable1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically This
 
 instance Evaluatable This where

--- a/src/Data/Syntax/Expression.hs
+++ b/src/Data/Syntax/Expression.hs
@@ -18,7 +18,7 @@ import qualified Data.Abstract.ScopeGraph as ScopeGraph
 
 -- | Typical prefix function application, like `f(x)` in many languages, or `f x` in Haskell.
 data Call a = Call { callContext :: ![a], callFunction :: !a, callParams :: ![a], callBlock :: !a }
-  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Call where liftEq = genericLiftEq
 instance Ord1 Call where liftCompare = genericLiftCompare
@@ -34,7 +34,7 @@ instance Evaluatable Call where
     call op args
 
 data LessThan a = LessThan { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 LessThan where liftEq = genericLiftEq
 instance Ord1 LessThan where liftCompare = genericLiftCompare
@@ -45,7 +45,7 @@ instance Evaluatable LessThan where
     go (LessThan a b) = liftComparison (Concrete (<)) a b
 
 data LessThanEqual a = LessThanEqual { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 LessThanEqual where liftEq = genericLiftEq
 instance Ord1 LessThanEqual where liftCompare = genericLiftCompare
@@ -56,7 +56,7 @@ instance Evaluatable LessThanEqual where
     go (LessThanEqual a b) = liftComparison (Concrete (<=)) a b
 
 data GreaterThan a = GreaterThan { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 GreaterThan where liftEq = genericLiftEq
 instance Ord1 GreaterThan where liftCompare = genericLiftCompare
@@ -67,7 +67,7 @@ instance Evaluatable GreaterThan where
     go (GreaterThan a b) = liftComparison (Concrete (>)) a b
 
 data GreaterThanEqual a = GreaterThanEqual { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 GreaterThanEqual where liftEq = genericLiftEq
 instance Ord1 GreaterThanEqual where liftCompare = genericLiftCompare
@@ -78,7 +78,7 @@ instance Evaluatable GreaterThanEqual where
     go (GreaterThanEqual a b) = liftComparison (Concrete (>=)) a b
 
 data Equal a = Equal { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Equal where liftEq = genericLiftEq
 instance Ord1 Equal where liftCompare = genericLiftCompare
@@ -91,7 +91,7 @@ instance Evaluatable Equal where
     go (Equal a b) = liftComparison (Concrete (==)) a b
 
 data StrictEqual a = StrictEqual { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 StrictEqual where liftEq = genericLiftEq
 instance Ord1 StrictEqual where liftCompare = genericLiftCompare
@@ -104,7 +104,7 @@ instance Evaluatable StrictEqual where
     go (StrictEqual a b) = liftComparison (Concrete (==)) a b
 
 data Comparison a = Comparison { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Comparison where liftEq = genericLiftEq
 instance Ord1 Comparison where liftCompare = genericLiftCompare
@@ -115,7 +115,7 @@ instance Evaluatable Comparison where
     go (Comparison a b) = liftComparison (Concrete (==)) a b
 
 data Plus a = Plus { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Plus where liftEq = genericLiftEq
 instance Ord1 Plus where liftCompare = genericLiftCompare
@@ -126,7 +126,7 @@ instance Evaluatable Plus where
     go (Plus a b) = liftNumeric2 add a b  where add    = liftReal (+)
 
 data Minus a = Minus { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Minus where liftEq = genericLiftEq
 instance Ord1 Minus where liftCompare = genericLiftCompare
@@ -137,7 +137,7 @@ instance Evaluatable Minus where
     go (Minus a b) = liftNumeric2 (liftReal (-)) a b
 
 data Times a = Times { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Times where liftEq = genericLiftEq
 instance Ord1 Times where liftCompare = genericLiftCompare
@@ -148,7 +148,7 @@ instance Evaluatable Times where
     go (Times a b) = liftNumeric2 (liftReal (*)) a b
 
 data DividedBy a = DividedBy { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 DividedBy where liftEq = genericLiftEq
 instance Ord1 DividedBy where liftCompare = genericLiftCompare
@@ -159,7 +159,7 @@ instance Evaluatable DividedBy where
     go (DividedBy a b) = liftNumeric2 (liftIntegralFrac div (/)) a b
 
 data Modulo a = Modulo { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Modulo where liftEq = genericLiftEq
 instance Ord1 Modulo where liftCompare = genericLiftCompare
@@ -170,7 +170,7 @@ instance Evaluatable Modulo where
     go (Modulo a b) = liftNumeric2 (liftIntegralFrac mod mod') a b
 
 data Power a = Power { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Power where liftEq = genericLiftEq
 instance Ord1 Power where liftCompare = genericLiftCompare
@@ -181,7 +181,7 @@ instance Evaluatable Power where
     go (Power a b) = liftNumeric2 liftedExponent a b
 
 newtype Negate a = Negate { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Negate where liftEq = genericLiftEq
 instance Ord1 Negate where liftCompare = genericLiftCompare
@@ -192,7 +192,7 @@ instance Evaluatable Negate where
     go (Negate a) = liftNumeric negate a
 
 data FloorDivision a = FloorDivision { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 FloorDivision where liftEq = genericLiftEq
 instance Ord1 FloorDivision where liftCompare = genericLiftCompare
@@ -204,7 +204,7 @@ instance Evaluatable FloorDivision where
 
 -- | Regex matching operators (Ruby's =~ and ~!)
 data Matches a = Matches { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Matches where liftEq = genericLiftEq
 instance Ord1 Matches where liftCompare = genericLiftCompare
@@ -213,7 +213,7 @@ instance Show1 Matches where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Matches
 
 data NotMatches a = NotMatches { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 NotMatches where liftEq = genericLiftEq
 instance Ord1 NotMatches where liftCompare = genericLiftCompare
@@ -222,7 +222,7 @@ instance Show1 NotMatches where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable NotMatches
 
 data Or a = Or { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Or where liftEq = genericLiftEq
 instance Ord1 Or where liftCompare = genericLiftCompare
@@ -234,7 +234,7 @@ instance Evaluatable Or where
     ifthenelse a' (pure a') (eval b)
 
 data And a = And { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 And where liftEq = genericLiftEq
 instance Ord1 And where liftCompare = genericLiftCompare
@@ -246,7 +246,7 @@ instance Evaluatable And where
     ifthenelse a' (eval b) (pure a')
 
 newtype Not a = Not { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Not where liftEq = genericLiftEq
 instance Ord1 Not where liftCompare = genericLiftCompare
@@ -256,7 +256,7 @@ instance Evaluatable Not where
   eval eval _ (Not a) = eval a >>= asBool >>= boolean . not
 
 data XOr a = XOr { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 XOr where liftEq = genericLiftEq
 instance Ord1 XOr where liftCompare = genericLiftCompare
@@ -268,7 +268,7 @@ instance Evaluatable XOr where
 
 -- | Javascript delete operator
 newtype Delete a = Delete { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Delete where liftEq = genericLiftEq
 instance Ord1 Delete where liftCompare = genericLiftCompare
@@ -279,7 +279,7 @@ instance Evaluatable Delete where
 
 -- | A sequence expression such as Javascript or C's comma operator.
 data SequenceExpression a = SequenceExpression { firstExpression :: !a, secondExpression :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 SequenceExpression where liftEq = genericLiftEq
 instance Ord1 SequenceExpression where liftCompare = genericLiftCompare
@@ -291,7 +291,7 @@ instance Evaluatable SequenceExpression where
 
 -- | Javascript void operator
 newtype Void a = Void { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Void where liftEq = genericLiftEq
 instance Ord1 Void where liftCompare = genericLiftCompare
@@ -303,7 +303,7 @@ instance Evaluatable Void where
 
 -- | Javascript typeof operator
 newtype Typeof a = Typeof { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Typeof where liftEq = genericLiftEq
 instance Ord1 Typeof where liftCompare = genericLiftCompare
@@ -314,7 +314,7 @@ instance Evaluatable Typeof
 
 -- | Bitwise operators.
 data BOr a = BOr { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 BOr where liftEq = genericLiftEq
 instance Ord1 BOr where liftCompare = genericLiftCompare
@@ -327,7 +327,7 @@ instance Evaluatable BOr where
     liftBitwise2 (.|.) a' b'
 
 data BAnd a = BAnd { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 BAnd where liftEq = genericLiftEq
 instance Ord1 BAnd where liftCompare = genericLiftCompare
@@ -340,7 +340,7 @@ instance Evaluatable BAnd where
     liftBitwise2 (.&.) a' b'
 
 data BXOr a = BXOr { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 BXOr where liftEq = genericLiftEq
 instance Ord1 BXOr where liftCompare = genericLiftCompare
@@ -353,7 +353,7 @@ instance Evaluatable BXOr where
     liftBitwise2 xor a' b'
 
 data LShift a = LShift { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 LShift where liftEq = genericLiftEq
 instance Ord1 LShift where liftCompare = genericLiftCompare
@@ -368,7 +368,7 @@ instance Evaluatable LShift where
       shiftL' a b = shiftL a (fromIntegral (toInteger b))
 
 data RShift a = RShift { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 RShift where liftEq = genericLiftEq
 instance Ord1 RShift where liftCompare = genericLiftCompare
@@ -383,7 +383,7 @@ instance Evaluatable RShift where
       shiftR' a b = shiftR a (fromIntegral (toInteger b))
 
 data UnsignedRShift a = UnsignedRShift { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 UnsignedRShift where liftEq = genericLiftEq
 instance Ord1 UnsignedRShift where liftCompare = genericLiftCompare
@@ -396,7 +396,7 @@ instance Evaluatable UnsignedRShift where
     unsignedRShift a' b'
 
 newtype Complement a = Complement { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Complement where liftEq = genericLiftEq
 instance Ord1 Complement where liftCompare = genericLiftCompare
@@ -409,7 +409,7 @@ instance Evaluatable Complement where
 
 -- | Member Access (e.g. a.b)
 data MemberAccess a = MemberAccess { lhs :: a, rhs :: a }
-  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 MemberAccess where liftEq = genericLiftEq
 instance Ord1 MemberAccess where liftCompare = genericLiftCompare
@@ -460,7 +460,7 @@ instance Evaluatable MemberAccess where
 
 -- | Subscript (e.g a[1])
 data Subscript a = Subscript { lhs :: a, rhs :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Subscript where liftEq = genericLiftEq
 instance Ord1 Subscript where liftCompare = genericLiftCompare
@@ -473,7 +473,7 @@ instance Evaluatable Subscript where
   eval _    _ (Subscript _ _)   = throwUnspecializedError (UnspecializedError "Eval unspecialized for subscript with slices")
 
 data Member a = Member { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Member where liftEq = genericLiftEq
 instance Ord1 Member where liftCompare = genericLiftCompare
@@ -483,7 +483,7 @@ instance Evaluatable Member where
 
 -- | Enumeration (e.g. a[1:10:1] in Python (start at index 1, stop at index 10, step 1 element from start to stop))
 data Enumeration a = Enumeration { enumerationStart :: !a, enumerationEnd :: !a, enumerationStep :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Enumeration where liftEq = genericLiftEq
 instance Ord1 Enumeration where liftCompare = genericLiftCompare
@@ -494,7 +494,7 @@ instance Evaluatable Enumeration
 
 -- | InstanceOf (e.g. a instanceof b in JavaScript
 data InstanceOf a = InstanceOf { instanceOfSubject :: !a, instanceOfObject :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 InstanceOf where liftEq = genericLiftEq
 instance Ord1 InstanceOf where liftCompare = genericLiftCompare
@@ -506,7 +506,7 @@ instance Evaluatable InstanceOf
 
 -- | ScopeResolution (e.g. import a.b in Python or a::b in C++)
 newtype ScopeResolution a = ScopeResolution { scopes :: NonEmpty a }
-  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, ToJSONFields1, Traversable, NFData1)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, ToJSONFields1, Traversable)
 
 instance Eq1 ScopeResolution where liftEq = genericLiftEq
 instance Ord1 ScopeResolution where liftCompare = genericLiftCompare
@@ -521,7 +521,7 @@ instance Declarations1 ScopeResolution where
 
 -- | A non-null expression such as Typescript or Swift's ! expression.
 newtype NonNullExpression a = NonNullExpression { nonNullExpression :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 NonNullExpression where liftEq = genericLiftEq
 instance Ord1 NonNullExpression where liftCompare = genericLiftCompare
@@ -533,7 +533,7 @@ instance Evaluatable NonNullExpression
 
 -- | An await expression in Javascript or C#.
 newtype Await a = Await { awaitSubject :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Await where liftEq = genericLiftEq
 instance Ord1 Await where liftCompare = genericLiftCompare
@@ -545,7 +545,7 @@ instance Evaluatable Await where
 
 -- | An object constructor call in Javascript, Java, etc.
 data New a = New { newSubject :: a , newTypeParameters :: a, newArguments :: [a] }
-  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 New where liftEq = genericLiftEq
 instance Ord1 New where liftCompare = genericLiftCompare
@@ -591,7 +591,7 @@ instance Evaluatable New where
 
 -- | A cast expression to a specified type.
 data Cast a =  Cast { castSubject :: !a, castType :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Cast where liftEq = genericLiftEq
 instance Ord1 Cast where liftCompare = genericLiftCompare
@@ -600,7 +600,7 @@ instance Show1 Cast where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Cast
 
 data Super a = Super
-  deriving (Diffable, Foldable, Functor,  Generic1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, Hashable1, NFData1)
+  deriving (Diffable, Foldable, Functor,  Generic1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, Hashable1)
 
 instance Eq1 Super where liftEq = genericLiftEq
 instance Ord1 Super where liftCompare = genericLiftCompare
@@ -609,7 +609,7 @@ instance Show1 Super where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Super
 
 data This a = This
-  deriving (Diffable, Foldable, Functor,  Generic1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, Hashable1, NFData1)
+  deriving (Diffable, Foldable, Functor,  Generic1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, Hashable1)
 
 instance Eq1 This where liftEq = genericLiftEq
 instance Ord1 This where liftCompare = genericLiftCompare

--- a/src/Data/Syntax/Literal.hs
+++ b/src/Data/Syntax/Literal.hs
@@ -17,7 +17,7 @@ import           Text.Read (readMaybe)
 
 newtype Boolean a = Boolean { booleanContent :: Bool }
   deriving stock (Foldable, Traversable, Functor, Generic1)
-  deriving anyclass (Hashable1, Diffable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving anyclass (Hashable1, Diffable, FreeVariables1, Declarations1, ToJSONFields1)
 
 instance Eq1 Boolean where liftEq = genericLiftEq
 instance Ord1 Boolean where liftCompare = genericLiftCompare
@@ -34,7 +34,7 @@ instance Evaluatable Boolean where
 
 -- | A literal integer of unspecified width. No particular base is implied.
 newtype Integer a = Integer { integerContent :: Text }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Data.Syntax.Literal.Integer where liftEq = genericLiftEq
 instance Ord1 Data.Syntax.Literal.Integer where liftCompare = genericLiftCompare
@@ -48,7 +48,7 @@ instance Evaluatable Data.Syntax.Literal.Integer where
 -- | A literal float of unspecified width.
 
 newtype Float a = Float { floatContent :: Text }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Data.Syntax.Literal.Float where liftEq = genericLiftEq
 instance Ord1 Data.Syntax.Literal.Float where liftCompare = genericLiftCompare
@@ -61,7 +61,7 @@ instance Evaluatable Data.Syntax.Literal.Float where
 
 -- Rational literals e.g. `2/3r`
 newtype Rational a = Rational { value :: Text }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Data.Syntax.Literal.Rational where liftEq = genericLiftEq
 instance Ord1 Data.Syntax.Literal.Rational where liftCompare = genericLiftCompare
@@ -76,7 +76,7 @@ instance Evaluatable Data.Syntax.Literal.Rational where
 
 -- Complex literals e.g. `3 + 2i`
 newtype Complex a = Complex { value :: Text }
-  deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1)
 
 instance Eq1 Complex where liftEq = genericLiftEq
 instance Ord1 Complex where liftCompare = genericLiftCompare
@@ -88,7 +88,7 @@ instance Evaluatable Complex
 -- Strings, symbols
 
 newtype String a = String { stringElements :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Data.Syntax.Literal.String where liftEq = genericLiftEq
 instance Ord1 Data.Syntax.Literal.String where liftCompare = genericLiftCompare
@@ -100,7 +100,7 @@ instance Show1 Data.Syntax.Literal.String where liftShowsPrec = genericLiftShows
 instance Evaluatable Data.Syntax.Literal.String
 
 newtype Character a = Character { characterContent :: Text }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Character where liftEq = genericLiftEq
 instance Ord1 Character where liftCompare = genericLiftCompare
@@ -110,7 +110,7 @@ instance Evaluatable Data.Syntax.Literal.Character
 
 -- | An interpolation element within a string literal.
 newtype InterpolationElement a = InterpolationElement { interpolationBody :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 InterpolationElement where liftEq = genericLiftEq
 instance Ord1 InterpolationElement where liftCompare = genericLiftCompare
@@ -121,7 +121,7 @@ instance Evaluatable InterpolationElement
 
 -- | A sequence of textual contents within a string literal.
 newtype TextElement a = TextElement { textElementContent :: Text }
-  deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1)
 
 instance Eq1 TextElement where liftEq = genericLiftEq
 instance Ord1 TextElement where liftCompare = genericLiftCompare
@@ -140,7 +140,7 @@ quoted t = TextElement ("\"" <> t <> "\"")
 
 -- | A sequence of textual contents within a string literal.
 newtype EscapeSequence a = EscapeSequence { value :: Text }
-  deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1)
 
 instance Eq1 EscapeSequence where liftEq = genericLiftEq
 instance Ord1 EscapeSequence where liftCompare = genericLiftCompare
@@ -150,7 +150,7 @@ instance Show1 EscapeSequence where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable EscapeSequence
 
 data Null a = Null
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Null where liftEq = genericLiftEq
 instance Ord1 Null where liftCompare = genericLiftCompare
@@ -159,7 +159,7 @@ instance Show1 Null where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Null where eval _ _ _ = pure null
 
 newtype Symbol a = Symbol { symbolElements :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Symbol where liftEq = genericLiftEq
 instance Ord1 Symbol where liftCompare = genericLiftCompare
@@ -169,7 +169,7 @@ instance Show1 Symbol where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Symbol
 
 newtype SymbolElement a = SymbolElement { symbolContent :: Text }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 SymbolElement where liftEq = genericLiftEq
 instance Ord1 SymbolElement where liftCompare = genericLiftCompare
@@ -179,7 +179,7 @@ instance Evaluatable SymbolElement where
   eval _ _ (SymbolElement s) = string s
 
 newtype Regex a = Regex { regexContent :: Text }
-  deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1)
 
 instance Eq1 Regex where liftEq = genericLiftEq
 instance Ord1 Regex where liftCompare = genericLiftCompare
@@ -194,7 +194,7 @@ instance Evaluatable Regex where
 -- Collections
 
 newtype Array a = Array { arrayElements :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Array where liftEq = genericLiftEq
 instance Ord1 Array where liftCompare = genericLiftCompare
@@ -204,7 +204,7 @@ instance Evaluatable Array where
   eval eval _ Array{..} = array =<< traverse eval arrayElements
 
 newtype Hash a = Hash { hashElements :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Hash where liftEq = genericLiftEq
 instance Ord1 Hash where liftCompare = genericLiftCompare
@@ -216,7 +216,7 @@ instance Evaluatable Hash where
     Eval.hash elements
 
 data KeyValue a = KeyValue { key :: !a, value :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 KeyValue where liftEq = genericLiftEq
 instance Ord1 KeyValue where liftCompare = genericLiftCompare
@@ -229,7 +229,7 @@ instance Evaluatable KeyValue where
     kvPair k v
 
 newtype Tuple a = Tuple { tupleContents :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Tuple where liftEq = genericLiftEq
 instance Ord1 Tuple where liftCompare = genericLiftCompare
@@ -239,7 +239,7 @@ instance Evaluatable Tuple where
   eval eval _ (Tuple cs) = tuple =<< traverse eval cs
 
 newtype Set a = Set { setElements :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Set where liftEq = genericLiftEq
 instance Ord1 Set where liftCompare = genericLiftCompare
@@ -253,7 +253,7 @@ instance Evaluatable Set
 
 -- | A declared pointer (e.g. var pointer *int in Go)
 newtype Pointer a = Pointer { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Pointer where liftEq = genericLiftEq
 instance Ord1 Pointer where liftCompare = genericLiftCompare
@@ -265,7 +265,7 @@ instance Evaluatable Pointer
 
 -- | A reference to a pointer's address (e.g. &pointer in Go)
 newtype Reference a = Reference { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Reference where liftEq = genericLiftEq
 instance Ord1 Reference where liftCompare = genericLiftCompare

--- a/src/Data/Syntax/Literal.hs
+++ b/src/Data/Syntax/Literal.hs
@@ -16,7 +16,7 @@ import           Text.Read (readMaybe)
 -- Boolean
 
 newtype Boolean a = Boolean { booleanContent :: Bool }
-  deriving stock (Eq, Ord, Show, Foldable, Traversable, Functor, Generic1)
+  deriving stock (Foldable, Traversable, Functor, Generic1)
   deriving anyclass (Hashable1, Diffable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
   deriving (Eq1, Ord1, Show1) via Generically Boolean
 
@@ -31,7 +31,7 @@ instance Evaluatable Boolean where
 
 -- | A literal integer of unspecified width. No particular base is implied.
 newtype Integer a = Integer { integerContent :: Text }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Ord1, Show1) via Generically Data.Syntax.Literal.Integer
 
 instance Evaluatable Data.Syntax.Literal.Integer where
@@ -42,7 +42,7 @@ instance Evaluatable Data.Syntax.Literal.Integer where
 -- | A literal float of unspecified width.
 
 newtype Float a = Float { floatContent :: Text }
-  deriving (Eq, Ord, Show, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Ord1, Show1) via Generically Data.Syntax.Literal.Float
 
 
@@ -52,7 +52,7 @@ instance Evaluatable Data.Syntax.Literal.Float where
 
 -- Rational literals e.g. `2/3r`
 newtype Rational a = Rational { value :: Text }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Ord1, Show1) via Generically Data.Syntax.Literal.Rational
 
 instance Evaluatable Data.Syntax.Literal.Rational where
@@ -64,7 +64,7 @@ instance Evaluatable Data.Syntax.Literal.Rational where
 
 -- Complex literals e.g. `3 + 2i`
 newtype Complex a = Complex { value :: Text }
-  deriving (Diffable, Eq, Foldable, Functor, Generic1, Hashable1, Ord, Show, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
   deriving (Eq1, Ord1, Show1) via Generically Complex
 
 -- TODO: Implement Eval instance for Complex
@@ -73,7 +73,7 @@ instance Evaluatable Complex
 -- Strings, symbols
 
 newtype String a = String { stringElements :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Ord1, Show1) via Generically Data.Syntax.Literal.String
 
 -- TODO: Should string literal bodies include escapes too?
@@ -82,14 +82,14 @@ newtype String a = String { stringElements :: [a] }
 instance Evaluatable Data.Syntax.Literal.String
 
 newtype Character a = Character { characterContent :: Text }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Ord1, Show1) via Generically Character
 
 instance Evaluatable Data.Syntax.Literal.Character
 
 -- | An interpolation element within a string literal.
 newtype InterpolationElement a = InterpolationElement { interpolationBody :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Ord1, Show1) via Generically InterpolationElement
 
 -- TODO: Implement Eval instance for InterpolationElement
@@ -97,7 +97,7 @@ instance Evaluatable InterpolationElement
 
 -- | A sequence of textual contents within a string literal.
 newtype TextElement a = TextElement { textElementContent :: Text }
-  deriving (Diffable, Eq, Foldable, Functor, Generic1, Hashable1, Ord, Show, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
   deriving (Eq1, Ord1, Show1) via Generically TextElement
 
 instance Evaluatable TextElement where
@@ -113,34 +113,34 @@ quoted t = TextElement ("\"" <> t <> "\"")
 
 -- | A sequence of textual contents within a string literal.
 newtype EscapeSequence a = EscapeSequence { value :: Text }
-  deriving (Diffable, Eq, Foldable, Functor, Generic1, Hashable1, Ord, Show, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
   deriving (Eq1, Ord1, Show1) via Generically EscapeSequence
 
 -- TODO: Implement Eval instance for EscapeSequence
 instance Evaluatable EscapeSequence
 
 data Null a = Null
-  deriving (Eq, Ord, Show, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Ord1, Show1) via Generically Null
 
 instance Evaluatable Null where eval _ _ _ = pure null
 
 newtype Symbol a = Symbol { symbolElements :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Ord1, Show1) via Generically Symbol
 
 -- TODO: Implement Eval instance for Symbol
 instance Evaluatable Symbol
 
 newtype SymbolElement a = SymbolElement { symbolContent :: Text }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Ord1, Show1) via Generically SymbolElement
 
 instance Evaluatable SymbolElement where
   eval _ _ (SymbolElement s) = string s
 
 newtype Regex a = Regex { regexContent :: Text }
-  deriving (Diffable, Eq, Foldable, Functor, Generic1, Hashable1, Ord, Show, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
   deriving (Eq1, Ord1, Show1) via Generically Regex
 
 -- TODO: Heredoc-style string literals?
@@ -152,14 +152,14 @@ instance Evaluatable Regex where
 -- Collections
 
 newtype Array a = Array { arrayElements :: [a] }
-  deriving (Eq, Ord, Show, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Ord1, Show1) via Generically Array
 
 instance Evaluatable Array where
   eval eval _ Array{..} = array =<< traverse eval arrayElements
 
 newtype Hash a = Hash { hashElements :: [a] }
-  deriving (Eq, Ord, Show, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Ord1, Show1) via Generically Hash
 
 instance Evaluatable Hash where
@@ -168,7 +168,7 @@ instance Evaluatable Hash where
     Eval.hash elements
 
 data KeyValue a = KeyValue { key :: !a, value :: !a }
-  deriving (Eq, Ord, Show, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Ord1, Show1) via Generically KeyValue
 
 instance Evaluatable KeyValue where
@@ -178,14 +178,14 @@ instance Evaluatable KeyValue where
     kvPair k v
 
 newtype Tuple a = Tuple { tupleContents :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Ord1, Show1) via Generically Tuple
 
 instance Evaluatable Tuple where
   eval eval _ (Tuple cs) = tuple =<< traverse eval cs
 
 newtype Set a = Set { setElements :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Ord1, Show1) via Generically Set
 
 -- TODO: Implement Eval instance for Set
@@ -196,7 +196,7 @@ instance Evaluatable Set
 
 -- | A declared pointer (e.g. var pointer *int in Go)
 newtype Pointer a = Pointer { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Ord1, Show1) via Generically Pointer
 
 -- TODO: Implement Eval instance for Pointer
@@ -205,7 +205,7 @@ instance Evaluatable Pointer
 
 -- | A reference to a pointer's address (e.g. &pointer in Go)
 newtype Reference a = Reference { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Ord1, Show1) via Generically Reference
 
 -- TODO: Implement Eval instance for Reference

--- a/src/Data/Syntax/Literal.hs
+++ b/src/Data/Syntax/Literal.hs
@@ -18,7 +18,10 @@ import           Text.Read (readMaybe)
 newtype Boolean a = Boolean { booleanContent :: Bool }
   deriving stock (Foldable, Traversable, Functor, Generic1)
   deriving anyclass (Hashable1, Diffable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
-  deriving (Eq1, Ord1, Show1) via Generically Boolean
+
+instance Eq1 Boolean where liftEq = genericLiftEq
+instance Ord1 Boolean where liftCompare = genericLiftCompare
+instance Show1 Boolean where liftShowsPrec = genericLiftShowsPrec
 
 true :: Boolean a
 true = Boolean True
@@ -32,7 +35,10 @@ instance Evaluatable Boolean where
 -- | A literal integer of unspecified width. No particular base is implied.
 newtype Integer a = Integer { integerContent :: Text }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Ord1, Show1) via Generically Data.Syntax.Literal.Integer
+
+instance Eq1 Data.Syntax.Literal.Integer where liftEq = genericLiftEq
+instance Ord1 Data.Syntax.Literal.Integer where liftCompare = genericLiftCompare
+instance Show1 Data.Syntax.Literal.Integer where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Data.Syntax.Literal.Integer where
   -- TODO: We should use something more robust than shelling out to readMaybe.
@@ -43,7 +49,10 @@ instance Evaluatable Data.Syntax.Literal.Integer where
 
 newtype Float a = Float { floatContent :: Text }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Ord1, Show1) via Generically Data.Syntax.Literal.Float
+
+instance Eq1 Data.Syntax.Literal.Float where liftEq = genericLiftEq
+instance Ord1 Data.Syntax.Literal.Float where liftCompare = genericLiftCompare
+instance Show1 Data.Syntax.Literal.Float where liftShowsPrec = genericLiftShowsPrec
 
 
 instance Evaluatable Data.Syntax.Literal.Float where
@@ -53,7 +62,10 @@ instance Evaluatable Data.Syntax.Literal.Float where
 -- Rational literals e.g. `2/3r`
 newtype Rational a = Rational { value :: Text }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Ord1, Show1) via Generically Data.Syntax.Literal.Rational
+
+instance Eq1 Data.Syntax.Literal.Rational where liftEq = genericLiftEq
+instance Ord1 Data.Syntax.Literal.Rational where liftCompare = genericLiftCompare
+instance Show1 Data.Syntax.Literal.Rational where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Data.Syntax.Literal.Rational where
   eval _ _ (Rational r) =
@@ -65,7 +77,10 @@ instance Evaluatable Data.Syntax.Literal.Rational where
 -- Complex literals e.g. `3 + 2i`
 newtype Complex a = Complex { value :: Text }
   deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
-  deriving (Eq1, Ord1, Show1) via Generically Complex
+
+instance Eq1 Complex where liftEq = genericLiftEq
+instance Ord1 Complex where liftCompare = genericLiftCompare
+instance Show1 Complex where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Complex
 instance Evaluatable Complex
@@ -74,7 +89,10 @@ instance Evaluatable Complex
 
 newtype String a = String { stringElements :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Ord1, Show1) via Generically Data.Syntax.Literal.String
+
+instance Eq1 Data.Syntax.Literal.String where liftEq = genericLiftEq
+instance Ord1 Data.Syntax.Literal.String where liftCompare = genericLiftCompare
+instance Show1 Data.Syntax.Literal.String where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Should string literal bodies include escapes too?
 
@@ -83,14 +101,20 @@ instance Evaluatable Data.Syntax.Literal.String
 
 newtype Character a = Character { characterContent :: Text }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Ord1, Show1) via Generically Character
+
+instance Eq1 Character where liftEq = genericLiftEq
+instance Ord1 Character where liftCompare = genericLiftCompare
+instance Show1 Character where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Data.Syntax.Literal.Character
 
 -- | An interpolation element within a string literal.
 newtype InterpolationElement a = InterpolationElement { interpolationBody :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Ord1, Show1) via Generically InterpolationElement
+
+instance Eq1 InterpolationElement where liftEq = genericLiftEq
+instance Ord1 InterpolationElement where liftCompare = genericLiftCompare
+instance Show1 InterpolationElement where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for InterpolationElement
 instance Evaluatable InterpolationElement
@@ -98,7 +122,10 @@ instance Evaluatable InterpolationElement
 -- | A sequence of textual contents within a string literal.
 newtype TextElement a = TextElement { textElementContent :: Text }
   deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
-  deriving (Eq1, Ord1, Show1) via Generically TextElement
+
+instance Eq1 TextElement where liftEq = genericLiftEq
+instance Ord1 TextElement where liftCompare = genericLiftCompare
+instance Show1 TextElement where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable TextElement where
   eval _ _ (TextElement x) = string x
@@ -114,34 +141,49 @@ quoted t = TextElement ("\"" <> t <> "\"")
 -- | A sequence of textual contents within a string literal.
 newtype EscapeSequence a = EscapeSequence { value :: Text }
   deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
-  deriving (Eq1, Ord1, Show1) via Generically EscapeSequence
+
+instance Eq1 EscapeSequence where liftEq = genericLiftEq
+instance Ord1 EscapeSequence where liftCompare = genericLiftCompare
+instance Show1 EscapeSequence where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for EscapeSequence
 instance Evaluatable EscapeSequence
 
 data Null a = Null
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Ord1, Show1) via Generically Null
+
+instance Eq1 Null where liftEq = genericLiftEq
+instance Ord1 Null where liftCompare = genericLiftCompare
+instance Show1 Null where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Null where eval _ _ _ = pure null
 
 newtype Symbol a = Symbol { symbolElements :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Ord1, Show1) via Generically Symbol
+
+instance Eq1 Symbol where liftEq = genericLiftEq
+instance Ord1 Symbol where liftCompare = genericLiftCompare
+instance Show1 Symbol where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Symbol
 instance Evaluatable Symbol
 
 newtype SymbolElement a = SymbolElement { symbolContent :: Text }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Ord1, Show1) via Generically SymbolElement
+
+instance Eq1 SymbolElement where liftEq = genericLiftEq
+instance Ord1 SymbolElement where liftCompare = genericLiftCompare
+instance Show1 SymbolElement where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable SymbolElement where
   eval _ _ (SymbolElement s) = string s
 
 newtype Regex a = Regex { regexContent :: Text }
   deriving (Diffable, Foldable, Functor, Generic1, Hashable1, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
-  deriving (Eq1, Ord1, Show1) via Generically Regex
+
+instance Eq1 Regex where liftEq = genericLiftEq
+instance Ord1 Regex where liftCompare = genericLiftCompare
+instance Show1 Regex where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Heredoc-style string literals?
 
@@ -153,14 +195,20 @@ instance Evaluatable Regex where
 
 newtype Array a = Array { arrayElements :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Ord1, Show1) via Generically Array
+
+instance Eq1 Array where liftEq = genericLiftEq
+instance Ord1 Array where liftCompare = genericLiftCompare
+instance Show1 Array where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Array where
   eval eval _ Array{..} = array =<< traverse eval arrayElements
 
 newtype Hash a = Hash { hashElements :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Ord1, Show1) via Generically Hash
+
+instance Eq1 Hash where liftEq = genericLiftEq
+instance Ord1 Hash where liftCompare = genericLiftCompare
+instance Show1 Hash where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Hash where
   eval eval _ t = do
@@ -169,7 +217,10 @@ instance Evaluatable Hash where
 
 data KeyValue a = KeyValue { key :: !a, value :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Ord1, Show1) via Generically KeyValue
+
+instance Eq1 KeyValue where liftEq = genericLiftEq
+instance Ord1 KeyValue where liftCompare = genericLiftCompare
+instance Show1 KeyValue where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable KeyValue where
   eval eval _ KeyValue{..} = do
@@ -179,14 +230,20 @@ instance Evaluatable KeyValue where
 
 newtype Tuple a = Tuple { tupleContents :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Ord1, Show1) via Generically Tuple
+
+instance Eq1 Tuple where liftEq = genericLiftEq
+instance Ord1 Tuple where liftCompare = genericLiftCompare
+instance Show1 Tuple where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Tuple where
   eval eval _ (Tuple cs) = tuple =<< traverse eval cs
 
 newtype Set a = Set { setElements :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Ord1, Show1) via Generically Set
+
+instance Eq1 Set where liftEq = genericLiftEq
+instance Ord1 Set where liftCompare = genericLiftCompare
+instance Show1 Set where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Set
 instance Evaluatable Set
@@ -197,7 +254,10 @@ instance Evaluatable Set
 -- | A declared pointer (e.g. var pointer *int in Go)
 newtype Pointer a = Pointer { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Ord1, Show1) via Generically Pointer
+
+instance Eq1 Pointer where liftEq = genericLiftEq
+instance Ord1 Pointer where liftCompare = genericLiftCompare
+instance Show1 Pointer where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Pointer
 instance Evaluatable Pointer
@@ -206,7 +266,10 @@ instance Evaluatable Pointer
 -- | A reference to a pointer's address (e.g. &pointer in Go)
 newtype Reference a = Reference { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Ord1, Show1) via Generically Reference
+
+instance Eq1 Reference where liftEq = genericLiftEq
+instance Ord1 Reference where liftCompare = genericLiftCompare
+instance Show1 Reference where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Reference
 instance Evaluatable Reference

--- a/src/Data/Syntax/Statement.hs
+++ b/src/Data/Syntax/Statement.hs
@@ -21,7 +21,7 @@ import           Diffing.Algorithm
 --   3. Only the last statement’s return value is returned.
 --   TODO: Separate top-level statement nodes into non-lexical Statement and lexical StatementBlock nodes
 newtype Statements a = Statements { statements :: [a] }
-  deriving (Diffable, Eq, Foldable, Functor, Generic1, Hashable1, Ord, Show, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Statements
 
 instance ToJSON1 Statements
@@ -31,7 +31,7 @@ instance Evaluatable Statements where
     maybe unit (runApp . foldMap1 (App . eval)) (nonEmpty xs)
 
 newtype StatementBlock a = StatementBlock { statements :: [a] }
-  deriving (Diffable, Eq, Foldable, Functor, Generic1, Hashable1, Ord, Show, Traversable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically StatementBlock
 
 instance ToJSON1 StatementBlock
@@ -42,7 +42,7 @@ instance Evaluatable StatementBlock where
 
 -- | Conditional. This must have an else block, which can be filled with some default value when omitted in the source, e.g. 'pure ()' for C-style if-without-else or 'pure Nothing' for Ruby-style, in both cases assuming some appropriate Applicative context into which the If will be lifted.
 data If a = If { ifCondition :: !a, ifThenBody :: !a, ifElseBody :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically If
 
 instance Evaluatable If where
@@ -53,7 +53,7 @@ instance Evaluatable If where
 
 -- | Else statement. The else condition is any term, that upon successful completion, continues evaluation to the elseBody, e.g. `for ... else` in Python.
 data Else a = Else { elseCondition :: !a, elseBody :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Else
 
 -- TODO: Implement Eval instance for Else
@@ -64,7 +64,7 @@ instance Evaluatable Else
 
 -- | Goto statement (e.g. `goto a` in Go).
 newtype Goto a = Goto { gotoLocation :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Goto
 
 -- TODO: Implement Eval instance for Goto
@@ -72,7 +72,7 @@ instance Evaluatable Goto
 
 -- | A pattern-matching or computed jump control-flow statement, like 'switch' in C or JavaScript, or 'case' in Ruby or Haskell.
 data Match a = Match { matchSubject :: !a, matchPatterns :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Match
 
 -- TODO: Implement Eval instance for Match
@@ -81,7 +81,7 @@ instance Evaluatable Match
 
 -- | A pattern in a pattern-matching or computed jump control-flow statement, like 'case' in C or JavaScript, 'when' in Ruby, or the left-hand side of '->' in the body of Haskell 'case' expressions.
 data Pattern a = Pattern { value :: !a, patternBody :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Pattern
 
 -- TODO: Implement Eval instance for Pattern
@@ -89,7 +89,7 @@ instance Evaluatable Pattern
 
 -- | A let statement or local binding, like 'a as b' or 'let a = b'.
 data Let a  = Let { letVariable :: !a, letValue :: !a, letBody :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Let
 
 instance Evaluatable Let where
@@ -112,7 +112,7 @@ instance Evaluatable Let where
 
 -- | Assignment to a variable or other lvalue.
 data Assignment a = Assignment { assignmentContext :: ![a], assignmentTarget :: !a, assignmentValue :: !a }
-  deriving (Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Assignment
 
 instance Declarations1 Assignment where
@@ -139,7 +139,7 @@ instance Evaluatable Assignment where
 
 -- | Post increment operator (e.g. 1++ in Go, or i++ in C).
 newtype PostIncrement a = PostIncrement { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically PostIncrement
 
 -- TODO: Implement Eval instance for PostIncrement
@@ -148,7 +148,7 @@ instance Evaluatable PostIncrement
 
 -- | Post decrement operator (e.g. 1-- in Go, or i-- in C).
 newtype PostDecrement a = PostDecrement { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically PostDecrement
 
 -- TODO: Implement Eval instance for PostDecrement
@@ -156,7 +156,7 @@ instance Evaluatable PostDecrement
 
 -- | Pre increment operator (e.g. ++1 in C or Java).
 newtype PreIncrement a = PreIncrement { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically PreIncrement
 
 -- TODO: Implement Eval instance for PreIncrement
@@ -165,7 +165,7 @@ instance Evaluatable PreIncrement
 
 -- | Pre decrement operator (e.g. --1 in C or Java).
 newtype PreDecrement a = PreDecrement { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically PreDecrement
 
 -- TODO: Implement Eval instance for PreDecrement
@@ -175,14 +175,14 @@ instance Evaluatable PreDecrement
 -- Returns
 
 newtype Return a = Return { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Return
 
 instance Evaluatable Return where
   eval eval _ (Return x) = eval x >>= earlyReturn
 
 newtype Yield a = Yield { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Yield
 
 -- TODO: Implement Eval instance for Yield
@@ -190,28 +190,28 @@ instance Evaluatable Yield
 
 
 newtype Break a = Break { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Break
 
 instance Evaluatable Break where
   eval eval _ (Break x) = eval x >>= throwBreak
 
 newtype Continue a = Continue { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Continue
 
 instance Evaluatable Continue where
   eval eval _ (Continue x) = eval x >>= throwContinue
 
 newtype Retry a = Retry { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Retry
 
 -- TODO: Implement Eval instance for Retry
 instance Evaluatable Retry
 
 newtype NoOp a = NoOp { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically NoOp
 
 instance Evaluatable NoOp where
@@ -220,28 +220,28 @@ instance Evaluatable NoOp where
 -- Loops
 
 data For a = For { forBefore :: !a, forCondition :: !a, forStep :: !a, forBody :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically For
 
 instance Evaluatable For where
   eval eval _ (fmap eval -> For before cond step body) = forLoop before cond step body
 
 data ForEach a = ForEach { forEachBinding :: !a, forEachSubject :: !a, forEachBody :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically ForEach
 
 -- TODO: Implement Eval instance for ForEach
 instance Evaluatable ForEach
 
 data While a = While { whileCondition :: !a, whileBody :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically While
 
 instance Evaluatable While where
   eval eval _ While{..} = while (eval whileCondition) (eval whileBody)
 
 data DoWhile a = DoWhile { doWhileCondition :: !a, doWhileBody :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically DoWhile
 
 instance Evaluatable DoWhile where
@@ -250,7 +250,7 @@ instance Evaluatable DoWhile where
 -- Exception handling
 
 newtype Throw a = Throw { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Throw
 
 -- TODO: Implement Eval instance for Throw
@@ -258,21 +258,21 @@ instance Evaluatable Throw
 
 
 data Try a = Try { tryBody :: !a, tryCatch :: ![a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Try
 
 -- TODO: Implement Eval instance for Try
 instance Evaluatable Try
 
 data Catch a = Catch { catchException :: !a, catchBody :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Catch
 
 -- TODO: Implement Eval instance for Catch
 instance Evaluatable Catch
 
 newtype Finally a = Finally { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Finally
 
 -- TODO: Implement Eval instance for Finally
@@ -282,7 +282,7 @@ instance Evaluatable Finally
 
 -- | ScopeEntry (e.g. `BEGIN {}` block in Ruby or Perl).
 newtype ScopeEntry a = ScopeEntry { terms :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically ScopeEntry
 
 -- TODO: Implement Eval instance for ScopeEntry
@@ -291,7 +291,7 @@ instance Evaluatable ScopeEntry
 
 -- | ScopeExit (e.g. `END {}` block in Ruby or Perl).
 newtype ScopeExit a = ScopeExit { terms :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically ScopeExit
 
 -- TODO: Implement Eval instance for ScopeExit

--- a/src/Data/Syntax/Statement.hs
+++ b/src/Data/Syntax/Statement.hs
@@ -22,7 +22,10 @@ import           Diffing.Algorithm
 --   TODO: Separate top-level statement nodes into non-lexical Statement and lexical StatementBlock nodes
 newtype Statements a = Statements { statements :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Statements
+
+instance Eq1 Statements where liftEq = genericLiftEq
+instance Ord1 Statements where liftCompare = genericLiftCompare
+instance Show1 Statements where liftShowsPrec = genericLiftShowsPrec
 
 instance ToJSON1 Statements
 
@@ -32,7 +35,10 @@ instance Evaluatable Statements where
 
 newtype StatementBlock a = StatementBlock { statements :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically StatementBlock
+
+instance Eq1 StatementBlock where liftEq = genericLiftEq
+instance Ord1 StatementBlock where liftCompare = genericLiftCompare
+instance Show1 StatementBlock where liftShowsPrec = genericLiftShowsPrec
 
 instance ToJSON1 StatementBlock
 
@@ -43,7 +49,10 @@ instance Evaluatable StatementBlock where
 -- | Conditional. This must have an else block, which can be filled with some default value when omitted in the source, e.g. 'pure ()' for C-style if-without-else or 'pure Nothing' for Ruby-style, in both cases assuming some appropriate Applicative context into which the If will be lifted.
 data If a = If { ifCondition :: !a, ifThenBody :: !a, ifElseBody :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically If
+
+instance Eq1 If where liftEq = genericLiftEq
+instance Ord1 If where liftCompare = genericLiftCompare
+instance Show1 If where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable If where
   eval eval _ (If cond if' else') = do
@@ -54,7 +63,10 @@ instance Evaluatable If where
 -- | Else statement. The else condition is any term, that upon successful completion, continues evaluation to the elseBody, e.g. `for ... else` in Python.
 data Else a = Else { elseCondition :: !a, elseBody :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Else
+
+instance Eq1 Else where liftEq = genericLiftEq
+instance Ord1 Else where liftCompare = genericLiftCompare
+instance Show1 Else where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Else
 instance Evaluatable Else
@@ -65,7 +77,10 @@ instance Evaluatable Else
 -- | Goto statement (e.g. `goto a` in Go).
 newtype Goto a = Goto { gotoLocation :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Goto
+
+instance Eq1 Goto where liftEq = genericLiftEq
+instance Ord1 Goto where liftCompare = genericLiftCompare
+instance Show1 Goto where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Goto
 instance Evaluatable Goto
@@ -73,7 +88,10 @@ instance Evaluatable Goto
 -- | A pattern-matching or computed jump control-flow statement, like 'switch' in C or JavaScript, or 'case' in Ruby or Haskell.
 data Match a = Match { matchSubject :: !a, matchPatterns :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Match
+
+instance Eq1 Match where liftEq = genericLiftEq
+instance Ord1 Match where liftCompare = genericLiftCompare
+instance Show1 Match where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Match
 instance Evaluatable Match
@@ -82,7 +100,10 @@ instance Evaluatable Match
 -- | A pattern in a pattern-matching or computed jump control-flow statement, like 'case' in C or JavaScript, 'when' in Ruby, or the left-hand side of '->' in the body of Haskell 'case' expressions.
 data Pattern a = Pattern { value :: !a, patternBody :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Pattern
+
+instance Eq1 Pattern where liftEq = genericLiftEq
+instance Ord1 Pattern where liftCompare = genericLiftCompare
+instance Show1 Pattern where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Pattern
 instance Evaluatable Pattern
@@ -90,7 +111,10 @@ instance Evaluatable Pattern
 -- | A let statement or local binding, like 'a as b' or 'let a = b'.
 data Let a  = Let { letVariable :: !a, letValue :: !a, letBody :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Let
+
+instance Eq1 Let where liftEq = genericLiftEq
+instance Ord1 Let where liftCompare = genericLiftCompare
+instance Show1 Let where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Let where
   eval eval _ Let{..} = do
@@ -113,7 +137,10 @@ instance Evaluatable Let where
 -- | Assignment to a variable or other lvalue.
 data Assignment a = Assignment { assignmentContext :: ![a], assignmentTarget :: !a, assignmentValue :: !a }
   deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Assignment
+
+instance Eq1 Assignment where liftEq = genericLiftEq
+instance Ord1 Assignment where liftCompare = genericLiftCompare
+instance Show1 Assignment where liftShowsPrec = genericLiftShowsPrec
 
 instance Declarations1 Assignment where
   liftDeclaredName declaredName Assignment{..} = declaredName assignmentTarget
@@ -140,7 +167,10 @@ instance Evaluatable Assignment where
 -- | Post increment operator (e.g. 1++ in Go, or i++ in C).
 newtype PostIncrement a = PostIncrement { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically PostIncrement
+
+instance Eq1 PostIncrement where liftEq = genericLiftEq
+instance Ord1 PostIncrement where liftCompare = genericLiftCompare
+instance Show1 PostIncrement where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for PostIncrement
 instance Evaluatable PostIncrement
@@ -149,7 +179,10 @@ instance Evaluatable PostIncrement
 -- | Post decrement operator (e.g. 1-- in Go, or i-- in C).
 newtype PostDecrement a = PostDecrement { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically PostDecrement
+
+instance Eq1 PostDecrement where liftEq = genericLiftEq
+instance Ord1 PostDecrement where liftCompare = genericLiftCompare
+instance Show1 PostDecrement where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for PostDecrement
 instance Evaluatable PostDecrement
@@ -157,7 +190,10 @@ instance Evaluatable PostDecrement
 -- | Pre increment operator (e.g. ++1 in C or Java).
 newtype PreIncrement a = PreIncrement { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically PreIncrement
+
+instance Eq1 PreIncrement where liftEq = genericLiftEq
+instance Ord1 PreIncrement where liftCompare = genericLiftCompare
+instance Show1 PreIncrement where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for PreIncrement
 instance Evaluatable PreIncrement
@@ -166,7 +202,10 @@ instance Evaluatable PreIncrement
 -- | Pre decrement operator (e.g. --1 in C or Java).
 newtype PreDecrement a = PreDecrement { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically PreDecrement
+
+instance Eq1 PreDecrement where liftEq = genericLiftEq
+instance Ord1 PreDecrement where liftCompare = genericLiftCompare
+instance Show1 PreDecrement where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for PreDecrement
 instance Evaluatable PreDecrement
@@ -176,14 +215,20 @@ instance Evaluatable PreDecrement
 
 newtype Return a = Return { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Return
+
+instance Eq1 Return where liftEq = genericLiftEq
+instance Ord1 Return where liftCompare = genericLiftCompare
+instance Show1 Return where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Return where
   eval eval _ (Return x) = eval x >>= earlyReturn
 
 newtype Yield a = Yield { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Yield
+
+instance Eq1 Yield where liftEq = genericLiftEq
+instance Ord1 Yield where liftCompare = genericLiftCompare
+instance Show1 Yield where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Yield
 instance Evaluatable Yield
@@ -191,28 +236,40 @@ instance Evaluatable Yield
 
 newtype Break a = Break { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Break
+
+instance Eq1 Break where liftEq = genericLiftEq
+instance Ord1 Break where liftCompare = genericLiftCompare
+instance Show1 Break where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Break where
   eval eval _ (Break x) = eval x >>= throwBreak
 
 newtype Continue a = Continue { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Continue
+
+instance Eq1 Continue where liftEq = genericLiftEq
+instance Ord1 Continue where liftCompare = genericLiftCompare
+instance Show1 Continue where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Continue where
   eval eval _ (Continue x) = eval x >>= throwContinue
 
 newtype Retry a = Retry { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Retry
+
+instance Eq1 Retry where liftEq = genericLiftEq
+instance Ord1 Retry where liftCompare = genericLiftCompare
+instance Show1 Retry where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Retry
 instance Evaluatable Retry
 
 newtype NoOp a = NoOp { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically NoOp
+
+instance Eq1 NoOp where liftEq = genericLiftEq
+instance Ord1 NoOp where liftCompare = genericLiftCompare
+instance Show1 NoOp where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable NoOp where
   eval _ _ _ = unit
@@ -221,28 +278,40 @@ instance Evaluatable NoOp where
 
 data For a = For { forBefore :: !a, forCondition :: !a, forStep :: !a, forBody :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically For
+
+instance Eq1 For where liftEq = genericLiftEq
+instance Ord1 For where liftCompare = genericLiftCompare
+instance Show1 For where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable For where
   eval eval _ (fmap eval -> For before cond step body) = forLoop before cond step body
 
 data ForEach a = ForEach { forEachBinding :: !a, forEachSubject :: !a, forEachBody :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically ForEach
+
+instance Eq1 ForEach where liftEq = genericLiftEq
+instance Ord1 ForEach where liftCompare = genericLiftCompare
+instance Show1 ForEach where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for ForEach
 instance Evaluatable ForEach
 
 data While a = While { whileCondition :: !a, whileBody :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically While
+
+instance Eq1 While where liftEq = genericLiftEq
+instance Ord1 While where liftCompare = genericLiftCompare
+instance Show1 While where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable While where
   eval eval _ While{..} = while (eval whileCondition) (eval whileBody)
 
 data DoWhile a = DoWhile { doWhileCondition :: !a, doWhileBody :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically DoWhile
+
+instance Eq1 DoWhile where liftEq = genericLiftEq
+instance Ord1 DoWhile where liftCompare = genericLiftCompare
+instance Show1 DoWhile where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable DoWhile where
   eval eval _ DoWhile{..} = doWhile (eval doWhileBody) (eval doWhileCondition)
@@ -251,7 +320,10 @@ instance Evaluatable DoWhile where
 
 newtype Throw a = Throw { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Throw
+
+instance Eq1 Throw where liftEq = genericLiftEq
+instance Ord1 Throw where liftCompare = genericLiftCompare
+instance Show1 Throw where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Throw
 instance Evaluatable Throw
@@ -259,21 +331,30 @@ instance Evaluatable Throw
 
 data Try a = Try { tryBody :: !a, tryCatch :: ![a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Try
+
+instance Eq1 Try where liftEq = genericLiftEq
+instance Ord1 Try where liftCompare = genericLiftCompare
+instance Show1 Try where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Try
 instance Evaluatable Try
 
 data Catch a = Catch { catchException :: !a, catchBody :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Catch
+
+instance Eq1 Catch where liftEq = genericLiftEq
+instance Ord1 Catch where liftCompare = genericLiftCompare
+instance Show1 Catch where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Catch
 instance Evaluatable Catch
 
 newtype Finally a = Finally { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Finally
+
+instance Eq1 Finally where liftEq = genericLiftEq
+instance Ord1 Finally where liftCompare = genericLiftCompare
+instance Show1 Finally where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Finally
 instance Evaluatable Finally
@@ -283,7 +364,10 @@ instance Evaluatable Finally
 -- | ScopeEntry (e.g. `BEGIN {}` block in Ruby or Perl).
 newtype ScopeEntry a = ScopeEntry { terms :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically ScopeEntry
+
+instance Eq1 ScopeEntry where liftEq = genericLiftEq
+instance Ord1 ScopeEntry where liftCompare = genericLiftCompare
+instance Show1 ScopeEntry where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for ScopeEntry
 instance Evaluatable ScopeEntry
@@ -292,7 +376,10 @@ instance Evaluatable ScopeEntry
 -- | ScopeExit (e.g. `END {}` block in Ruby or Perl).
 newtype ScopeExit a = ScopeExit { terms :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically ScopeExit
+
+instance Eq1 ScopeExit where liftEq = genericLiftEq
+instance Ord1 ScopeExit where liftCompare = genericLiftCompare
+instance Show1 ScopeExit where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for ScopeExit
 instance Evaluatable ScopeExit

--- a/src/Data/Syntax/Statement.hs
+++ b/src/Data/Syntax/Statement.hs
@@ -21,7 +21,7 @@ import           Diffing.Algorithm
 --   3. Only the last statement’s return value is returned.
 --   TODO: Separate top-level statement nodes into non-lexical Statement and lexical StatementBlock nodes
 newtype Statements a = Statements { statements :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Statements where liftEq = genericLiftEq
 instance Ord1 Statements where liftCompare = genericLiftCompare
@@ -34,7 +34,7 @@ instance Evaluatable Statements where
     maybe unit (runApp . foldMap1 (App . eval)) (nonEmpty xs)
 
 newtype StatementBlock a = StatementBlock { statements :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 StatementBlock where liftEq = genericLiftEq
 instance Ord1 StatementBlock where liftCompare = genericLiftCompare
@@ -48,7 +48,7 @@ instance Evaluatable StatementBlock where
 
 -- | Conditional. This must have an else block, which can be filled with some default value when omitted in the source, e.g. 'pure ()' for C-style if-without-else or 'pure Nothing' for Ruby-style, in both cases assuming some appropriate Applicative context into which the If will be lifted.
 data If a = If { ifCondition :: !a, ifThenBody :: !a, ifElseBody :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 If where liftEq = genericLiftEq
 instance Ord1 If where liftCompare = genericLiftCompare
@@ -62,7 +62,7 @@ instance Evaluatable If where
 
 -- | Else statement. The else condition is any term, that upon successful completion, continues evaluation to the elseBody, e.g. `for ... else` in Python.
 data Else a = Else { elseCondition :: !a, elseBody :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Else where liftEq = genericLiftEq
 instance Ord1 Else where liftCompare = genericLiftCompare
@@ -76,7 +76,7 @@ instance Evaluatable Else
 
 -- | Goto statement (e.g. `goto a` in Go).
 newtype Goto a = Goto { gotoLocation :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Goto where liftEq = genericLiftEq
 instance Ord1 Goto where liftCompare = genericLiftCompare
@@ -87,7 +87,7 @@ instance Evaluatable Goto
 
 -- | A pattern-matching or computed jump control-flow statement, like 'switch' in C or JavaScript, or 'case' in Ruby or Haskell.
 data Match a = Match { matchSubject :: !a, matchPatterns :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Match where liftEq = genericLiftEq
 instance Ord1 Match where liftCompare = genericLiftCompare
@@ -99,7 +99,7 @@ instance Evaluatable Match
 
 -- | A pattern in a pattern-matching or computed jump control-flow statement, like 'case' in C or JavaScript, 'when' in Ruby, or the left-hand side of '->' in the body of Haskell 'case' expressions.
 data Pattern a = Pattern { value :: !a, patternBody :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Pattern where liftEq = genericLiftEq
 instance Ord1 Pattern where liftCompare = genericLiftCompare
@@ -110,7 +110,7 @@ instance Evaluatable Pattern
 
 -- | A let statement or local binding, like 'a as b' or 'let a = b'.
 data Let a  = Let { letVariable :: !a, letValue :: !a, letBody :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Let where liftEq = genericLiftEq
 instance Ord1 Let where liftCompare = genericLiftCompare
@@ -136,7 +136,7 @@ instance Evaluatable Let where
 
 -- | Assignment to a variable or other lvalue.
 data Assignment a = Assignment { assignmentContext :: ![a], assignmentTarget :: !a, assignmentValue :: !a }
-  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Assignment where liftEq = genericLiftEq
 instance Ord1 Assignment where liftCompare = genericLiftCompare
@@ -166,7 +166,7 @@ instance Evaluatable Assignment where
 
 -- | Post increment operator (e.g. 1++ in Go, or i++ in C).
 newtype PostIncrement a = PostIncrement { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 PostIncrement where liftEq = genericLiftEq
 instance Ord1 PostIncrement where liftCompare = genericLiftCompare
@@ -178,7 +178,7 @@ instance Evaluatable PostIncrement
 
 -- | Post decrement operator (e.g. 1-- in Go, or i-- in C).
 newtype PostDecrement a = PostDecrement { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 PostDecrement where liftEq = genericLiftEq
 instance Ord1 PostDecrement where liftCompare = genericLiftCompare
@@ -189,7 +189,7 @@ instance Evaluatable PostDecrement
 
 -- | Pre increment operator (e.g. ++1 in C or Java).
 newtype PreIncrement a = PreIncrement { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 PreIncrement where liftEq = genericLiftEq
 instance Ord1 PreIncrement where liftCompare = genericLiftCompare
@@ -201,7 +201,7 @@ instance Evaluatable PreIncrement
 
 -- | Pre decrement operator (e.g. --1 in C or Java).
 newtype PreDecrement a = PreDecrement { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 PreDecrement where liftEq = genericLiftEq
 instance Ord1 PreDecrement where liftCompare = genericLiftCompare
@@ -214,7 +214,7 @@ instance Evaluatable PreDecrement
 -- Returns
 
 newtype Return a = Return { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Return where liftEq = genericLiftEq
 instance Ord1 Return where liftCompare = genericLiftCompare
@@ -224,7 +224,7 @@ instance Evaluatable Return where
   eval eval _ (Return x) = eval x >>= earlyReturn
 
 newtype Yield a = Yield { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Yield where liftEq = genericLiftEq
 instance Ord1 Yield where liftCompare = genericLiftCompare
@@ -235,7 +235,7 @@ instance Evaluatable Yield
 
 
 newtype Break a = Break { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Break where liftEq = genericLiftEq
 instance Ord1 Break where liftCompare = genericLiftCompare
@@ -245,7 +245,7 @@ instance Evaluatable Break where
   eval eval _ (Break x) = eval x >>= throwBreak
 
 newtype Continue a = Continue { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Continue where liftEq = genericLiftEq
 instance Ord1 Continue where liftCompare = genericLiftCompare
@@ -255,7 +255,7 @@ instance Evaluatable Continue where
   eval eval _ (Continue x) = eval x >>= throwContinue
 
 newtype Retry a = Retry { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Retry where liftEq = genericLiftEq
 instance Ord1 Retry where liftCompare = genericLiftCompare
@@ -265,7 +265,7 @@ instance Show1 Retry where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Retry
 
 newtype NoOp a = NoOp { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 NoOp where liftEq = genericLiftEq
 instance Ord1 NoOp where liftCompare = genericLiftCompare
@@ -277,7 +277,7 @@ instance Evaluatable NoOp where
 -- Loops
 
 data For a = For { forBefore :: !a, forCondition :: !a, forStep :: !a, forBody :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 For where liftEq = genericLiftEq
 instance Ord1 For where liftCompare = genericLiftCompare
@@ -287,7 +287,7 @@ instance Evaluatable For where
   eval eval _ (fmap eval -> For before cond step body) = forLoop before cond step body
 
 data ForEach a = ForEach { forEachBinding :: !a, forEachSubject :: !a, forEachBody :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ForEach where liftEq = genericLiftEq
 instance Ord1 ForEach where liftCompare = genericLiftCompare
@@ -297,7 +297,7 @@ instance Show1 ForEach where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ForEach
 
 data While a = While { whileCondition :: !a, whileBody :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 While where liftEq = genericLiftEq
 instance Ord1 While where liftCompare = genericLiftCompare
@@ -307,7 +307,7 @@ instance Evaluatable While where
   eval eval _ While{..} = while (eval whileCondition) (eval whileBody)
 
 data DoWhile a = DoWhile { doWhileCondition :: !a, doWhileBody :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 DoWhile where liftEq = genericLiftEq
 instance Ord1 DoWhile where liftCompare = genericLiftCompare
@@ -319,7 +319,7 @@ instance Evaluatable DoWhile where
 -- Exception handling
 
 newtype Throw a = Throw { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Throw where liftEq = genericLiftEq
 instance Ord1 Throw where liftCompare = genericLiftCompare
@@ -330,7 +330,7 @@ instance Evaluatable Throw
 
 
 data Try a = Try { tryBody :: !a, tryCatch :: ![a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Try where liftEq = genericLiftEq
 instance Ord1 Try where liftCompare = genericLiftCompare
@@ -340,7 +340,7 @@ instance Show1 Try where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Try
 
 data Catch a = Catch { catchException :: !a, catchBody :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Catch where liftEq = genericLiftEq
 instance Ord1 Catch where liftCompare = genericLiftCompare
@@ -350,7 +350,7 @@ instance Show1 Catch where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Catch
 
 newtype Finally a = Finally { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Finally where liftEq = genericLiftEq
 instance Ord1 Finally where liftCompare = genericLiftCompare
@@ -363,7 +363,7 @@ instance Evaluatable Finally
 
 -- | ScopeEntry (e.g. `BEGIN {}` block in Ruby or Perl).
 newtype ScopeEntry a = ScopeEntry { terms :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ScopeEntry where liftEq = genericLiftEq
 instance Ord1 ScopeEntry where liftCompare = genericLiftCompare
@@ -375,7 +375,7 @@ instance Evaluatable ScopeEntry
 
 -- | ScopeExit (e.g. `END {}` block in Ruby or Perl).
 newtype ScopeExit a = ScopeExit { terms :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ScopeExit where liftEq = genericLiftEq
 instance Ord1 ScopeExit where liftCompare = genericLiftCompare

--- a/src/Data/Syntax/Type.hs
+++ b/src/Data/Syntax/Type.hs
@@ -9,7 +9,7 @@ import Prelude hiding (Bool, Float, Int, Double)
 import Prologue hiding (Map)
 
 data Array a = Array { arraySize :: Maybe a, arrayElementType :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Array
 
 -- TODO: Implement Eval instance for Array
@@ -18,7 +18,7 @@ instance Evaluatable Array
 
 -- TODO: What about type variables? re: FreeVariables1
 data Annotation a = Annotation { annotationSubject :: a, annotationType :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Annotation
 
 -- TODO: Specialize Evaluatable for Type to unify the inferred type of the subject with the specified type
@@ -27,7 +27,7 @@ instance Evaluatable Annotation where
 
 
 data Function a = Function { functionParameters :: [a], functionReturn :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Function
 
 -- TODO: Implement Eval instance for Function
@@ -35,35 +35,35 @@ instance Evaluatable Function
 
 
 newtype Interface a = Interface { values :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Interface
 
 -- TODO: Implement Eval instance for Interface
 instance Evaluatable Interface
 
 data Map a = Map { mapKeyType :: a, mapElementType :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Map
 
 -- TODO: Implement Eval instance for Map
 instance Evaluatable Map
 
 newtype Parenthesized a = Parenthesized { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Parenthesized
 
 -- TODO: Implement Eval instance for Parenthesized
 instance Evaluatable Parenthesized
 
 newtype Pointer a = Pointer { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Pointer
 
 -- TODO: Implement Eval instance for Pointer
 instance Evaluatable Pointer
 
 newtype Product a = Product { values :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Product
 
 -- TODO: Implement Eval instance for Product
@@ -71,21 +71,21 @@ instance Evaluatable Product
 
 
 data Readonly a = Readonly
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Readonly
 
 -- TODO: Implement Eval instance for Readonly
 instance Evaluatable Readonly
 
 newtype Slice a = Slice { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Slice
 
 -- TODO: Implement Eval instance for Slice
 instance Evaluatable Slice
 
 newtype TypeParameters a = TypeParameters { terms :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically TypeParameters
 
 -- TODO: Implement Eval instance for TypeParameters
@@ -93,7 +93,7 @@ instance Evaluatable TypeParameters
 
 -- data instead of newtype because no payload
 data Void a = Void
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Void
 
 -- TODO: Implement Eval instance for Void
@@ -101,28 +101,28 @@ instance Evaluatable Void
 
 -- data instead of newtype because no payload
 data Int a = Int
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Int
 
 -- TODO: Implement Eval instance for Int
 instance Evaluatable Int
 
 data Float a = Float
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Float
 
 -- TODO: Implement Eval instance for Float
 instance Evaluatable Float
 
 data Double a = Double
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Double
 
 -- TODO: Implement Eval instance for Double
 instance Evaluatable Double
 
 data Bool a = Bool
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Bool
 
 -- TODO: Implement Eval instance for Float

--- a/src/Data/Syntax/Type.hs
+++ b/src/Data/Syntax/Type.hs
@@ -10,7 +10,10 @@ import Prologue hiding (Map)
 
 data Array a = Array { arraySize :: Maybe a, arrayElementType :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Array
+
+instance Eq1 Array where liftEq = genericLiftEq
+instance Ord1 Array where liftCompare = genericLiftCompare
+instance Show1 Array where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Array
 instance Evaluatable Array
@@ -19,7 +22,10 @@ instance Evaluatable Array
 -- TODO: What about type variables? re: FreeVariables1
 data Annotation a = Annotation { annotationSubject :: a, annotationType :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Annotation
+
+instance Eq1 Annotation where liftEq = genericLiftEq
+instance Ord1 Annotation where liftCompare = genericLiftCompare
+instance Show1 Annotation where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Specialize Evaluatable for Type to unify the inferred type of the subject with the specified type
 instance Evaluatable Annotation where
@@ -28,7 +34,10 @@ instance Evaluatable Annotation where
 
 data Function a = Function { functionParameters :: [a], functionReturn :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Function
+
+instance Eq1 Function where liftEq = genericLiftEq
+instance Ord1 Function where liftCompare = genericLiftCompare
+instance Show1 Function where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Function
 instance Evaluatable Function
@@ -36,35 +45,50 @@ instance Evaluatable Function
 
 newtype Interface a = Interface { values :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Interface
+
+instance Eq1 Interface where liftEq = genericLiftEq
+instance Ord1 Interface where liftCompare = genericLiftCompare
+instance Show1 Interface where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Interface
 instance Evaluatable Interface
 
 data Map a = Map { mapKeyType :: a, mapElementType :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Map
+
+instance Eq1 Map where liftEq = genericLiftEq
+instance Ord1 Map where liftCompare = genericLiftCompare
+instance Show1 Map where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Map
 instance Evaluatable Map
 
 newtype Parenthesized a = Parenthesized { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Parenthesized
+
+instance Eq1 Parenthesized where liftEq = genericLiftEq
+instance Ord1 Parenthesized where liftCompare = genericLiftCompare
+instance Show1 Parenthesized where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Parenthesized
 instance Evaluatable Parenthesized
 
 newtype Pointer a = Pointer { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Pointer
+
+instance Eq1 Pointer where liftEq = genericLiftEq
+instance Ord1 Pointer where liftCompare = genericLiftCompare
+instance Show1 Pointer where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Pointer
 instance Evaluatable Pointer
 
 newtype Product a = Product { values :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Product
+
+instance Eq1 Product where liftEq = genericLiftEq
+instance Ord1 Product where liftCompare = genericLiftCompare
+instance Show1 Product where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Product
 instance Evaluatable Product
@@ -72,21 +96,30 @@ instance Evaluatable Product
 
 data Readonly a = Readonly
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Readonly
+
+instance Eq1 Readonly where liftEq = genericLiftEq
+instance Ord1 Readonly where liftCompare = genericLiftCompare
+instance Show1 Readonly where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Readonly
 instance Evaluatable Readonly
 
 newtype Slice a = Slice { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Slice
+
+instance Eq1 Slice where liftEq = genericLiftEq
+instance Ord1 Slice where liftCompare = genericLiftCompare
+instance Show1 Slice where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Slice
 instance Evaluatable Slice
 
 newtype TypeParameters a = TypeParameters { terms :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically TypeParameters
+
+instance Eq1 TypeParameters where liftEq = genericLiftEq
+instance Ord1 TypeParameters where liftCompare = genericLiftCompare
+instance Show1 TypeParameters where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for TypeParameters
 instance Evaluatable TypeParameters
@@ -94,7 +127,10 @@ instance Evaluatable TypeParameters
 -- data instead of newtype because no payload
 data Void a = Void
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Void
+
+instance Eq1 Void where liftEq = genericLiftEq
+instance Ord1 Void where liftCompare = genericLiftCompare
+instance Show1 Void where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Void
 instance Evaluatable Void
@@ -102,28 +138,40 @@ instance Evaluatable Void
 -- data instead of newtype because no payload
 data Int a = Int
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Int
+
+instance Eq1 Int where liftEq = genericLiftEq
+instance Ord1 Int where liftCompare = genericLiftCompare
+instance Show1 Int where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Int
 instance Evaluatable Int
 
 data Float a = Float
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Float
+
+instance Eq1 Float where liftEq = genericLiftEq
+instance Ord1 Float where liftCompare = genericLiftCompare
+instance Show1 Float where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Float
 instance Evaluatable Float
 
 data Double a = Double
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Double
+
+instance Eq1 Double where liftEq = genericLiftEq
+instance Ord1 Double where liftCompare = genericLiftCompare
+instance Show1 Double where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Double
 instance Evaluatable Double
 
 data Bool a = Bool
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Bool
+
+instance Eq1 Bool where liftEq = genericLiftEq
+instance Ord1 Bool where liftCompare = genericLiftCompare
+instance Show1 Bool where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Float
 instance Evaluatable Bool

--- a/src/Data/Syntax/Type.hs
+++ b/src/Data/Syntax/Type.hs
@@ -9,7 +9,7 @@ import Prelude hiding (Bool, Float, Int, Double)
 import Prologue hiding (Map)
 
 data Array a = Array { arraySize :: Maybe a, arrayElementType :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Array where liftEq = genericLiftEq
 instance Ord1 Array where liftCompare = genericLiftCompare
@@ -21,7 +21,7 @@ instance Evaluatable Array
 
 -- TODO: What about type variables? re: FreeVariables1
 data Annotation a = Annotation { annotationSubject :: a, annotationType :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Annotation where liftEq = genericLiftEq
 instance Ord1 Annotation where liftCompare = genericLiftCompare
@@ -33,7 +33,7 @@ instance Evaluatable Annotation where
 
 
 data Function a = Function { functionParameters :: [a], functionReturn :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Function where liftEq = genericLiftEq
 instance Ord1 Function where liftCompare = genericLiftCompare
@@ -44,7 +44,7 @@ instance Evaluatable Function
 
 
 newtype Interface a = Interface { values :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Interface where liftEq = genericLiftEq
 instance Ord1 Interface where liftCompare = genericLiftCompare
@@ -54,7 +54,7 @@ instance Show1 Interface where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Interface
 
 data Map a = Map { mapKeyType :: a, mapElementType :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Map where liftEq = genericLiftEq
 instance Ord1 Map where liftCompare = genericLiftCompare
@@ -64,7 +64,7 @@ instance Show1 Map where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Map
 
 newtype Parenthesized a = Parenthesized { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Parenthesized where liftEq = genericLiftEq
 instance Ord1 Parenthesized where liftCompare = genericLiftCompare
@@ -74,7 +74,7 @@ instance Show1 Parenthesized where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Parenthesized
 
 newtype Pointer a = Pointer { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Pointer where liftEq = genericLiftEq
 instance Ord1 Pointer where liftCompare = genericLiftCompare
@@ -84,7 +84,7 @@ instance Show1 Pointer where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Pointer
 
 newtype Product a = Product { values :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Product where liftEq = genericLiftEq
 instance Ord1 Product where liftCompare = genericLiftCompare
@@ -95,7 +95,7 @@ instance Evaluatable Product
 
 
 data Readonly a = Readonly
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Readonly where liftEq = genericLiftEq
 instance Ord1 Readonly where liftCompare = genericLiftCompare
@@ -105,7 +105,7 @@ instance Show1 Readonly where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Readonly
 
 newtype Slice a = Slice { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Slice where liftEq = genericLiftEq
 instance Ord1 Slice where liftCompare = genericLiftCompare
@@ -115,7 +115,7 @@ instance Show1 Slice where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Slice
 
 newtype TypeParameters a = TypeParameters { terms :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 TypeParameters where liftEq = genericLiftEq
 instance Ord1 TypeParameters where liftCompare = genericLiftCompare
@@ -126,7 +126,7 @@ instance Evaluatable TypeParameters
 
 -- data instead of newtype because no payload
 data Void a = Void
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Void where liftEq = genericLiftEq
 instance Ord1 Void where liftCompare = genericLiftCompare
@@ -137,7 +137,7 @@ instance Evaluatable Void
 
 -- data instead of newtype because no payload
 data Int a = Int
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Int where liftEq = genericLiftEq
 instance Ord1 Int where liftCompare = genericLiftCompare
@@ -147,7 +147,7 @@ instance Show1 Int where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Int
 
 data Float a = Float
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Float where liftEq = genericLiftEq
 instance Ord1 Float where liftCompare = genericLiftCompare
@@ -157,7 +157,7 @@ instance Show1 Float where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Float
 
 data Double a = Double
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Double where liftEq = genericLiftEq
 instance Ord1 Double where liftCompare = genericLiftCompare
@@ -167,7 +167,7 @@ instance Show1 Double where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Double
 
 data Bool a = Bool
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Bool where liftEq = genericLiftEq
 instance Ord1 Bool where liftCompare = genericLiftCompare

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -99,12 +99,6 @@ instance Ord1 f => Ord1 (Term f) where
 instance (Ord1 f, Ord a) => Ord (Term f a) where
   compare = compare1
 
-instance NFData1 f => NFData1 (Term f) where
-  liftRnf rnf = go where go x = liftRnf2 rnf go (unTerm x)
-
-instance (NFData1 f, NFData a) => NFData (Term f a) where
-  rnf = liftRnf rnf
-
 
 instance Functor f => Bifunctor (TermF f) where
   bimap f g (In a r) = In (f a) (fmap g r)
@@ -134,9 +128,6 @@ instance Ord1 f => Ord2 (TermF f) where
 
 instance (Ord1 f, Ord a) => Ord1 (TermF f a) where
   liftCompare = liftCompare2 compare
-
-instance NFData1 f => NFData2 (TermF f) where
-  liftRnf2 rnf1 rnf2 (In a1 f1) = rnf1 a1 `seq` liftRnf rnf2 f1
 
 instance (ToJSONFields a, ToJSONFields1 f) => ToJSON (Term f a) where
   toJSON = object . toJSONFields

--- a/src/Language/Go/Syntax.hs
+++ b/src/Language/Go/Syntax.hs
@@ -51,7 +51,7 @@ resolveGoImport (ImportPath path NonRelative) = do
 --
 -- If the list of symbols is empty copy everything to the calling environment.
 data Import a = Import { importFrom :: ImportPath, importWildcardToken :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Import
 
 instance Evaluatable Import where
@@ -69,7 +69,7 @@ instance Evaluatable Import where
 --
 -- If the list of symbols is empty copy and qualify everything to the calling environment.
 data QualifiedImport a = QualifiedImport { qualifiedImportFrom :: !ImportPath, qualifiedImportAlias :: !a}
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically QualifiedImport
 
 instance Evaluatable QualifiedImport where
@@ -99,7 +99,7 @@ instance Evaluatable QualifiedImport where
 
 -- | Side effect only imports (no symbols made available to the calling environment).
 data SideEffectImport a = SideEffectImport { sideEffectImportFrom :: !ImportPath, sideEffectImportToken :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically SideEffectImport
 
 -- TODO: Revisit this and confirm if this is correct.
@@ -112,7 +112,7 @@ instance Evaluatable SideEffectImport where
 
 -- A composite literal in Go
 data Composite a = Composite { compositeType :: !a, compositeElement :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Composite
 
 -- TODO: Implement Eval instance for Composite
@@ -120,7 +120,7 @@ instance Evaluatable Composite
 
 -- | A default pattern in a Go select or switch statement (e.g. `switch { default: s() }`).
 newtype DefaultPattern a = DefaultPattern { defaultPatternBody :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically DefaultPattern
 
 -- TODO: Implement Eval instance for DefaultPattern
@@ -128,7 +128,7 @@ instance Evaluatable DefaultPattern
 
 -- | A defer statement in Go (e.g. `defer x()`).
 newtype Defer a = Defer { deferBody :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Defer
 
 -- TODO: Implement Eval instance for Defer
@@ -136,7 +136,7 @@ instance Evaluatable Defer
 
 -- | A go statement (i.e. go routine) in Go (e.g. `go x()`).
 newtype Go a = Go { goBody :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Go
 
 -- TODO: Implement Eval instance for Go
@@ -144,7 +144,7 @@ instance Evaluatable Go
 
 -- | A label statement in Go (e.g. `label:continue`).
 data Label a = Label { labelName :: !a, labelStatement :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Label
 
 -- TODO: Implement Eval instance for Label
@@ -152,7 +152,7 @@ instance Evaluatable Label
 
 -- | A rune literal in Go (e.g. `'⌘'`).
 newtype Rune a = Rune { runeLiteral :: Text }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Rune
 
 -- TODO: Implement Eval instance for Rune
@@ -160,7 +160,7 @@ instance Evaluatable Rune
 
 -- | A select statement in Go (e.g. `select { case x := <-c: x() }` where each case is a send or receive operation on channels).
 newtype Select a = Select { selectCases :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Select
 
 -- TODO: Implement Eval instance for Select
@@ -168,7 +168,7 @@ instance Evaluatable Select
 
 -- | A send statement in Go (e.g. `channel <- value`).
 data Send a = Send { sendReceiver :: !a, sendValue :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Send
 
 -- TODO: Implement Eval instance for Send
@@ -176,7 +176,7 @@ instance Evaluatable Send
 
 -- | A slice expression in Go (e.g. `a[1:4:3]` where a is a list, 1 is the low bound, 4 is the high bound, and 3 is the max capacity).
 data Slice a = Slice { sliceName :: !a, sliceLow :: !a, sliceHigh :: !a, sliceCapacity :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Slice
 
 -- TODO: Implement Eval instance for Slice
@@ -184,7 +184,7 @@ instance Evaluatable Slice
 
 -- | A type switch statement in Go (e.g. `switch x.(type) { // cases }`).
 data TypeSwitch a = TypeSwitch { typeSwitchSubject :: !a, typeSwitchCases :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically TypeSwitch
 
 -- TODO: Implement Eval instance for TypeSwitch
@@ -192,7 +192,7 @@ instance Evaluatable TypeSwitch
 
 -- | A type switch guard statement in a Go type switch statement (e.g. `switch i := x.(type) { // cases}`).
 newtype TypeSwitchGuard a = TypeSwitchGuard { typeSwitchGuardSubject :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically TypeSwitchGuard
 
 -- TODO: Implement Eval instance for TypeSwitchGuard
@@ -200,7 +200,7 @@ instance Evaluatable TypeSwitchGuard
 
 -- | A receive statement in a Go select statement (e.g. `case value := <-channel` )
 data Receive a = Receive { receiveSubject :: !a, receiveExpression :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Receive
 
 -- TODO: Implement Eval instance for Receive
@@ -208,7 +208,7 @@ instance Evaluatable Receive
 
 -- | A receive operator unary expression in Go (e.g. `<-channel` )
 newtype ReceiveOperator a = ReceiveOperator { value :: a}
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically ReceiveOperator
 
 -- TODO: Implement Eval instance for ReceiveOperator
@@ -216,14 +216,14 @@ instance Evaluatable ReceiveOperator
 
 -- | A field declaration in a Go struct type declaration.
 data Field a = Field { fieldContext :: ![a], fieldName :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Field
 
 -- TODO: Implement Eval instance for Field
 instance Evaluatable Field
 
 data Package a = Package { packageName :: !a, packageContents :: ![a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Package
 
 instance Evaluatable Package where
@@ -231,7 +231,7 @@ instance Evaluatable Package where
 
 -- | A type assertion in Go (e.g. `x.(T)` where the value of `x` is not nil and is of type `T`).
 data TypeAssertion a = TypeAssertion { typeAssertionSubject :: !a, typeAssertionType :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically TypeAssertion
 
 -- TODO: Implement Eval instance for TypeAssertion
@@ -239,7 +239,7 @@ instance Evaluatable TypeAssertion
 
 -- | A type conversion expression in Go (e.g. `T(x)` where `T` is a type and `x` is an expression that can be converted to type `T`).
 data TypeConversion a = TypeConversion { typeConversionType :: !a, typeConversionSubject :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically TypeConversion
 
 -- TODO: Implement Eval instance for TypeConversion
@@ -247,7 +247,7 @@ instance Evaluatable TypeConversion
 
 -- | Variadic arguments and parameters in Go (e.g. parameter: `param ...Type`, argument: `Type...`).
 data Variadic a = Variadic { variadicContext :: [a], variadicIdentifier :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Variadic
 
 -- TODO: Implement Eval instance for Variadic

--- a/src/Language/Go/Syntax.hs
+++ b/src/Language/Go/Syntax.hs
@@ -52,7 +52,10 @@ resolveGoImport (ImportPath path NonRelative) = do
 -- If the list of symbols is empty copy everything to the calling environment.
 data Import a = Import { importFrom :: ImportPath, importWildcardToken :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Import
+
+instance Eq1 Import where liftEq = genericLiftEq
+instance Ord1 Import where liftCompare = genericLiftCompare
+instance Show1 Import where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Import where
   eval _ _ (Language.Go.Syntax.Import importPath _) = do
@@ -70,7 +73,10 @@ instance Evaluatable Import where
 -- If the list of symbols is empty copy and qualify everything to the calling environment.
 data QualifiedImport a = QualifiedImport { qualifiedImportFrom :: !ImportPath, qualifiedImportAlias :: !a}
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically QualifiedImport
+
+instance Eq1 QualifiedImport where liftEq = genericLiftEq
+instance Ord1 QualifiedImport where liftCompare = genericLiftCompare
+instance Show1 QualifiedImport where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable QualifiedImport where
   eval _ _ (QualifiedImport importPath aliasTerm) = do
@@ -100,7 +106,10 @@ instance Evaluatable QualifiedImport where
 -- | Side effect only imports (no symbols made available to the calling environment).
 data SideEffectImport a = SideEffectImport { sideEffectImportFrom :: !ImportPath, sideEffectImportToken :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically SideEffectImport
+
+instance Eq1 SideEffectImport where liftEq = genericLiftEq
+instance Ord1 SideEffectImport where liftCompare = genericLiftCompare
+instance Show1 SideEffectImport where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Revisit this and confirm if this is correct.
 instance Evaluatable SideEffectImport where
@@ -113,7 +122,10 @@ instance Evaluatable SideEffectImport where
 -- A composite literal in Go
 data Composite a = Composite { compositeType :: !a, compositeElement :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Composite
+
+instance Eq1 Composite where liftEq = genericLiftEq
+instance Ord1 Composite where liftCompare = genericLiftCompare
+instance Show1 Composite where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Composite
 instance Evaluatable Composite
@@ -121,7 +133,10 @@ instance Evaluatable Composite
 -- | A default pattern in a Go select or switch statement (e.g. `switch { default: s() }`).
 newtype DefaultPattern a = DefaultPattern { defaultPatternBody :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically DefaultPattern
+
+instance Eq1 DefaultPattern where liftEq = genericLiftEq
+instance Ord1 DefaultPattern where liftCompare = genericLiftCompare
+instance Show1 DefaultPattern where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for DefaultPattern
 instance Evaluatable DefaultPattern
@@ -129,7 +144,10 @@ instance Evaluatable DefaultPattern
 -- | A defer statement in Go (e.g. `defer x()`).
 newtype Defer a = Defer { deferBody :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Defer
+
+instance Eq1 Defer where liftEq = genericLiftEq
+instance Ord1 Defer where liftCompare = genericLiftCompare
+instance Show1 Defer where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Defer
 instance Evaluatable Defer
@@ -137,7 +155,10 @@ instance Evaluatable Defer
 -- | A go statement (i.e. go routine) in Go (e.g. `go x()`).
 newtype Go a = Go { goBody :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Go
+
+instance Eq1 Go where liftEq = genericLiftEq
+instance Ord1 Go where liftCompare = genericLiftCompare
+instance Show1 Go where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Go
 instance Evaluatable Go
@@ -145,7 +166,10 @@ instance Evaluatable Go
 -- | A label statement in Go (e.g. `label:continue`).
 data Label a = Label { labelName :: !a, labelStatement :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Label
+
+instance Eq1 Label where liftEq = genericLiftEq
+instance Ord1 Label where liftCompare = genericLiftCompare
+instance Show1 Label where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Label
 instance Evaluatable Label
@@ -153,7 +177,10 @@ instance Evaluatable Label
 -- | A rune literal in Go (e.g. `'⌘'`).
 newtype Rune a = Rune { runeLiteral :: Text }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Rune
+
+instance Eq1 Rune where liftEq = genericLiftEq
+instance Ord1 Rune where liftCompare = genericLiftCompare
+instance Show1 Rune where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Rune
 instance Evaluatable Rune
@@ -161,7 +188,10 @@ instance Evaluatable Rune
 -- | A select statement in Go (e.g. `select { case x := <-c: x() }` where each case is a send or receive operation on channels).
 newtype Select a = Select { selectCases :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Select
+
+instance Eq1 Select where liftEq = genericLiftEq
+instance Ord1 Select where liftCompare = genericLiftCompare
+instance Show1 Select where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Select
 instance Evaluatable Select
@@ -169,7 +199,10 @@ instance Evaluatable Select
 -- | A send statement in Go (e.g. `channel <- value`).
 data Send a = Send { sendReceiver :: !a, sendValue :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Send
+
+instance Eq1 Send where liftEq = genericLiftEq
+instance Ord1 Send where liftCompare = genericLiftCompare
+instance Show1 Send where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Send
 instance Evaluatable Send
@@ -177,7 +210,10 @@ instance Evaluatable Send
 -- | A slice expression in Go (e.g. `a[1:4:3]` where a is a list, 1 is the low bound, 4 is the high bound, and 3 is the max capacity).
 data Slice a = Slice { sliceName :: !a, sliceLow :: !a, sliceHigh :: !a, sliceCapacity :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Slice
+
+instance Eq1 Slice where liftEq = genericLiftEq
+instance Ord1 Slice where liftCompare = genericLiftCompare
+instance Show1 Slice where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Slice
 instance Evaluatable Slice
@@ -185,7 +221,10 @@ instance Evaluatable Slice
 -- | A type switch statement in Go (e.g. `switch x.(type) { // cases }`).
 data TypeSwitch a = TypeSwitch { typeSwitchSubject :: !a, typeSwitchCases :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically TypeSwitch
+
+instance Eq1 TypeSwitch where liftEq = genericLiftEq
+instance Ord1 TypeSwitch where liftCompare = genericLiftCompare
+instance Show1 TypeSwitch where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for TypeSwitch
 instance Evaluatable TypeSwitch
@@ -193,7 +232,10 @@ instance Evaluatable TypeSwitch
 -- | A type switch guard statement in a Go type switch statement (e.g. `switch i := x.(type) { // cases}`).
 newtype TypeSwitchGuard a = TypeSwitchGuard { typeSwitchGuardSubject :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically TypeSwitchGuard
+
+instance Eq1 TypeSwitchGuard where liftEq = genericLiftEq
+instance Ord1 TypeSwitchGuard where liftCompare = genericLiftCompare
+instance Show1 TypeSwitchGuard where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for TypeSwitchGuard
 instance Evaluatable TypeSwitchGuard
@@ -201,7 +243,10 @@ instance Evaluatable TypeSwitchGuard
 -- | A receive statement in a Go select statement (e.g. `case value := <-channel` )
 data Receive a = Receive { receiveSubject :: !a, receiveExpression :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Receive
+
+instance Eq1 Receive where liftEq = genericLiftEq
+instance Ord1 Receive where liftCompare = genericLiftCompare
+instance Show1 Receive where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Receive
 instance Evaluatable Receive
@@ -209,7 +254,10 @@ instance Evaluatable Receive
 -- | A receive operator unary expression in Go (e.g. `<-channel` )
 newtype ReceiveOperator a = ReceiveOperator { value :: a}
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically ReceiveOperator
+
+instance Eq1 ReceiveOperator where liftEq = genericLiftEq
+instance Ord1 ReceiveOperator where liftCompare = genericLiftCompare
+instance Show1 ReceiveOperator where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for ReceiveOperator
 instance Evaluatable ReceiveOperator
@@ -217,14 +265,20 @@ instance Evaluatable ReceiveOperator
 -- | A field declaration in a Go struct type declaration.
 data Field a = Field { fieldContext :: ![a], fieldName :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Field
+
+instance Eq1 Field where liftEq = genericLiftEq
+instance Ord1 Field where liftCompare = genericLiftCompare
+instance Show1 Field where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Field
 instance Evaluatable Field
 
 data Package a = Package { packageName :: !a, packageContents :: ![a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Package
+
+instance Eq1 Package where liftEq = genericLiftEq
+instance Ord1 Package where liftCompare = genericLiftCompare
+instance Show1 Package where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Package where
   eval eval _ (Package _ xs) = maybe unit (runApp . foldMap1 (App . eval)) (nonEmpty xs)
@@ -232,7 +286,10 @@ instance Evaluatable Package where
 -- | A type assertion in Go (e.g. `x.(T)` where the value of `x` is not nil and is of type `T`).
 data TypeAssertion a = TypeAssertion { typeAssertionSubject :: !a, typeAssertionType :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically TypeAssertion
+
+instance Eq1 TypeAssertion where liftEq = genericLiftEq
+instance Ord1 TypeAssertion where liftCompare = genericLiftCompare
+instance Show1 TypeAssertion where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for TypeAssertion
 instance Evaluatable TypeAssertion
@@ -240,7 +297,10 @@ instance Evaluatable TypeAssertion
 -- | A type conversion expression in Go (e.g. `T(x)` where `T` is a type and `x` is an expression that can be converted to type `T`).
 data TypeConversion a = TypeConversion { typeConversionType :: !a, typeConversionSubject :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically TypeConversion
+
+instance Eq1 TypeConversion where liftEq = genericLiftEq
+instance Ord1 TypeConversion where liftCompare = genericLiftCompare
+instance Show1 TypeConversion where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for TypeConversion
 instance Evaluatable TypeConversion
@@ -248,7 +308,10 @@ instance Evaluatable TypeConversion
 -- | Variadic arguments and parameters in Go (e.g. parameter: `param ...Type`, argument: `Type...`).
 data Variadic a = Variadic { variadicContext :: [a], variadicIdentifier :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Variadic
+
+instance Eq1 Variadic where liftEq = genericLiftEq
+instance Ord1 Variadic where liftCompare = genericLiftCompare
+instance Show1 Variadic where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Variadic
 instance Evaluatable Variadic

--- a/src/Language/Go/Syntax.hs
+++ b/src/Language/Go/Syntax.hs
@@ -51,7 +51,7 @@ resolveGoImport (ImportPath path NonRelative) = do
 --
 -- If the list of symbols is empty copy everything to the calling environment.
 data Import a = Import { importFrom :: ImportPath, importWildcardToken :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Import where liftEq = genericLiftEq
 instance Ord1 Import where liftCompare = genericLiftCompare
@@ -72,7 +72,7 @@ instance Evaluatable Import where
 --
 -- If the list of symbols is empty copy and qualify everything to the calling environment.
 data QualifiedImport a = QualifiedImport { qualifiedImportFrom :: !ImportPath, qualifiedImportAlias :: !a}
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 QualifiedImport where liftEq = genericLiftEq
 instance Ord1 QualifiedImport where liftCompare = genericLiftCompare
@@ -105,7 +105,7 @@ instance Evaluatable QualifiedImport where
 
 -- | Side effect only imports (no symbols made available to the calling environment).
 data SideEffectImport a = SideEffectImport { sideEffectImportFrom :: !ImportPath, sideEffectImportToken :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 SideEffectImport where liftEq = genericLiftEq
 instance Ord1 SideEffectImport where liftCompare = genericLiftCompare
@@ -121,7 +121,7 @@ instance Evaluatable SideEffectImport where
 
 -- A composite literal in Go
 data Composite a = Composite { compositeType :: !a, compositeElement :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Composite where liftEq = genericLiftEq
 instance Ord1 Composite where liftCompare = genericLiftCompare
@@ -132,7 +132,7 @@ instance Evaluatable Composite
 
 -- | A default pattern in a Go select or switch statement (e.g. `switch { default: s() }`).
 newtype DefaultPattern a = DefaultPattern { defaultPatternBody :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 DefaultPattern where liftEq = genericLiftEq
 instance Ord1 DefaultPattern where liftCompare = genericLiftCompare
@@ -143,7 +143,7 @@ instance Evaluatable DefaultPattern
 
 -- | A defer statement in Go (e.g. `defer x()`).
 newtype Defer a = Defer { deferBody :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Defer where liftEq = genericLiftEq
 instance Ord1 Defer where liftCompare = genericLiftCompare
@@ -154,7 +154,7 @@ instance Evaluatable Defer
 
 -- | A go statement (i.e. go routine) in Go (e.g. `go x()`).
 newtype Go a = Go { goBody :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Go where liftEq = genericLiftEq
 instance Ord1 Go where liftCompare = genericLiftCompare
@@ -165,7 +165,7 @@ instance Evaluatable Go
 
 -- | A label statement in Go (e.g. `label:continue`).
 data Label a = Label { labelName :: !a, labelStatement :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Label where liftEq = genericLiftEq
 instance Ord1 Label where liftCompare = genericLiftCompare
@@ -176,7 +176,7 @@ instance Evaluatable Label
 
 -- | A rune literal in Go (e.g. `'⌘'`).
 newtype Rune a = Rune { runeLiteral :: Text }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Rune where liftEq = genericLiftEq
 instance Ord1 Rune where liftCompare = genericLiftCompare
@@ -187,7 +187,7 @@ instance Evaluatable Rune
 
 -- | A select statement in Go (e.g. `select { case x := <-c: x() }` where each case is a send or receive operation on channels).
 newtype Select a = Select { selectCases :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Select where liftEq = genericLiftEq
 instance Ord1 Select where liftCompare = genericLiftCompare
@@ -198,7 +198,7 @@ instance Evaluatable Select
 
 -- | A send statement in Go (e.g. `channel <- value`).
 data Send a = Send { sendReceiver :: !a, sendValue :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Send where liftEq = genericLiftEq
 instance Ord1 Send where liftCompare = genericLiftCompare
@@ -209,7 +209,7 @@ instance Evaluatable Send
 
 -- | A slice expression in Go (e.g. `a[1:4:3]` where a is a list, 1 is the low bound, 4 is the high bound, and 3 is the max capacity).
 data Slice a = Slice { sliceName :: !a, sliceLow :: !a, sliceHigh :: !a, sliceCapacity :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Slice where liftEq = genericLiftEq
 instance Ord1 Slice where liftCompare = genericLiftCompare
@@ -220,7 +220,7 @@ instance Evaluatable Slice
 
 -- | A type switch statement in Go (e.g. `switch x.(type) { // cases }`).
 data TypeSwitch a = TypeSwitch { typeSwitchSubject :: !a, typeSwitchCases :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 TypeSwitch where liftEq = genericLiftEq
 instance Ord1 TypeSwitch where liftCompare = genericLiftCompare
@@ -231,7 +231,7 @@ instance Evaluatable TypeSwitch
 
 -- | A type switch guard statement in a Go type switch statement (e.g. `switch i := x.(type) { // cases}`).
 newtype TypeSwitchGuard a = TypeSwitchGuard { typeSwitchGuardSubject :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 TypeSwitchGuard where liftEq = genericLiftEq
 instance Ord1 TypeSwitchGuard where liftCompare = genericLiftCompare
@@ -242,7 +242,7 @@ instance Evaluatable TypeSwitchGuard
 
 -- | A receive statement in a Go select statement (e.g. `case value := <-channel` )
 data Receive a = Receive { receiveSubject :: !a, receiveExpression :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Receive where liftEq = genericLiftEq
 instance Ord1 Receive where liftCompare = genericLiftCompare
@@ -253,7 +253,7 @@ instance Evaluatable Receive
 
 -- | A receive operator unary expression in Go (e.g. `<-channel` )
 newtype ReceiveOperator a = ReceiveOperator { value :: a}
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ReceiveOperator where liftEq = genericLiftEq
 instance Ord1 ReceiveOperator where liftCompare = genericLiftCompare
@@ -264,7 +264,7 @@ instance Evaluatable ReceiveOperator
 
 -- | A field declaration in a Go struct type declaration.
 data Field a = Field { fieldContext :: ![a], fieldName :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Field where liftEq = genericLiftEq
 instance Ord1 Field where liftCompare = genericLiftCompare
@@ -274,7 +274,7 @@ instance Show1 Field where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Field
 
 data Package a = Package { packageName :: !a, packageContents :: ![a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Package where liftEq = genericLiftEq
 instance Ord1 Package where liftCompare = genericLiftCompare
@@ -285,7 +285,7 @@ instance Evaluatable Package where
 
 -- | A type assertion in Go (e.g. `x.(T)` where the value of `x` is not nil and is of type `T`).
 data TypeAssertion a = TypeAssertion { typeAssertionSubject :: !a, typeAssertionType :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 TypeAssertion where liftEq = genericLiftEq
 instance Ord1 TypeAssertion where liftCompare = genericLiftCompare
@@ -296,7 +296,7 @@ instance Evaluatable TypeAssertion
 
 -- | A type conversion expression in Go (e.g. `T(x)` where `T` is a type and `x` is an expression that can be converted to type `T`).
 data TypeConversion a = TypeConversion { typeConversionType :: !a, typeConversionSubject :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 TypeConversion where liftEq = genericLiftEq
 instance Ord1 TypeConversion where liftCompare = genericLiftCompare
@@ -307,7 +307,7 @@ instance Evaluatable TypeConversion
 
 -- | Variadic arguments and parameters in Go (e.g. parameter: `param ...Type`, argument: `Type...`).
 data Variadic a = Variadic { variadicContext :: [a], variadicIdentifier :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Variadic where liftEq = genericLiftEq
 instance Ord1 Variadic where liftCompare = genericLiftCompare

--- a/src/Language/Go/Type.hs
+++ b/src/Language/Go/Type.hs
@@ -11,7 +11,10 @@ import Diffing.Algorithm
 -- | A Bidirectional channel in Go (e.g. `chan`).
 newtype BidirectionalChannel a = BidirectionalChannel { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically BidirectionalChannel
+
+instance Eq1 BidirectionalChannel where liftEq = genericLiftEq
+instance Ord1 BidirectionalChannel where liftCompare = genericLiftCompare
+instance Show1 BidirectionalChannel where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for BidirectionalChannel
 instance Evaluatable BidirectionalChannel
@@ -19,7 +22,10 @@ instance Evaluatable BidirectionalChannel
 -- | A Receive channel in Go (e.g. `<-chan`).
 newtype ReceiveChannel a = ReceiveChannel { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically ReceiveChannel
+
+instance Eq1 ReceiveChannel where liftEq = genericLiftEq
+instance Ord1 ReceiveChannel where liftCompare = genericLiftCompare
+instance Show1 ReceiveChannel where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for ReceiveChannel
 instance Evaluatable ReceiveChannel
@@ -27,7 +33,10 @@ instance Evaluatable ReceiveChannel
 -- | A Send channel in Go (e.g. `chan<-`).
 newtype SendChannel a = SendChannel { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically SendChannel
+
+instance Eq1 SendChannel where liftEq = genericLiftEq
+instance Ord1 SendChannel where liftCompare = genericLiftCompare
+instance Show1 SendChannel where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for SendChannel
 instance Evaluatable SendChannel

--- a/src/Language/Go/Type.hs
+++ b/src/Language/Go/Type.hs
@@ -10,7 +10,7 @@ import Diffing.Algorithm
 
 -- | A Bidirectional channel in Go (e.g. `chan`).
 newtype BidirectionalChannel a = BidirectionalChannel { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically BidirectionalChannel
 
 -- TODO: Implement Eval instance for BidirectionalChannel
@@ -18,7 +18,7 @@ instance Evaluatable BidirectionalChannel
 
 -- | A Receive channel in Go (e.g. `<-chan`).
 newtype ReceiveChannel a = ReceiveChannel { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically ReceiveChannel
 
 -- TODO: Implement Eval instance for ReceiveChannel
@@ -26,7 +26,7 @@ instance Evaluatable ReceiveChannel
 
 -- | A Send channel in Go (e.g. `chan<-`).
 newtype SendChannel a = SendChannel { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically SendChannel
 
 -- TODO: Implement Eval instance for SendChannel

--- a/src/Language/Go/Type.hs
+++ b/src/Language/Go/Type.hs
@@ -10,7 +10,7 @@ import Diffing.Algorithm
 
 -- | A Bidirectional channel in Go (e.g. `chan`).
 newtype BidirectionalChannel a = BidirectionalChannel { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 BidirectionalChannel where liftEq = genericLiftEq
 instance Ord1 BidirectionalChannel where liftCompare = genericLiftCompare
@@ -21,7 +21,7 @@ instance Evaluatable BidirectionalChannel
 
 -- | A Receive channel in Go (e.g. `<-chan`).
 newtype ReceiveChannel a = ReceiveChannel { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ReceiveChannel where liftEq = genericLiftEq
 instance Ord1 ReceiveChannel where liftCompare = genericLiftCompare
@@ -32,7 +32,7 @@ instance Evaluatable ReceiveChannel
 
 -- | A Send channel in Go (e.g. `chan<-`).
 newtype SendChannel a = SendChannel { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, NFData1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 SendChannel where liftEq = genericLiftEq
 instance Ord1 SendChannel where liftCompare = genericLiftCompare

--- a/src/Language/Markdown/Syntax.hs
+++ b/src/Language/Markdown/Syntax.hs
@@ -10,82 +10,139 @@ import           Prologue hiding (Text)
 
 newtype Document a = Document { values :: [a] }
   deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Document
+
+instance Eq1 Document where liftEq = genericLiftEq
+instance Ord1 Document where liftCompare = genericLiftCompare
+instance Show1 Document where liftShowsPrec = genericLiftShowsPrec
 
 
 -- Block elements
 
 newtype Paragraph a = Paragraph { values :: [a] }
   deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Paragraph
+
+instance Eq1 Paragraph where liftEq = genericLiftEq
+instance Ord1 Paragraph where liftCompare = genericLiftCompare
+instance Show1 Paragraph where liftShowsPrec = genericLiftShowsPrec
 
 data Heading a = Heading { headingLevel :: Int, headingContent :: [a], sectionContent :: [a] }
   deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Heading
+
+instance Eq1 Heading where liftEq = genericLiftEq
+instance Ord1 Heading where liftCompare = genericLiftCompare
+instance Show1 Heading where liftShowsPrec = genericLiftShowsPrec
 
 newtype UnorderedList a = UnorderedList { values :: [a] }
   deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically UnorderedList
+
+instance Eq1 UnorderedList where liftEq = genericLiftEq
+instance Ord1 UnorderedList where liftCompare = genericLiftCompare
+instance Show1 UnorderedList where liftShowsPrec = genericLiftShowsPrec
 
 newtype OrderedList a = OrderedList { values :: [a] }
   deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically OrderedList
+
+instance Eq1 OrderedList where liftEq = genericLiftEq
+instance Ord1 OrderedList where liftCompare = genericLiftCompare
+instance Show1 OrderedList where liftShowsPrec = genericLiftShowsPrec
 
 newtype BlockQuote a = BlockQuote { values :: [a] }
   deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically BlockQuote
+
+instance Eq1 BlockQuote where liftEq = genericLiftEq
+instance Ord1 BlockQuote where liftCompare = genericLiftCompare
+instance Show1 BlockQuote where liftShowsPrec = genericLiftShowsPrec
 
 data ThematicBreak a = ThematicBreak
   deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically ThematicBreak
+
+instance Eq1 ThematicBreak where liftEq = genericLiftEq
+instance Ord1 ThematicBreak where liftCompare = genericLiftCompare
+instance Show1 ThematicBreak where liftShowsPrec = genericLiftShowsPrec
 
 newtype HTMLBlock a = HTMLBlock { value :: T.Text }
   deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically HTMLBlock
+
+instance Eq1 HTMLBlock where liftEq = genericLiftEq
+instance Ord1 HTMLBlock where liftCompare = genericLiftCompare
+instance Show1 HTMLBlock where liftShowsPrec = genericLiftShowsPrec
 
 newtype Table a = Table { values :: [a] }
   deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Table
+
+instance Eq1 Table where liftEq = genericLiftEq
+instance Ord1 Table where liftCompare = genericLiftCompare
+instance Show1 Table where liftShowsPrec = genericLiftShowsPrec
 
 newtype TableRow a = TableRow { values :: [a] }
   deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically TableRow
+
+instance Eq1 TableRow where liftEq = genericLiftEq
+instance Ord1 TableRow where liftCompare = genericLiftCompare
+instance Show1 TableRow where liftShowsPrec = genericLiftShowsPrec
 
 newtype TableCell a = TableCell { values :: [a] }
   deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically TableCell
+
+instance Eq1 TableCell where liftEq = genericLiftEq
+instance Ord1 TableCell where liftCompare = genericLiftCompare
+instance Show1 TableCell where liftShowsPrec = genericLiftShowsPrec
 
 
 -- Inline elements
 
 newtype Strong a = Strong { values :: [a] }
   deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Strong
+
+instance Eq1 Strong where liftEq = genericLiftEq
+instance Ord1 Strong where liftCompare = genericLiftCompare
+instance Show1 Strong where liftShowsPrec = genericLiftShowsPrec
 
 newtype Emphasis a = Emphasis { values :: [a] }
   deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Emphasis
+
+instance Eq1 Emphasis where liftEq = genericLiftEq
+instance Ord1 Emphasis where liftCompare = genericLiftCompare
+instance Show1 Emphasis where liftShowsPrec = genericLiftShowsPrec
 
 newtype Text a = Text { value :: T.Text}
   deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Text
+
+instance Eq1 Text where liftEq = genericLiftEq
+instance Ord1 Text where liftCompare = genericLiftCompare
+instance Show1 Text where liftShowsPrec = genericLiftShowsPrec
 
 data Link a = Link { linkURL :: T.Text, linkTitle :: Maybe T.Text }
   deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Link
+
+instance Eq1 Link where liftEq = genericLiftEq
+instance Ord1 Link where liftCompare = genericLiftCompare
+instance Show1 Link where liftShowsPrec = genericLiftShowsPrec
 
 data Image a = Image { imageURL :: T.Text, imageTitle :: Maybe T.Text }
   deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Image
+
+instance Eq1 Image where liftEq = genericLiftEq
+instance Ord1 Image where liftCompare = genericLiftCompare
+instance Show1 Image where liftShowsPrec = genericLiftShowsPrec
 
 data Code a = Code { codeLanguage :: Maybe T.Text, codeContent :: T.Text }
   deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Code
+
+instance Eq1 Code where liftEq = genericLiftEq
+instance Ord1 Code where liftCompare = genericLiftCompare
+instance Show1 Code where liftShowsPrec = genericLiftShowsPrec
 
 data LineBreak a = LineBreak
   deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically LineBreak
+
+instance Eq1 LineBreak where liftEq = genericLiftEq
+instance Ord1 LineBreak where liftCompare = genericLiftCompare
+instance Show1 LineBreak where liftShowsPrec = genericLiftShowsPrec
 
 newtype Strikethrough a = Strikethrough { values :: [a] }
   deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Strikethrough
+
+instance Eq1 Strikethrough where liftEq = genericLiftEq
+instance Ord1 Strikethrough where liftCompare = genericLiftCompare
+instance Show1 Strikethrough where liftShowsPrec = genericLiftShowsPrec

--- a/src/Language/Markdown/Syntax.hs
+++ b/src/Language/Markdown/Syntax.hs
@@ -9,7 +9,7 @@ import           Diffing.Algorithm
 import           Prologue hiding (Text)
 
 newtype Document a = Document { values :: [a] }
-  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1)
 
 instance Eq1 Document where liftEq = genericLiftEq
 instance Ord1 Document where liftCompare = genericLiftCompare
@@ -19,70 +19,70 @@ instance Show1 Document where liftShowsPrec = genericLiftShowsPrec
 -- Block elements
 
 newtype Paragraph a = Paragraph { values :: [a] }
-  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1)
 
 instance Eq1 Paragraph where liftEq = genericLiftEq
 instance Ord1 Paragraph where liftCompare = genericLiftCompare
 instance Show1 Paragraph where liftShowsPrec = genericLiftShowsPrec
 
 data Heading a = Heading { headingLevel :: Int, headingContent :: [a], sectionContent :: [a] }
-  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1)
 
 instance Eq1 Heading where liftEq = genericLiftEq
 instance Ord1 Heading where liftCompare = genericLiftCompare
 instance Show1 Heading where liftShowsPrec = genericLiftShowsPrec
 
 newtype UnorderedList a = UnorderedList { values :: [a] }
-  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1)
 
 instance Eq1 UnorderedList where liftEq = genericLiftEq
 instance Ord1 UnorderedList where liftCompare = genericLiftCompare
 instance Show1 UnorderedList where liftShowsPrec = genericLiftShowsPrec
 
 newtype OrderedList a = OrderedList { values :: [a] }
-  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1)
 
 instance Eq1 OrderedList where liftEq = genericLiftEq
 instance Ord1 OrderedList where liftCompare = genericLiftCompare
 instance Show1 OrderedList where liftShowsPrec = genericLiftShowsPrec
 
 newtype BlockQuote a = BlockQuote { values :: [a] }
-  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1)
 
 instance Eq1 BlockQuote where liftEq = genericLiftEq
 instance Ord1 BlockQuote where liftCompare = genericLiftCompare
 instance Show1 BlockQuote where liftShowsPrec = genericLiftShowsPrec
 
 data ThematicBreak a = ThematicBreak
-  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1)
 
 instance Eq1 ThematicBreak where liftEq = genericLiftEq
 instance Ord1 ThematicBreak where liftCompare = genericLiftCompare
 instance Show1 ThematicBreak where liftShowsPrec = genericLiftShowsPrec
 
 newtype HTMLBlock a = HTMLBlock { value :: T.Text }
-  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1)
 
 instance Eq1 HTMLBlock where liftEq = genericLiftEq
 instance Ord1 HTMLBlock where liftCompare = genericLiftCompare
 instance Show1 HTMLBlock where liftShowsPrec = genericLiftShowsPrec
 
 newtype Table a = Table { values :: [a] }
-  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1)
 
 instance Eq1 Table where liftEq = genericLiftEq
 instance Ord1 Table where liftCompare = genericLiftCompare
 instance Show1 Table where liftShowsPrec = genericLiftShowsPrec
 
 newtype TableRow a = TableRow { values :: [a] }
-  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1)
 
 instance Eq1 TableRow where liftEq = genericLiftEq
 instance Ord1 TableRow where liftCompare = genericLiftCompare
 instance Show1 TableRow where liftShowsPrec = genericLiftShowsPrec
 
 newtype TableCell a = TableCell { values :: [a] }
-  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1)
 
 instance Eq1 TableCell where liftEq = genericLiftEq
 instance Ord1 TableCell where liftCompare = genericLiftCompare
@@ -92,56 +92,56 @@ instance Show1 TableCell where liftShowsPrec = genericLiftShowsPrec
 -- Inline elements
 
 newtype Strong a = Strong { values :: [a] }
-  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1)
 
 instance Eq1 Strong where liftEq = genericLiftEq
 instance Ord1 Strong where liftCompare = genericLiftCompare
 instance Show1 Strong where liftShowsPrec = genericLiftShowsPrec
 
 newtype Emphasis a = Emphasis { values :: [a] }
-  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1)
 
 instance Eq1 Emphasis where liftEq = genericLiftEq
 instance Ord1 Emphasis where liftCompare = genericLiftCompare
 instance Show1 Emphasis where liftShowsPrec = genericLiftShowsPrec
 
 newtype Text a = Text { value :: T.Text}
-  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1)
 
 instance Eq1 Text where liftEq = genericLiftEq
 instance Ord1 Text where liftCompare = genericLiftCompare
 instance Show1 Text where liftShowsPrec = genericLiftShowsPrec
 
 data Link a = Link { linkURL :: T.Text, linkTitle :: Maybe T.Text }
-  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1)
 
 instance Eq1 Link where liftEq = genericLiftEq
 instance Ord1 Link where liftCompare = genericLiftCompare
 instance Show1 Link where liftShowsPrec = genericLiftShowsPrec
 
 data Image a = Image { imageURL :: T.Text, imageTitle :: Maybe T.Text }
-  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1)
 
 instance Eq1 Image where liftEq = genericLiftEq
 instance Ord1 Image where liftCompare = genericLiftCompare
 instance Show1 Image where liftShowsPrec = genericLiftShowsPrec
 
 data Code a = Code { codeLanguage :: Maybe T.Text, codeContent :: T.Text }
-  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1)
 
 instance Eq1 Code where liftEq = genericLiftEq
 instance Ord1 Code where liftCompare = genericLiftCompare
 instance Show1 Code where liftShowsPrec = genericLiftShowsPrec
 
 data LineBreak a = LineBreak
-  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1)
 
 instance Eq1 LineBreak where liftEq = genericLiftEq
 instance Ord1 LineBreak where liftCompare = genericLiftCompare
 instance Show1 LineBreak where liftShowsPrec = genericLiftShowsPrec
 
 newtype Strikethrough a = Strikethrough { values :: [a] }
-  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1)
 
 instance Eq1 Strikethrough where liftEq = genericLiftEq
 instance Ord1 Strikethrough where liftCompare = genericLiftCompare

--- a/src/Language/Markdown/Syntax.hs
+++ b/src/Language/Markdown/Syntax.hs
@@ -9,83 +9,83 @@ import           Diffing.Algorithm
 import           Prologue hiding (Text)
 
 newtype Document a = Document { values :: [a] }
-  deriving (Eq, Ord, Show, Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Document
 
 
 -- Block elements
 
 newtype Paragraph a = Paragraph { values :: [a] }
-  deriving (Eq, Ord, Show, Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Paragraph
 
 data Heading a = Heading { headingLevel :: Int, headingContent :: [a], sectionContent :: [a] }
-  deriving (Eq, Ord, Show, Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Heading
 
 newtype UnorderedList a = UnorderedList { values :: [a] }
-  deriving (Eq, Ord, Show, Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically UnorderedList
 
 newtype OrderedList a = OrderedList { values :: [a] }
-  deriving (Eq, Ord, Show, Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically OrderedList
 
 newtype BlockQuote a = BlockQuote { values :: [a] }
-  deriving (Eq, Ord, Show, Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically BlockQuote
 
 data ThematicBreak a = ThematicBreak
-  deriving (Eq, Ord, Show, Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically ThematicBreak
 
 newtype HTMLBlock a = HTMLBlock { value :: T.Text }
-  deriving (Eq, Ord, Show, Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically HTMLBlock
 
 newtype Table a = Table { values :: [a] }
-  deriving (Eq, Ord, Show, Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Table
 
 newtype TableRow a = TableRow { values :: [a] }
-  deriving (Eq, Ord, Show, Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically TableRow
 
 newtype TableCell a = TableCell { values :: [a] }
-  deriving (Eq, Ord, Show, Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically TableCell
 
 
 -- Inline elements
 
 newtype Strong a = Strong { values :: [a] }
-  deriving (Eq, Ord, Show, Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Strong
 
 newtype Emphasis a = Emphasis { values :: [a] }
-  deriving (Eq, Ord, Show, Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Emphasis
 
 newtype Text a = Text { value :: T.Text}
-  deriving (Eq, Ord, Show, Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Text
 
 data Link a = Link { linkURL :: T.Text, linkTitle :: Maybe T.Text }
-  deriving (Eq, Ord, Show, Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Link
 
 data Image a = Image { imageURL :: T.Text, imageTitle :: Maybe T.Text }
-  deriving (Eq, Ord, Show, Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Image
 
 data Code a = Code { codeLanguage :: Maybe T.Text, codeContent :: T.Text }
-  deriving (Eq, Ord, Show, Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Code
 
 data LineBreak a = LineBreak
-  deriving (Eq, Ord, Show, Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically LineBreak
 
 newtype Strikethrough a = Strikethrough { values :: [a] }
-  deriving (Eq, Ord, Show, Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
+  deriving (Declarations1, Foldable, Traversable, Functor, Generic1, Hashable1, Diffable, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Strikethrough

--- a/src/Language/PHP/Syntax.hs
+++ b/src/Language/PHP/Syntax.hs
@@ -20,7 +20,7 @@ import           Diffing.Algorithm
 import           Source.Span
 
 newtype Text a = Text { value :: T.Text }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Text where liftEq = genericLiftEq
 instance Ord1 Text where liftCompare = genericLiftCompare
@@ -29,7 +29,7 @@ instance Show1 Text where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Text
 
 newtype VariableName a = VariableName { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 VariableName where liftEq = genericLiftEq
 instance Ord1 VariableName where liftCompare = genericLiftCompare
@@ -87,7 +87,7 @@ include eval pathTerm f = do
   pure v
 
 newtype Require a = Require { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Require where liftEq = genericLiftEq
 instance Ord1 Require where liftCompare = genericLiftCompare
@@ -98,7 +98,7 @@ instance Evaluatable Require where
 
 
 newtype RequireOnce a = RequireOnce { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 RequireOnce where liftEq = genericLiftEq
 instance Ord1 RequireOnce where liftCompare = genericLiftCompare
@@ -108,7 +108,7 @@ instance Evaluatable RequireOnce where
   eval eval _ (RequireOnce path) = include eval path require
 
 newtype Include a = Include { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Include where liftEq = genericLiftEq
 instance Ord1 Include where liftCompare = genericLiftCompare
@@ -118,7 +118,7 @@ instance Evaluatable Include where
   eval eval _ (Include path) = include eval path load
 
 newtype IncludeOnce a = IncludeOnce { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 IncludeOnce where liftEq = genericLiftEq
 instance Ord1 IncludeOnce where liftCompare = genericLiftCompare
@@ -128,7 +128,7 @@ instance Evaluatable IncludeOnce where
   eval eval _ (IncludeOnce path) = include eval path require
 
 newtype ArrayElement a = ArrayElement { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ArrayElement where liftEq = genericLiftEq
 instance Ord1 ArrayElement where liftCompare = genericLiftCompare
@@ -137,7 +137,7 @@ instance Show1 ArrayElement where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ArrayElement
 
 newtype GlobalDeclaration a = GlobalDeclaration { values :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 GlobalDeclaration where liftEq = genericLiftEq
 instance Ord1 GlobalDeclaration where liftCompare = genericLiftCompare
@@ -146,7 +146,7 @@ instance Show1 GlobalDeclaration where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable GlobalDeclaration
 
 newtype SimpleVariable a = SimpleVariable { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 SimpleVariable where liftEq = genericLiftEq
 instance Ord1 SimpleVariable where liftCompare = genericLiftCompare
@@ -155,7 +155,7 @@ instance Show1 SimpleVariable where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable SimpleVariable
 
 data Concat a = Concat { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Concat where liftEq = genericLiftEq
 instance Ord1 Concat where liftCompare = genericLiftCompare
@@ -165,7 +165,7 @@ instance Evaluatable Concat
 
 -- | TODO: Unify with TypeScript's PredefinedType
 newtype CastType a = CastType { _castType :: T.Text }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 CastType where liftEq = genericLiftEq
 instance Ord1 CastType where liftCompare = genericLiftCompare
@@ -174,7 +174,7 @@ instance Show1 CastType where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable CastType
 
 newtype ErrorControl a = ErrorControl { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ErrorControl where liftEq = genericLiftEq
 instance Ord1 ErrorControl where liftCompare = genericLiftCompare
@@ -183,7 +183,7 @@ instance Show1 ErrorControl where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ErrorControl
 
 newtype Clone a = Clone { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Clone where liftEq = genericLiftEq
 instance Ord1 Clone where liftCompare = genericLiftCompare
@@ -192,7 +192,7 @@ instance Show1 Clone where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Clone
 
 newtype ShellCommand a = ShellCommand { value :: T.Text }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ShellCommand where liftEq = genericLiftEq
 instance Ord1 ShellCommand where liftCompare = genericLiftCompare
@@ -202,7 +202,7 @@ instance Evaluatable ShellCommand
 
 -- | TODO: Combine with TypeScript update expression.
 newtype Update a = Update { _updateSubject :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Update where liftEq = genericLiftEq
 instance Ord1 Update where liftCompare = genericLiftCompare
@@ -210,7 +210,7 @@ instance Show1 Update where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Update
 
 newtype NewVariable a = NewVariable { values :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 NewVariable where liftEq = genericLiftEq
 instance Ord1 NewVariable where liftCompare = genericLiftCompare
@@ -219,7 +219,7 @@ instance Show1 NewVariable where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable NewVariable
 
 newtype RelativeScope a = RelativeScope { value :: T.Text }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 RelativeScope where liftEq = genericLiftEq
 instance Ord1 RelativeScope where liftCompare = genericLiftCompare
@@ -228,7 +228,7 @@ instance Show1 RelativeScope where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable RelativeScope
 
 data QualifiedName a = QualifiedName { name :: a, identifier :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 QualifiedName where liftEq = genericLiftEq
 instance Ord1 QualifiedName where liftCompare = genericLiftCompare
@@ -256,7 +256,7 @@ instance Evaluatable QualifiedName where
         unit
 
 newtype NamespaceName a = NamespaceName { names :: NonEmpty a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, ToJSONFields1, Traversable)
 
 instance Eq1 NamespaceName where liftEq = genericLiftEq
 instance Ord1 NamespaceName where liftCompare = genericLiftCompare
@@ -267,7 +267,7 @@ instance Hashable1 NamespaceName where liftHashWithSalt = foldl
 instance Evaluatable NamespaceName
 
 newtype ConstDeclaration a = ConstDeclaration { values :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ConstDeclaration where liftEq = genericLiftEq
 instance Ord1 ConstDeclaration where liftCompare = genericLiftCompare
@@ -276,7 +276,7 @@ instance Show1 ConstDeclaration where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ConstDeclaration
 
 data ClassConstDeclaration a = ClassConstDeclaration { visibility :: a, elements :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ClassConstDeclaration where liftEq = genericLiftEq
 instance Ord1 ClassConstDeclaration where liftCompare = genericLiftCompare
@@ -285,7 +285,7 @@ instance Show1 ClassConstDeclaration where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ClassConstDeclaration
 
 newtype ClassInterfaceClause a = ClassInterfaceClause { values :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ClassInterfaceClause where liftEq = genericLiftEq
 instance Ord1 ClassInterfaceClause where liftCompare = genericLiftCompare
@@ -294,7 +294,7 @@ instance Show1 ClassInterfaceClause where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ClassInterfaceClause
 
 newtype ClassBaseClause a = ClassBaseClause { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ClassBaseClause where liftEq = genericLiftEq
 instance Ord1 ClassBaseClause where liftCompare = genericLiftCompare
@@ -303,7 +303,7 @@ instance Show1 ClassBaseClause where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ClassBaseClause
 
 newtype UseClause a = UseClause { values :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 UseClause where liftEq = genericLiftEq
 instance Ord1 UseClause where liftCompare = genericLiftCompare
@@ -312,7 +312,7 @@ instance Show1 UseClause where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable UseClause
 
 newtype ReturnType a = ReturnType { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ReturnType where liftEq = genericLiftEq
 instance Ord1 ReturnType where liftCompare = genericLiftCompare
@@ -321,7 +321,7 @@ instance Show1 ReturnType where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ReturnType
 
 newtype TypeDeclaration a = TypeDeclaration { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 TypeDeclaration where liftEq = genericLiftEq
 instance Ord1 TypeDeclaration where liftCompare = genericLiftCompare
@@ -330,7 +330,7 @@ instance Show1 TypeDeclaration where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable TypeDeclaration
 
 newtype BaseTypeDeclaration a = BaseTypeDeclaration { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 BaseTypeDeclaration where liftEq = genericLiftEq
 instance Ord1 BaseTypeDeclaration where liftCompare = genericLiftCompare
@@ -338,7 +338,7 @@ instance Show1 BaseTypeDeclaration where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable BaseTypeDeclaration
 
 newtype ScalarType a = ScalarType { value :: T.Text }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ScalarType where liftEq = genericLiftEq
 instance Ord1 ScalarType where liftCompare = genericLiftCompare
@@ -347,7 +347,7 @@ instance Show1 ScalarType where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ScalarType
 
 newtype EmptyIntrinsic a = EmptyIntrinsic { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 EmptyIntrinsic where liftEq = genericLiftEq
 instance Ord1 EmptyIntrinsic where liftCompare = genericLiftCompare
@@ -356,7 +356,7 @@ instance Show1 EmptyIntrinsic where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable EmptyIntrinsic
 
 newtype ExitIntrinsic a = ExitIntrinsic { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ExitIntrinsic where liftEq = genericLiftEq
 instance Ord1 ExitIntrinsic where liftCompare = genericLiftCompare
@@ -365,7 +365,7 @@ instance Show1 ExitIntrinsic where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ExitIntrinsic
 
 newtype IssetIntrinsic a = IssetIntrinsic { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 IssetIntrinsic where liftEq = genericLiftEq
 instance Ord1 IssetIntrinsic where liftCompare = genericLiftCompare
@@ -374,7 +374,7 @@ instance Show1 IssetIntrinsic where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable IssetIntrinsic
 
 newtype EvalIntrinsic a = EvalIntrinsic { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 EvalIntrinsic where liftEq = genericLiftEq
 instance Ord1 EvalIntrinsic where liftCompare = genericLiftCompare
@@ -383,7 +383,7 @@ instance Show1 EvalIntrinsic where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable EvalIntrinsic
 
 newtype PrintIntrinsic a = PrintIntrinsic { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 PrintIntrinsic where liftEq = genericLiftEq
 instance Ord1 PrintIntrinsic where liftCompare = genericLiftCompare
@@ -392,7 +392,7 @@ instance Show1 PrintIntrinsic where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable PrintIntrinsic
 
 newtype NamespaceAliasingClause a = NamespaceAliasingClause { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 NamespaceAliasingClause where liftEq = genericLiftEq
 instance Ord1 NamespaceAliasingClause where liftCompare = genericLiftCompare
@@ -400,7 +400,7 @@ instance Show1 NamespaceAliasingClause where liftShowsPrec = genericLiftShowsPre
 instance Evaluatable NamespaceAliasingClause
 
 newtype NamespaceUseDeclaration a = NamespaceUseDeclaration { values :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 NamespaceUseDeclaration where liftEq = genericLiftEq
 instance Ord1 NamespaceUseDeclaration where liftCompare = genericLiftCompare
@@ -409,7 +409,7 @@ instance Show1 NamespaceUseDeclaration where liftShowsPrec = genericLiftShowsPre
 instance Evaluatable NamespaceUseDeclaration
 
 newtype NamespaceUseClause a = NamespaceUseClause { values :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 NamespaceUseClause where liftEq = genericLiftEq
 instance Ord1 NamespaceUseClause where liftCompare = genericLiftCompare
@@ -418,7 +418,7 @@ instance Show1 NamespaceUseClause where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable NamespaceUseClause
 
 newtype NamespaceUseGroupClause a = NamespaceUseGroupClause { values :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 NamespaceUseGroupClause where liftEq = genericLiftEq
 instance Ord1 NamespaceUseGroupClause where liftCompare = genericLiftCompare
@@ -427,7 +427,7 @@ instance Show1 NamespaceUseGroupClause where liftShowsPrec = genericLiftShowsPre
 instance Evaluatable NamespaceUseGroupClause
 
 data Namespace a = Namespace { namespaceName :: [a], namespaceBody :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Namespace where liftEq = genericLiftEq
 instance Ord1 Namespace where liftCompare = genericLiftCompare
@@ -436,7 +436,7 @@ instance Show1 Namespace where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Namespace
 
 data TraitDeclaration a = TraitDeclaration { traitName :: a, traitStatements :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 TraitDeclaration where liftEq = genericLiftEq
 instance Ord1 TraitDeclaration where liftCompare = genericLiftCompare
@@ -445,7 +445,7 @@ instance Show1 TraitDeclaration where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable TraitDeclaration
 
 data AliasAs a = AliasAs { aliasAsName  :: a, aliasAsModifier :: a, aliasAsClause :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 AliasAs where liftEq = genericLiftEq
 instance Ord1 AliasAs where liftCompare = genericLiftCompare
@@ -454,7 +454,7 @@ instance Show1 AliasAs where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable AliasAs
 
 data InsteadOf a = InsteadOf { left :: a, right :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 InsteadOf where liftEq = genericLiftEq
 instance Ord1 InsteadOf where liftCompare = genericLiftCompare
@@ -463,7 +463,7 @@ instance Show1 InsteadOf where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable InsteadOf
 
 newtype TraitUseSpecification a = TraitUseSpecification { values :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 TraitUseSpecification where liftEq = genericLiftEq
 instance Ord1 TraitUseSpecification where liftCompare = genericLiftCompare
@@ -472,7 +472,7 @@ instance Show1 TraitUseSpecification where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable TraitUseSpecification
 
 data TraitUseClause a = TraitUseClause { namespace :: [a], alias :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 TraitUseClause where liftEq = genericLiftEq
 instance Ord1 TraitUseClause where liftCompare = genericLiftCompare
@@ -481,7 +481,7 @@ instance Show1 TraitUseClause where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable TraitUseClause
 
 data DestructorDeclaration a = DestructorDeclaration { body:: [a], name :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 DestructorDeclaration where liftEq = genericLiftEq
 instance Ord1 DestructorDeclaration where liftCompare = genericLiftCompare
@@ -490,7 +490,7 @@ instance Show1 DestructorDeclaration where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable DestructorDeclaration
 
 newtype Static a = Static { value :: T.Text }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Static where liftEq = genericLiftEq
 instance Ord1 Static where liftCompare = genericLiftCompare
@@ -499,7 +499,7 @@ instance Show1 Static where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Static
 
 newtype ClassModifier a = ClassModifier { value :: T.Text }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ClassModifier where liftEq = genericLiftEq
 instance Ord1 ClassModifier where liftCompare = genericLiftCompare
@@ -508,7 +508,7 @@ instance Show1 ClassModifier where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ClassModifier
 
 data ConstructorDeclaration a = ConstructorDeclaration { modifiers :: [a], parameters :: [a], body :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ConstructorDeclaration where liftEq = genericLiftEq
 instance Ord1 ConstructorDeclaration where liftCompare = genericLiftCompare
@@ -516,7 +516,7 @@ instance Show1 ConstructorDeclaration where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ConstructorDeclaration
 
 data PropertyDeclaration a = PropertyDeclaration { modifier :: a, elements :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 PropertyDeclaration where liftEq = genericLiftEq
 instance Ord1 PropertyDeclaration where liftCompare = genericLiftCompare
@@ -525,7 +525,7 @@ instance Show1 PropertyDeclaration where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable PropertyDeclaration
 
 data PropertyModifier a = PropertyModifier { visibility :: a , static :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 PropertyModifier where liftEq = genericLiftEq
 instance Ord1 PropertyModifier where liftCompare = genericLiftCompare
@@ -534,7 +534,7 @@ instance Show1 PropertyModifier where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable PropertyModifier
 
 data InterfaceDeclaration a = InterfaceDeclaration { name :: a, base :: a, declarations :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 InterfaceDeclaration where liftEq = genericLiftEq
 instance Ord1 InterfaceDeclaration where liftCompare = genericLiftCompare
@@ -543,7 +543,7 @@ instance Show1 InterfaceDeclaration where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable InterfaceDeclaration
 
 newtype InterfaceBaseClause a = InterfaceBaseClause { values :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 InterfaceBaseClause where liftEq = genericLiftEq
 instance Ord1 InterfaceBaseClause where liftCompare = genericLiftCompare
@@ -552,7 +552,7 @@ instance Show1 InterfaceBaseClause where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable InterfaceBaseClause
 
 newtype Echo a = Echo { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Echo where liftEq = genericLiftEq
 instance Ord1 Echo where liftCompare = genericLiftCompare
@@ -561,7 +561,7 @@ instance Show1 Echo where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Echo
 
 newtype Unset a = Unset { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Unset where liftEq = genericLiftEq
 instance Ord1 Unset where liftCompare = genericLiftCompare
@@ -570,7 +570,7 @@ instance Show1 Unset where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Unset
 
 data Declare a = Declare { left :: a, right :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Declare where liftEq = genericLiftEq
 instance Ord1 Declare where liftCompare = genericLiftCompare
@@ -579,7 +579,7 @@ instance Show1 Declare where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Declare
 
 newtype DeclareDirective a = DeclareDirective { value :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 DeclareDirective where liftEq = genericLiftEq
 instance Ord1 DeclareDirective where liftCompare = genericLiftCompare
@@ -588,7 +588,7 @@ instance Show1 DeclareDirective where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable DeclareDirective
 
 newtype LabeledStatement a = LabeledStatement { _labeledStatementIdentifier :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 LabeledStatement where liftEq = genericLiftEq
 instance Ord1 LabeledStatement where liftCompare = genericLiftCompare

--- a/src/Language/PHP/Syntax.hs
+++ b/src/Language/PHP/Syntax.hs
@@ -202,7 +202,7 @@ instance Evaluatable QualifiedName where
         unit
 
 newtype NamespaceName a = NamespaceName { names :: NonEmpty a }
-  deriving (Eq, Ord, Show, Foldable, Traversable, Functor, Generic1, Diffable, FreeVariables1, Declarations1, ToJSONFields1, NFData1)
+  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Ord, Show, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically NamespaceName
 
 instance Hashable1 NamespaceName where liftHashWithSalt = foldl

--- a/src/Language/PHP/Syntax.hs
+++ b/src/Language/PHP/Syntax.hs
@@ -20,13 +20,13 @@ import           Diffing.Algorithm
 import           Source.Span
 
 newtype Text a = Text { value :: T.Text }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Text
 
 instance Evaluatable Text
 
 newtype VariableName a = VariableName { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically VariableName
 
 instance Evaluatable VariableName
@@ -81,7 +81,7 @@ include eval pathTerm f = do
   pure v
 
 newtype Require a = Require { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Require
 
 instance Evaluatable Require where
@@ -89,95 +89,95 @@ instance Evaluatable Require where
 
 
 newtype RequireOnce a = RequireOnce { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically RequireOnce
 
 instance Evaluatable RequireOnce where
   eval eval _ (RequireOnce path) = include eval path require
 
 newtype Include a = Include { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Include
 
 instance Evaluatable Include where
   eval eval _ (Include path) = include eval path load
 
 newtype IncludeOnce a = IncludeOnce { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically IncludeOnce
 
 instance Evaluatable IncludeOnce where
   eval eval _ (IncludeOnce path) = include eval path require
 
 newtype ArrayElement a = ArrayElement { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically ArrayElement
 
 instance Evaluatable ArrayElement
 
 newtype GlobalDeclaration a = GlobalDeclaration { values :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically GlobalDeclaration
 
 instance Evaluatable GlobalDeclaration
 
 newtype SimpleVariable a = SimpleVariable { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically SimpleVariable
 
 instance Evaluatable SimpleVariable
 
 data Concat a = Concat { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Concat
 
 instance Evaluatable Concat
 
 -- | TODO: Unify with TypeScript's PredefinedType
 newtype CastType a = CastType { _castType :: T.Text }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically CastType
 
 instance Evaluatable CastType
 
 newtype ErrorControl a = ErrorControl { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically ErrorControl
 
 instance Evaluatable ErrorControl
 
 newtype Clone a = Clone { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Clone
 
 instance Evaluatable Clone
 
 newtype ShellCommand a = ShellCommand { value :: T.Text }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically ShellCommand
 
 instance Evaluatable ShellCommand
 
 -- | TODO: Combine with TypeScript update expression.
 newtype Update a = Update { _updateSubject :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Update
 instance Evaluatable Update
 
 newtype NewVariable a = NewVariable { values :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically NewVariable
 
 instance Evaluatable NewVariable
 
 newtype RelativeScope a = RelativeScope { value :: T.Text }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically RelativeScope
 
 instance Evaluatable RelativeScope
 
 data QualifiedName a = QualifiedName { name :: a, identifier :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically QualifiedName
 
 instance Evaluatable QualifiedName where
@@ -202,7 +202,7 @@ instance Evaluatable QualifiedName where
         unit
 
 newtype NamespaceName a = NamespaceName { names :: NonEmpty a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically NamespaceName
 
 instance Hashable1 NamespaceName where liftHashWithSalt = foldl
@@ -210,220 +210,220 @@ instance Hashable1 NamespaceName where liftHashWithSalt = foldl
 instance Evaluatable NamespaceName
 
 newtype ConstDeclaration a = ConstDeclaration { values :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically ConstDeclaration
 
 instance Evaluatable ConstDeclaration
 
 data ClassConstDeclaration a = ClassConstDeclaration { visibility :: a, elements :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically ClassConstDeclaration
 
 instance Evaluatable ClassConstDeclaration
 
 newtype ClassInterfaceClause a = ClassInterfaceClause { values :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically ClassInterfaceClause
 
 instance Evaluatable ClassInterfaceClause
 
 newtype ClassBaseClause a = ClassBaseClause { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically ClassBaseClause
 
 instance Evaluatable ClassBaseClause
 
 newtype UseClause a = UseClause { values :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically UseClause
 
 instance Evaluatable UseClause
 
 newtype ReturnType a = ReturnType { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically ReturnType
 
 instance Evaluatable ReturnType
 
 newtype TypeDeclaration a = TypeDeclaration { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically TypeDeclaration
 
 instance Evaluatable TypeDeclaration
 
 newtype BaseTypeDeclaration a = BaseTypeDeclaration { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically BaseTypeDeclaration
 instance Evaluatable BaseTypeDeclaration
 
 newtype ScalarType a = ScalarType { value :: T.Text }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically ScalarType
 
 instance Evaluatable ScalarType
 
 newtype EmptyIntrinsic a = EmptyIntrinsic { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically EmptyIntrinsic
 
 instance Evaluatable EmptyIntrinsic
 
 newtype ExitIntrinsic a = ExitIntrinsic { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically ExitIntrinsic
 
 instance Evaluatable ExitIntrinsic
 
 newtype IssetIntrinsic a = IssetIntrinsic { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically IssetIntrinsic
 
 instance Evaluatable IssetIntrinsic
 
 newtype EvalIntrinsic a = EvalIntrinsic { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically EvalIntrinsic
 
 instance Evaluatable EvalIntrinsic
 
 newtype PrintIntrinsic a = PrintIntrinsic { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically PrintIntrinsic
 
 instance Evaluatable PrintIntrinsic
 
 newtype NamespaceAliasingClause a = NamespaceAliasingClause { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically NamespaceAliasingClause
 instance Evaluatable NamespaceAliasingClause
 
 newtype NamespaceUseDeclaration a = NamespaceUseDeclaration { values :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically NamespaceUseDeclaration
 
 instance Evaluatable NamespaceUseDeclaration
 
 newtype NamespaceUseClause a = NamespaceUseClause { values :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically NamespaceUseClause
 
 instance Evaluatable NamespaceUseClause
 
 newtype NamespaceUseGroupClause a = NamespaceUseGroupClause { values :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically NamespaceUseGroupClause
 
 instance Evaluatable NamespaceUseGroupClause
 
 data Namespace a = Namespace { namespaceName :: [a], namespaceBody :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Namespace
 
 instance Evaluatable Namespace
 
 data TraitDeclaration a = TraitDeclaration { traitName :: a, traitStatements :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically TraitDeclaration
 
 instance Evaluatable TraitDeclaration
 
 data AliasAs a = AliasAs { aliasAsName  :: a, aliasAsModifier :: a, aliasAsClause :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically AliasAs
 
 instance Evaluatable AliasAs
 
 data InsteadOf a = InsteadOf { left :: a, right :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically InsteadOf
 
 instance Evaluatable InsteadOf
 
 newtype TraitUseSpecification a = TraitUseSpecification { values :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically TraitUseSpecification
 
 instance Evaluatable TraitUseSpecification
 
 data TraitUseClause a = TraitUseClause { namespace :: [a], alias :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically TraitUseClause
 
 instance Evaluatable TraitUseClause
 
 data DestructorDeclaration a = DestructorDeclaration { body:: [a], name :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically DestructorDeclaration
 
 instance Evaluatable DestructorDeclaration
 
 newtype Static a = Static { value :: T.Text }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Static
 
 instance Evaluatable Static
 
 newtype ClassModifier a = ClassModifier { value :: T.Text }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically ClassModifier
 
 instance Evaluatable ClassModifier
 
 data ConstructorDeclaration a = ConstructorDeclaration { modifiers :: [a], parameters :: [a], body :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically ConstructorDeclaration
 instance Evaluatable ConstructorDeclaration
 
 data PropertyDeclaration a = PropertyDeclaration { modifier :: a, elements :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically PropertyDeclaration
 
 instance Evaluatable PropertyDeclaration
 
 data PropertyModifier a = PropertyModifier { visibility :: a , static :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically PropertyModifier
 
 instance Evaluatable PropertyModifier
 
 data InterfaceDeclaration a = InterfaceDeclaration { name :: a, base :: a, declarations :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically InterfaceDeclaration
 
 instance Evaluatable InterfaceDeclaration
 
 newtype InterfaceBaseClause a = InterfaceBaseClause { values :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically InterfaceBaseClause
 
 instance Evaluatable InterfaceBaseClause
 
 newtype Echo a = Echo { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Echo
 
 instance Evaluatable Echo
 
 newtype Unset a = Unset { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Unset
 
 instance Evaluatable Unset
 
 data Declare a = Declare { left :: a, right :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Declare
 
 instance Evaluatable Declare
 
 newtype DeclareDirective a = DeclareDirective { value :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically DeclareDirective
 
 instance Evaluatable DeclareDirective
 
 newtype LabeledStatement a = LabeledStatement { _labeledStatementIdentifier :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically LabeledStatement
 
 instance Evaluatable LabeledStatement

--- a/src/Language/PHP/Syntax.hs
+++ b/src/Language/PHP/Syntax.hs
@@ -21,13 +21,19 @@ import           Source.Span
 
 newtype Text a = Text { value :: T.Text }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Text
+
+instance Eq1 Text where liftEq = genericLiftEq
+instance Ord1 Text where liftCompare = genericLiftCompare
+instance Show1 Text where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Text
 
 newtype VariableName a = VariableName { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically VariableName
+
+instance Eq1 VariableName where liftEq = genericLiftEq
+instance Ord1 VariableName where liftCompare = genericLiftCompare
+instance Show1 VariableName where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable VariableName
 
@@ -82,7 +88,10 @@ include eval pathTerm f = do
 
 newtype Require a = Require { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Require
+
+instance Eq1 Require where liftEq = genericLiftEq
+instance Ord1 Require where liftCompare = genericLiftCompare
+instance Show1 Require where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Require where
   eval eval _ (Require path) = include eval path load
@@ -90,95 +99,140 @@ instance Evaluatable Require where
 
 newtype RequireOnce a = RequireOnce { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically RequireOnce
+
+instance Eq1 RequireOnce where liftEq = genericLiftEq
+instance Ord1 RequireOnce where liftCompare = genericLiftCompare
+instance Show1 RequireOnce where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable RequireOnce where
   eval eval _ (RequireOnce path) = include eval path require
 
 newtype Include a = Include { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Include
+
+instance Eq1 Include where liftEq = genericLiftEq
+instance Ord1 Include where liftCompare = genericLiftCompare
+instance Show1 Include where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Include where
   eval eval _ (Include path) = include eval path load
 
 newtype IncludeOnce a = IncludeOnce { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically IncludeOnce
+
+instance Eq1 IncludeOnce where liftEq = genericLiftEq
+instance Ord1 IncludeOnce where liftCompare = genericLiftCompare
+instance Show1 IncludeOnce where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable IncludeOnce where
   eval eval _ (IncludeOnce path) = include eval path require
 
 newtype ArrayElement a = ArrayElement { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically ArrayElement
+
+instance Eq1 ArrayElement where liftEq = genericLiftEq
+instance Ord1 ArrayElement where liftCompare = genericLiftCompare
+instance Show1 ArrayElement where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ArrayElement
 
 newtype GlobalDeclaration a = GlobalDeclaration { values :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically GlobalDeclaration
+
+instance Eq1 GlobalDeclaration where liftEq = genericLiftEq
+instance Ord1 GlobalDeclaration where liftCompare = genericLiftCompare
+instance Show1 GlobalDeclaration where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable GlobalDeclaration
 
 newtype SimpleVariable a = SimpleVariable { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically SimpleVariable
+
+instance Eq1 SimpleVariable where liftEq = genericLiftEq
+instance Ord1 SimpleVariable where liftCompare = genericLiftCompare
+instance Show1 SimpleVariable where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable SimpleVariable
 
 data Concat a = Concat { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Concat
+
+instance Eq1 Concat where liftEq = genericLiftEq
+instance Ord1 Concat where liftCompare = genericLiftCompare
+instance Show1 Concat where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Concat
 
 -- | TODO: Unify with TypeScript's PredefinedType
 newtype CastType a = CastType { _castType :: T.Text }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically CastType
+
+instance Eq1 CastType where liftEq = genericLiftEq
+instance Ord1 CastType where liftCompare = genericLiftCompare
+instance Show1 CastType where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable CastType
 
 newtype ErrorControl a = ErrorControl { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically ErrorControl
+
+instance Eq1 ErrorControl where liftEq = genericLiftEq
+instance Ord1 ErrorControl where liftCompare = genericLiftCompare
+instance Show1 ErrorControl where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ErrorControl
 
 newtype Clone a = Clone { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Clone
+
+instance Eq1 Clone where liftEq = genericLiftEq
+instance Ord1 Clone where liftCompare = genericLiftCompare
+instance Show1 Clone where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Clone
 
 newtype ShellCommand a = ShellCommand { value :: T.Text }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically ShellCommand
+
+instance Eq1 ShellCommand where liftEq = genericLiftEq
+instance Ord1 ShellCommand where liftCompare = genericLiftCompare
+instance Show1 ShellCommand where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ShellCommand
 
 -- | TODO: Combine with TypeScript update expression.
 newtype Update a = Update { _updateSubject :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Update
+
+instance Eq1 Update where liftEq = genericLiftEq
+instance Ord1 Update where liftCompare = genericLiftCompare
+instance Show1 Update where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Update
 
 newtype NewVariable a = NewVariable { values :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically NewVariable
+
+instance Eq1 NewVariable where liftEq = genericLiftEq
+instance Ord1 NewVariable where liftCompare = genericLiftCompare
+instance Show1 NewVariable where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable NewVariable
 
 newtype RelativeScope a = RelativeScope { value :: T.Text }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically RelativeScope
+
+instance Eq1 RelativeScope where liftEq = genericLiftEq
+instance Ord1 RelativeScope where liftCompare = genericLiftCompare
+instance Show1 RelativeScope where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable RelativeScope
 
 data QualifiedName a = QualifiedName { name :: a, identifier :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically QualifiedName
+
+instance Eq1 QualifiedName where liftEq = genericLiftEq
+instance Ord1 QualifiedName where liftCompare = genericLiftCompare
+instance Show1 QualifiedName where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable QualifiedName where
   eval _ _ (QualifiedName obj iden) = do
@@ -203,7 +257,10 @@ instance Evaluatable QualifiedName where
 
 newtype NamespaceName a = NamespaceName { names :: NonEmpty a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically NamespaceName
+
+instance Eq1 NamespaceName where liftEq = genericLiftEq
+instance Ord1 NamespaceName where liftCompare = genericLiftCompare
+instance Show1 NamespaceName where liftShowsPrec = genericLiftShowsPrec
 
 instance Hashable1 NamespaceName where liftHashWithSalt = foldl
 
@@ -211,219 +268,330 @@ instance Evaluatable NamespaceName
 
 newtype ConstDeclaration a = ConstDeclaration { values :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically ConstDeclaration
+
+instance Eq1 ConstDeclaration where liftEq = genericLiftEq
+instance Ord1 ConstDeclaration where liftCompare = genericLiftCompare
+instance Show1 ConstDeclaration where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ConstDeclaration
 
 data ClassConstDeclaration a = ClassConstDeclaration { visibility :: a, elements :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically ClassConstDeclaration
+
+instance Eq1 ClassConstDeclaration where liftEq = genericLiftEq
+instance Ord1 ClassConstDeclaration where liftCompare = genericLiftCompare
+instance Show1 ClassConstDeclaration where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ClassConstDeclaration
 
 newtype ClassInterfaceClause a = ClassInterfaceClause { values :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically ClassInterfaceClause
+
+instance Eq1 ClassInterfaceClause where liftEq = genericLiftEq
+instance Ord1 ClassInterfaceClause where liftCompare = genericLiftCompare
+instance Show1 ClassInterfaceClause where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ClassInterfaceClause
 
 newtype ClassBaseClause a = ClassBaseClause { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically ClassBaseClause
+
+instance Eq1 ClassBaseClause where liftEq = genericLiftEq
+instance Ord1 ClassBaseClause where liftCompare = genericLiftCompare
+instance Show1 ClassBaseClause where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ClassBaseClause
 
 newtype UseClause a = UseClause { values :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically UseClause
+
+instance Eq1 UseClause where liftEq = genericLiftEq
+instance Ord1 UseClause where liftCompare = genericLiftCompare
+instance Show1 UseClause where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable UseClause
 
 newtype ReturnType a = ReturnType { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically ReturnType
+
+instance Eq1 ReturnType where liftEq = genericLiftEq
+instance Ord1 ReturnType where liftCompare = genericLiftCompare
+instance Show1 ReturnType where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ReturnType
 
 newtype TypeDeclaration a = TypeDeclaration { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically TypeDeclaration
+
+instance Eq1 TypeDeclaration where liftEq = genericLiftEq
+instance Ord1 TypeDeclaration where liftCompare = genericLiftCompare
+instance Show1 TypeDeclaration where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable TypeDeclaration
 
 newtype BaseTypeDeclaration a = BaseTypeDeclaration { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically BaseTypeDeclaration
+
+instance Eq1 BaseTypeDeclaration where liftEq = genericLiftEq
+instance Ord1 BaseTypeDeclaration where liftCompare = genericLiftCompare
+instance Show1 BaseTypeDeclaration where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable BaseTypeDeclaration
 
 newtype ScalarType a = ScalarType { value :: T.Text }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically ScalarType
+
+instance Eq1 ScalarType where liftEq = genericLiftEq
+instance Ord1 ScalarType where liftCompare = genericLiftCompare
+instance Show1 ScalarType where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ScalarType
 
 newtype EmptyIntrinsic a = EmptyIntrinsic { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically EmptyIntrinsic
+
+instance Eq1 EmptyIntrinsic where liftEq = genericLiftEq
+instance Ord1 EmptyIntrinsic where liftCompare = genericLiftCompare
+instance Show1 EmptyIntrinsic where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable EmptyIntrinsic
 
 newtype ExitIntrinsic a = ExitIntrinsic { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically ExitIntrinsic
+
+instance Eq1 ExitIntrinsic where liftEq = genericLiftEq
+instance Ord1 ExitIntrinsic where liftCompare = genericLiftCompare
+instance Show1 ExitIntrinsic where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ExitIntrinsic
 
 newtype IssetIntrinsic a = IssetIntrinsic { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically IssetIntrinsic
+
+instance Eq1 IssetIntrinsic where liftEq = genericLiftEq
+instance Ord1 IssetIntrinsic where liftCompare = genericLiftCompare
+instance Show1 IssetIntrinsic where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable IssetIntrinsic
 
 newtype EvalIntrinsic a = EvalIntrinsic { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically EvalIntrinsic
+
+instance Eq1 EvalIntrinsic where liftEq = genericLiftEq
+instance Ord1 EvalIntrinsic where liftCompare = genericLiftCompare
+instance Show1 EvalIntrinsic where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable EvalIntrinsic
 
 newtype PrintIntrinsic a = PrintIntrinsic { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically PrintIntrinsic
+
+instance Eq1 PrintIntrinsic where liftEq = genericLiftEq
+instance Ord1 PrintIntrinsic where liftCompare = genericLiftCompare
+instance Show1 PrintIntrinsic where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable PrintIntrinsic
 
 newtype NamespaceAliasingClause a = NamespaceAliasingClause { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically NamespaceAliasingClause
+
+instance Eq1 NamespaceAliasingClause where liftEq = genericLiftEq
+instance Ord1 NamespaceAliasingClause where liftCompare = genericLiftCompare
+instance Show1 NamespaceAliasingClause where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable NamespaceAliasingClause
 
 newtype NamespaceUseDeclaration a = NamespaceUseDeclaration { values :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically NamespaceUseDeclaration
+
+instance Eq1 NamespaceUseDeclaration where liftEq = genericLiftEq
+instance Ord1 NamespaceUseDeclaration where liftCompare = genericLiftCompare
+instance Show1 NamespaceUseDeclaration where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable NamespaceUseDeclaration
 
 newtype NamespaceUseClause a = NamespaceUseClause { values :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically NamespaceUseClause
+
+instance Eq1 NamespaceUseClause where liftEq = genericLiftEq
+instance Ord1 NamespaceUseClause where liftCompare = genericLiftCompare
+instance Show1 NamespaceUseClause where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable NamespaceUseClause
 
 newtype NamespaceUseGroupClause a = NamespaceUseGroupClause { values :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically NamespaceUseGroupClause
+
+instance Eq1 NamespaceUseGroupClause where liftEq = genericLiftEq
+instance Ord1 NamespaceUseGroupClause where liftCompare = genericLiftCompare
+instance Show1 NamespaceUseGroupClause where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable NamespaceUseGroupClause
 
 data Namespace a = Namespace { namespaceName :: [a], namespaceBody :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Namespace
+
+instance Eq1 Namespace where liftEq = genericLiftEq
+instance Ord1 Namespace where liftCompare = genericLiftCompare
+instance Show1 Namespace where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Namespace
 
 data TraitDeclaration a = TraitDeclaration { traitName :: a, traitStatements :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically TraitDeclaration
+
+instance Eq1 TraitDeclaration where liftEq = genericLiftEq
+instance Ord1 TraitDeclaration where liftCompare = genericLiftCompare
+instance Show1 TraitDeclaration where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable TraitDeclaration
 
 data AliasAs a = AliasAs { aliasAsName  :: a, aliasAsModifier :: a, aliasAsClause :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically AliasAs
+
+instance Eq1 AliasAs where liftEq = genericLiftEq
+instance Ord1 AliasAs where liftCompare = genericLiftCompare
+instance Show1 AliasAs where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable AliasAs
 
 data InsteadOf a = InsteadOf { left :: a, right :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically InsteadOf
+
+instance Eq1 InsteadOf where liftEq = genericLiftEq
+instance Ord1 InsteadOf where liftCompare = genericLiftCompare
+instance Show1 InsteadOf where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable InsteadOf
 
 newtype TraitUseSpecification a = TraitUseSpecification { values :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically TraitUseSpecification
+
+instance Eq1 TraitUseSpecification where liftEq = genericLiftEq
+instance Ord1 TraitUseSpecification where liftCompare = genericLiftCompare
+instance Show1 TraitUseSpecification where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable TraitUseSpecification
 
 data TraitUseClause a = TraitUseClause { namespace :: [a], alias :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically TraitUseClause
+
+instance Eq1 TraitUseClause where liftEq = genericLiftEq
+instance Ord1 TraitUseClause where liftCompare = genericLiftCompare
+instance Show1 TraitUseClause where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable TraitUseClause
 
 data DestructorDeclaration a = DestructorDeclaration { body:: [a], name :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically DestructorDeclaration
+
+instance Eq1 DestructorDeclaration where liftEq = genericLiftEq
+instance Ord1 DestructorDeclaration where liftCompare = genericLiftCompare
+instance Show1 DestructorDeclaration where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable DestructorDeclaration
 
 newtype Static a = Static { value :: T.Text }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Static
+
+instance Eq1 Static where liftEq = genericLiftEq
+instance Ord1 Static where liftCompare = genericLiftCompare
+instance Show1 Static where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Static
 
 newtype ClassModifier a = ClassModifier { value :: T.Text }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically ClassModifier
+
+instance Eq1 ClassModifier where liftEq = genericLiftEq
+instance Ord1 ClassModifier where liftCompare = genericLiftCompare
+instance Show1 ClassModifier where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ClassModifier
 
 data ConstructorDeclaration a = ConstructorDeclaration { modifiers :: [a], parameters :: [a], body :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically ConstructorDeclaration
+
+instance Eq1 ConstructorDeclaration where liftEq = genericLiftEq
+instance Ord1 ConstructorDeclaration where liftCompare = genericLiftCompare
+instance Show1 ConstructorDeclaration where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ConstructorDeclaration
 
 data PropertyDeclaration a = PropertyDeclaration { modifier :: a, elements :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically PropertyDeclaration
+
+instance Eq1 PropertyDeclaration where liftEq = genericLiftEq
+instance Ord1 PropertyDeclaration where liftCompare = genericLiftCompare
+instance Show1 PropertyDeclaration where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable PropertyDeclaration
 
 data PropertyModifier a = PropertyModifier { visibility :: a , static :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically PropertyModifier
+
+instance Eq1 PropertyModifier where liftEq = genericLiftEq
+instance Ord1 PropertyModifier where liftCompare = genericLiftCompare
+instance Show1 PropertyModifier where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable PropertyModifier
 
 data InterfaceDeclaration a = InterfaceDeclaration { name :: a, base :: a, declarations :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically InterfaceDeclaration
+
+instance Eq1 InterfaceDeclaration where liftEq = genericLiftEq
+instance Ord1 InterfaceDeclaration where liftCompare = genericLiftCompare
+instance Show1 InterfaceDeclaration where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable InterfaceDeclaration
 
 newtype InterfaceBaseClause a = InterfaceBaseClause { values :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically InterfaceBaseClause
+
+instance Eq1 InterfaceBaseClause where liftEq = genericLiftEq
+instance Ord1 InterfaceBaseClause where liftCompare = genericLiftCompare
+instance Show1 InterfaceBaseClause where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable InterfaceBaseClause
 
 newtype Echo a = Echo { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Echo
+
+instance Eq1 Echo where liftEq = genericLiftEq
+instance Ord1 Echo where liftCompare = genericLiftCompare
+instance Show1 Echo where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Echo
 
 newtype Unset a = Unset { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Unset
+
+instance Eq1 Unset where liftEq = genericLiftEq
+instance Ord1 Unset where liftCompare = genericLiftCompare
+instance Show1 Unset where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Unset
 
 data Declare a = Declare { left :: a, right :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Declare
+
+instance Eq1 Declare where liftEq = genericLiftEq
+instance Ord1 Declare where liftCompare = genericLiftCompare
+instance Show1 Declare where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Declare
 
 newtype DeclareDirective a = DeclareDirective { value :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically DeclareDirective
+
+instance Eq1 DeclareDirective where liftEq = genericLiftEq
+instance Ord1 DeclareDirective where liftCompare = genericLiftCompare
+instance Show1 DeclareDirective where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable DeclareDirective
 
 newtype LabeledStatement a = LabeledStatement { _labeledStatementIdentifier :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically LabeledStatement
+
+instance Eq1 LabeledStatement where liftEq = genericLiftEq
+instance Ord1 LabeledStatement where liftCompare = genericLiftCompare
+instance Show1 LabeledStatement where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable LabeledStatement

--- a/src/Language/Python/Syntax.hs
+++ b/src/Language/Python/Syntax.hs
@@ -94,7 +94,10 @@ resolvePythonModules q = do
 
 data Alias a = Alias { aliasValue :: a, aliasName :: a}
   deriving (Generic1, Diffable, Foldable, FreeVariables1, Functor, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Alias
+
+instance Eq1 Alias where liftEq = genericLiftEq
+instance Ord1 Alias where liftCompare = genericLiftCompare
+instance Show1 Alias where liftShowsPrec = genericLiftShowsPrec
 
 instance Declarations1 Alias where
   liftDeclaredName declaredName = declaredName . aliasValue
@@ -107,11 +110,17 @@ instance Evaluatable Alias where
 -- If the list of symbols is empty copy everything to the calling environment.
 data Import a = Import { importFrom :: QualifiedName, importSymbols :: ![a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Import
+
+instance Eq1 Import where liftEq = genericLiftEq
+instance Ord1 Import where liftCompare = genericLiftCompare
+instance Show1 Import where liftShowsPrec = genericLiftShowsPrec
 
 newtype FutureImport a = FutureImport { futureImportSymbols :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically FutureImport
+
+instance Eq1 FutureImport where liftEq = genericLiftEq
+instance Ord1 FutureImport where liftCompare = genericLiftCompare
+instance Show1 FutureImport where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable FutureImport where
 
@@ -182,7 +191,10 @@ deriving instance Hashable1 NonEmpty
 
 newtype QualifiedImport a = QualifiedImport { qualifiedImportFrom :: NonEmpty a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically QualifiedImport
+
+instance Eq1 QualifiedImport where liftEq = genericLiftEq
+instance Ord1 QualifiedImport where liftCompare = genericLiftCompare
+instance Show1 QualifiedImport where liftShowsPrec = genericLiftShowsPrec
 
 -- import a.b.c
 instance Evaluatable QualifiedImport where
@@ -221,7 +233,10 @@ instance Evaluatable QualifiedImport where
 
 data QualifiedAliasedImport a = QualifiedAliasedImport { qualifiedAliasedImportFrom :: QualifiedName, qualifiedAliasedImportAlias :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically QualifiedAliasedImport
+
+instance Eq1 QualifiedAliasedImport where liftEq = genericLiftEq
+instance Ord1 QualifiedAliasedImport where liftCompare = genericLiftCompare
+instance Show1 QualifiedAliasedImport where liftShowsPrec = genericLiftShowsPrec
 
 -- import a.b.c as e
 instance Evaluatable QualifiedAliasedImport where
@@ -248,14 +263,20 @@ instance Evaluatable QualifiedAliasedImport where
 -- | Ellipsis (used in splice expressions and alternatively can be used as a fill in expression, like `undefined` in Haskell)
 data Ellipsis a = Ellipsis
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Ellipsis
+
+instance Eq1 Ellipsis where liftEq = genericLiftEq
+instance Ord1 Ellipsis where liftCompare = genericLiftCompare
+instance Show1 Ellipsis where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Ellipsis
 instance Evaluatable Ellipsis
 
 data Redirect a = Redirect { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Redirect
+
+instance Eq1 Redirect where liftEq = genericLiftEq
+instance Ord1 Redirect where liftCompare = genericLiftCompare
+instance Show1 Redirect where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for Redirect
 instance Evaluatable Redirect

--- a/src/Language/Python/Syntax.hs
+++ b/src/Language/Python/Syntax.hs
@@ -93,7 +93,7 @@ resolvePythonModules q = do
       maybeM (throwResolutionError $ NotFoundError path searchPaths Language.Python) modulePath
 
 data Alias a = Alias { aliasValue :: a, aliasName :: a}
-  deriving (Generic1, Diffable, Eq, Foldable, FreeVariables1, Functor, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Generic1, Diffable, Foldable, FreeVariables1, Functor, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Alias
 
 instance Declarations1 Alias where
@@ -106,11 +106,11 @@ instance Evaluatable Alias where
 --
 -- If the list of symbols is empty copy everything to the calling environment.
 data Import a = Import { importFrom :: QualifiedName, importSymbols :: ![a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Import
 
 newtype FutureImport a = FutureImport { futureImportSymbols :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically FutureImport
 
 instance Evaluatable FutureImport where
@@ -181,7 +181,7 @@ instance Evaluatable Import where
 deriving instance Hashable1 NonEmpty
 
 newtype QualifiedImport a = QualifiedImport { qualifiedImportFrom :: NonEmpty a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically QualifiedImport
 
 -- import a.b.c
@@ -220,7 +220,7 @@ instance Evaluatable QualifiedImport where
         fun (Map.singleton moduleScope moduleFrame)
 
 data QualifiedAliasedImport a = QualifiedAliasedImport { qualifiedAliasedImportFrom :: QualifiedName, qualifiedAliasedImportAlias :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically QualifiedAliasedImport
 
 -- import a.b.c as e
@@ -247,14 +247,14 @@ instance Evaluatable QualifiedAliasedImport where
 
 -- | Ellipsis (used in splice expressions and alternatively can be used as a fill in expression, like `undefined` in Haskell)
 data Ellipsis a = Ellipsis
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Ellipsis
 
 -- TODO: Implement Eval instance for Ellipsis
 instance Evaluatable Ellipsis
 
 data Redirect a = Redirect { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Redirect
 
 -- TODO: Implement Eval instance for Redirect

--- a/src/Language/Python/Syntax.hs
+++ b/src/Language/Python/Syntax.hs
@@ -27,7 +27,7 @@ import           Source.Span
 data QualifiedName
   = QualifiedName { paths :: NonEmpty FilePath }
   | RelativeQualifiedName { path :: FilePath, maybeQualifiedName ::  Maybe QualifiedName }
-  deriving (Eq, Generic, Hashable, Ord, Show, ToJSON, NFData)
+  deriving (Eq, Generic, Hashable, Ord, Show, ToJSON)
 
 qualifiedName :: NonEmpty Text -> QualifiedName
 qualifiedName xs = QualifiedName (T.unpack <$> xs)
@@ -93,7 +93,7 @@ resolvePythonModules q = do
       maybeM (throwResolutionError $ NotFoundError path searchPaths Language.Python) modulePath
 
 data Alias a = Alias { aliasValue :: a, aliasName :: a}
-  deriving (Generic1, Diffable, Foldable, FreeVariables1, Functor, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Generic1, Diffable, Foldable, FreeVariables1, Functor, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Alias where liftEq = genericLiftEq
 instance Ord1 Alias where liftCompare = genericLiftCompare
@@ -109,14 +109,14 @@ instance Evaluatable Alias where
 --
 -- If the list of symbols is empty copy everything to the calling environment.
 data Import a = Import { importFrom :: QualifiedName, importSymbols :: ![a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Import where liftEq = genericLiftEq
 instance Ord1 Import where liftCompare = genericLiftCompare
 instance Show1 Import where liftShowsPrec = genericLiftShowsPrec
 
 newtype FutureImport a = FutureImport { futureImportSymbols :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 FutureImport where liftEq = genericLiftEq
 instance Ord1 FutureImport where liftCompare = genericLiftCompare
@@ -190,7 +190,7 @@ instance Evaluatable Import where
 deriving instance Hashable1 NonEmpty
 
 newtype QualifiedImport a = QualifiedImport { qualifiedImportFrom :: NonEmpty a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 QualifiedImport where liftEq = genericLiftEq
 instance Ord1 QualifiedImport where liftCompare = genericLiftCompare
@@ -232,7 +232,7 @@ instance Evaluatable QualifiedImport where
         fun (Map.singleton moduleScope moduleFrame)
 
 data QualifiedAliasedImport a = QualifiedAliasedImport { qualifiedAliasedImportFrom :: QualifiedName, qualifiedAliasedImportAlias :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 QualifiedAliasedImport where liftEq = genericLiftEq
 instance Ord1 QualifiedAliasedImport where liftCompare = genericLiftCompare
@@ -262,7 +262,7 @@ instance Evaluatable QualifiedAliasedImport where
 
 -- | Ellipsis (used in splice expressions and alternatively can be used as a fill in expression, like `undefined` in Haskell)
 data Ellipsis a = Ellipsis
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Ellipsis where liftEq = genericLiftEq
 instance Ord1 Ellipsis where liftCompare = genericLiftCompare
@@ -272,7 +272,7 @@ instance Show1 Ellipsis where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Ellipsis
 
 data Redirect a = Redirect { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Redirect where liftEq = genericLiftEq
 instance Ord1 Redirect where liftCompare = genericLiftCompare

--- a/src/Language/Python/Syntax.hs
+++ b/src/Language/Python/Syntax.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DeriveAnyClass, DerivingVia #-}
 {-# OPTIONS_GHC -Wno-missing-export-lists #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-} -- FIXME
 module Language.Python.Syntax where
 
 import Prologue
@@ -187,14 +186,13 @@ instance Evaluatable Import where
 
     unit
 
-deriving instance Hashable1 NonEmpty
-
 newtype QualifiedImport a = QualifiedImport { qualifiedImportFrom :: NonEmpty a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, ToJSONFields1, Traversable)
 
 instance Eq1 QualifiedImport where liftEq = genericLiftEq
 instance Ord1 QualifiedImport where liftCompare = genericLiftCompare
 instance Show1 QualifiedImport where liftShowsPrec = genericLiftShowsPrec
+instance Hashable1 QualifiedImport where liftHashWithSalt = foldl
 
 -- import a.b.c
 instance Evaluatable QualifiedImport where

--- a/src/Language/Ruby/Syntax.hs
+++ b/src/Language/Ruby/Syntax.hs
@@ -60,7 +60,10 @@ cleanNameOrPath = T.unpack . dropRelativePrefix . stripQuotes
 
 data Send a = Send { sendReceiver :: Maybe a, sendSelector :: Maybe a, sendArgs :: [a], sendBlock :: Maybe a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Send
+
+instance Eq1 Send where liftEq = genericLiftEq
+instance Ord1 Send where liftCompare = genericLiftCompare
+instance Show1 Send where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Send where
   eval eval _ Send{..} = do
@@ -84,7 +87,10 @@ instance Evaluatable Send where
 
 data Require a = Require { requireRelative :: Bool, requirePath :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Require
+
+instance Eq1 Require where liftEq = genericLiftEq
+instance Ord1 Require where liftCompare = genericLiftCompare
+instance Show1 Require where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Require where
   eval eval _ (Require _ x) = do
@@ -111,7 +117,10 @@ doRequire path = do
 
 data Load a = Load { loadPath :: a, loadWrap :: Maybe a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Load
+
+instance Eq1 Load where liftEq = genericLiftEq
+instance Ord1 Load where liftCompare = genericLiftCompare
+instance Show1 Load where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Load where
   eval eval _ (Load x Nothing) = do
@@ -152,7 +161,10 @@ doLoad path shouldWrap = do
 
 data Class a = Class { classIdentifier :: !a, classSuperClass :: !(Maybe a), classBody :: !a }
   deriving (Foldable, Traversable, Functor, Generic1, Hashable1, FreeVariables1, ToJSONFields1, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Class
+
+instance Eq1 Class where liftEq = genericLiftEq
+instance Ord1 Class where liftCompare = genericLiftCompare
+instance Show1 Class where liftShowsPrec = genericLiftShowsPrec
 
 instance Diffable Class where
   equivalentBySubterm = Just . classIdentifier
@@ -209,7 +221,10 @@ instance Declarations1 Class where
 
 data Module a = Module { moduleIdentifier :: !a, moduleStatements :: ![a] }
   deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Module
+
+instance Eq1 Module where liftEq = genericLiftEq
+instance Ord1 Module where liftCompare = genericLiftCompare
+instance Show1 Module where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Module where
   eval eval _ Module{..} =  do
@@ -253,7 +268,10 @@ instance Declarations1 Module where
 
 data LowPrecedenceAnd a = LowPrecedenceAnd { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically LowPrecedenceAnd
+
+instance Eq1 LowPrecedenceAnd where liftEq = genericLiftEq
+instance Ord1 LowPrecedenceAnd where liftCompare = genericLiftCompare
+instance Show1 LowPrecedenceAnd where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable LowPrecedenceAnd where
   -- N.B. we have to use Monad rather than Applicative/Traversable on 'And' and 'Or' so that we don't evaluate both operands
@@ -265,7 +283,10 @@ instance Evaluatable LowPrecedenceAnd where
 
 data LowPrecedenceOr a = LowPrecedenceOr { lhs :: a, rhs :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically LowPrecedenceOr
+
+instance Eq1 LowPrecedenceOr where liftEq = genericLiftEq
+instance Ord1 LowPrecedenceOr where liftCompare = genericLiftCompare
+instance Show1 LowPrecedenceOr where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable LowPrecedenceOr where
   -- N.B. we have to use Monad rather than Applicative/Traversable on 'And' and 'Or' so that we don't evaluate both operands
@@ -276,7 +297,10 @@ instance Evaluatable LowPrecedenceOr where
 
 data Assignment a = Assignment { assignmentContext :: ![a], assignmentTarget :: !a, assignmentValue :: !a }
   deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically Assignment
+
+instance Eq1 Assignment where liftEq = genericLiftEq
+instance Ord1 Assignment where liftCompare = genericLiftCompare
+instance Show1 Assignment where liftShowsPrec = genericLiftShowsPrec
 
 instance Declarations1 Assignment where
   liftDeclaredName declaredName Assignment{..} = declaredName assignmentTarget
@@ -313,6 +337,9 @@ instance Evaluatable Assignment where
 -- arguments to the @super()@ invocation.
 data ZSuper a = ZSuper
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically ZSuper
+
+instance Eq1 ZSuper where liftEq = genericLiftEq
+instance Ord1 ZSuper where liftCompare = genericLiftCompare
+instance Show1 ZSuper where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ZSuper

--- a/src/Language/Ruby/Syntax.hs
+++ b/src/Language/Ruby/Syntax.hs
@@ -59,7 +59,7 @@ cleanNameOrPath :: Text -> String
 cleanNameOrPath = T.unpack . dropRelativePrefix . stripQuotes
 
 data Send a = Send { sendReceiver :: Maybe a, sendSelector :: Maybe a, sendArgs :: [a], sendBlock :: Maybe a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Send
 
 instance Evaluatable Send where
@@ -83,7 +83,7 @@ instance Evaluatable Send where
     maybe callFunction (`withScopeAndFrame` callFunction) lhsFrame
 
 data Require a = Require { requireRelative :: Bool, requirePath :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Require
 
 instance Evaluatable Require where
@@ -110,7 +110,7 @@ doRequire path = do
 
 
 data Load a = Load { loadPath :: a, loadWrap :: Maybe a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Load
 
 instance Evaluatable Load where
@@ -151,7 +151,7 @@ doLoad path shouldWrap = do
 -- TODO: autoload
 
 data Class a = Class { classIdentifier :: !a, classSuperClass :: !(Maybe a), classBody :: !a }
-  deriving (Eq, Ord, Show, Foldable, Traversable, Functor, Generic1, Hashable1, FreeVariables1, ToJSONFields1, NFData1)
+  deriving (Foldable, Traversable, Functor, Generic1, Hashable1, FreeVariables1, ToJSONFields1, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Class
 
 instance Diffable Class where
@@ -208,7 +208,7 @@ instance Declarations1 Class where
 
 
 data Module a = Module { moduleIdentifier :: !a, moduleStatements :: ![a] }
-  deriving (Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Module
 
 instance Evaluatable Module where
@@ -252,7 +252,7 @@ instance Declarations1 Module where
 
 
 data LowPrecedenceAnd a = LowPrecedenceAnd { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically LowPrecedenceAnd
 
 instance Evaluatable LowPrecedenceAnd where
@@ -264,7 +264,7 @@ instance Evaluatable LowPrecedenceAnd where
 
 
 data LowPrecedenceOr a = LowPrecedenceOr { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically LowPrecedenceOr
 
 instance Evaluatable LowPrecedenceOr where
@@ -275,7 +275,7 @@ instance Evaluatable LowPrecedenceOr where
       ifthenelse cond (pure cond) b
 
 data Assignment a = Assignment { assignmentContext :: ![a], assignmentTarget :: !a, assignmentValue :: !a }
-  deriving (Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically Assignment
 
 instance Declarations1 Assignment where
@@ -312,7 +312,7 @@ instance Evaluatable Assignment where
 -- the semantics of invoking @super()@ but implicitly passing the current function's
 -- arguments to the @super()@ invocation.
 data ZSuper a = ZSuper
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically ZSuper
 
 instance Evaluatable ZSuper

--- a/src/Language/Ruby/Syntax.hs
+++ b/src/Language/Ruby/Syntax.hs
@@ -59,7 +59,7 @@ cleanNameOrPath :: Text -> String
 cleanNameOrPath = T.unpack . dropRelativePrefix . stripQuotes
 
 data Send a = Send { sendReceiver :: Maybe a, sendSelector :: Maybe a, sendArgs :: [a], sendBlock :: Maybe a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Send where liftEq = genericLiftEq
 instance Ord1 Send where liftCompare = genericLiftCompare
@@ -86,7 +86,7 @@ instance Evaluatable Send where
     maybe callFunction (`withScopeAndFrame` callFunction) lhsFrame
 
 data Require a = Require { requireRelative :: Bool, requirePath :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Require where liftEq = genericLiftEq
 instance Ord1 Require where liftCompare = genericLiftCompare
@@ -116,7 +116,7 @@ doRequire path = do
 
 
 data Load a = Load { loadPath :: a, loadWrap :: Maybe a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Load where liftEq = genericLiftEq
 instance Ord1 Load where liftCompare = genericLiftCompare
@@ -160,7 +160,7 @@ doLoad path shouldWrap = do
 -- TODO: autoload
 
 data Class a = Class { classIdentifier :: !a, classSuperClass :: !(Maybe a), classBody :: !a }
-  deriving (Foldable, Traversable, Functor, Generic1, Hashable1, FreeVariables1, ToJSONFields1, NFData1)
+  deriving (Foldable, Traversable, Functor, Generic1, Hashable1, FreeVariables1, ToJSONFields1)
 
 instance Eq1 Class where liftEq = genericLiftEq
 instance Ord1 Class where liftCompare = genericLiftCompare
@@ -220,7 +220,7 @@ instance Declarations1 Class where
 
 
 data Module a = Module { moduleIdentifier :: !a, moduleStatements :: ![a] }
-  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Module where liftEq = genericLiftEq
 instance Ord1 Module where liftCompare = genericLiftCompare
@@ -267,7 +267,7 @@ instance Declarations1 Module where
 
 
 data LowPrecedenceAnd a = LowPrecedenceAnd { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 LowPrecedenceAnd where liftEq = genericLiftEq
 instance Ord1 LowPrecedenceAnd where liftCompare = genericLiftCompare
@@ -282,7 +282,7 @@ instance Evaluatable LowPrecedenceAnd where
 
 
 data LowPrecedenceOr a = LowPrecedenceOr { lhs :: a, rhs :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 LowPrecedenceOr where liftEq = genericLiftEq
 instance Ord1 LowPrecedenceOr where liftCompare = genericLiftCompare
@@ -296,7 +296,7 @@ instance Evaluatable LowPrecedenceOr where
       ifthenelse cond (pure cond) b
 
 data Assignment a = Assignment { assignmentContext :: ![a], assignmentTarget :: !a, assignmentValue :: !a }
-  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Assignment where liftEq = genericLiftEq
 instance Ord1 Assignment where liftCompare = genericLiftCompare
@@ -336,7 +336,7 @@ instance Evaluatable Assignment where
 -- the semantics of invoking @super()@ but implicitly passing the current function's
 -- arguments to the @super()@ invocation.
 data ZSuper a = ZSuper
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ZSuper where liftEq = genericLiftEq
 instance Ord1 ZSuper where liftCompare = genericLiftCompare

--- a/src/Language/TSX/Syntax/JSX.hs
+++ b/src/Language/TSX/Syntax/JSX.hs
@@ -11,55 +11,55 @@ import           Diffing.Algorithm
 
 
 data JsxElement a = JsxElement { jsxOpeningElement :: !a,  jsxElements :: ![a], jsxClosingElement :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically JsxElement
 
 instance Evaluatable JsxElement
 
 newtype JsxText a = JsxText { contents :: T.Text }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically JsxText
 
 instance Evaluatable JsxText
 
 newtype JsxExpression a = JsxExpression { jsxExpression :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically JsxExpression
 
 instance Evaluatable JsxExpression
 
 data JsxOpeningElement a = JsxOpeningElement { jsxOpeningElementIdentifier :: !a, jsxOpeningElementTypeArguments :: a, jsxAttributes :: ![a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically JsxOpeningElement
 
 instance Evaluatable JsxOpeningElement
 
 newtype JsxClosingElement a = JsxClosingElement { jsxClosingElementIdentifier :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically JsxClosingElement
 
 instance Evaluatable JsxClosingElement
 
 data JsxSelfClosingElement a = JsxSelfClosingElement { jsxSelfClosingElementIdentifier :: !a, jsxSelfClosingElementAttributes :: ![a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically JsxSelfClosingElement
 
 instance Evaluatable JsxSelfClosingElement
 
 data JsxAttribute a = JsxAttribute { jsxAttributeTarget :: !a, jsxAttributeValue :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically JsxAttribute
 
 instance Evaluatable JsxAttribute
 
 newtype JsxFragment a = JsxFragment { terms :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically JsxFragment
 
 instance Evaluatable JsxFragment
 
 data JsxNamespaceName a = JsxNamespaceName { left :: a, right :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically JsxNamespaceName
 
 instance Evaluatable JsxNamespaceName

--- a/src/Language/TSX/Syntax/JSX.hs
+++ b/src/Language/TSX/Syntax/JSX.hs
@@ -12,54 +12,81 @@ import           Diffing.Algorithm
 
 data JsxElement a = JsxElement { jsxOpeningElement :: !a,  jsxElements :: ![a], jsxClosingElement :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically JsxElement
+
+instance Eq1 JsxElement where liftEq = genericLiftEq
+instance Ord1 JsxElement where liftCompare = genericLiftCompare
+instance Show1 JsxElement where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable JsxElement
 
 newtype JsxText a = JsxText { contents :: T.Text }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically JsxText
+
+instance Eq1 JsxText where liftEq = genericLiftEq
+instance Ord1 JsxText where liftCompare = genericLiftCompare
+instance Show1 JsxText where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable JsxText
 
 newtype JsxExpression a = JsxExpression { jsxExpression :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically JsxExpression
+
+instance Eq1 JsxExpression where liftEq = genericLiftEq
+instance Ord1 JsxExpression where liftCompare = genericLiftCompare
+instance Show1 JsxExpression where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable JsxExpression
 
 data JsxOpeningElement a = JsxOpeningElement { jsxOpeningElementIdentifier :: !a, jsxOpeningElementTypeArguments :: a, jsxAttributes :: ![a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically JsxOpeningElement
+
+instance Eq1 JsxOpeningElement where liftEq = genericLiftEq
+instance Ord1 JsxOpeningElement where liftCompare = genericLiftCompare
+instance Show1 JsxOpeningElement where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable JsxOpeningElement
 
 newtype JsxClosingElement a = JsxClosingElement { jsxClosingElementIdentifier :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically JsxClosingElement
+
+instance Eq1 JsxClosingElement where liftEq = genericLiftEq
+instance Ord1 JsxClosingElement where liftCompare = genericLiftCompare
+instance Show1 JsxClosingElement where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable JsxClosingElement
 
 data JsxSelfClosingElement a = JsxSelfClosingElement { jsxSelfClosingElementIdentifier :: !a, jsxSelfClosingElementAttributes :: ![a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically JsxSelfClosingElement
+
+instance Eq1 JsxSelfClosingElement where liftEq = genericLiftEq
+instance Ord1 JsxSelfClosingElement where liftCompare = genericLiftCompare
+instance Show1 JsxSelfClosingElement where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable JsxSelfClosingElement
 
 data JsxAttribute a = JsxAttribute { jsxAttributeTarget :: !a, jsxAttributeValue :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically JsxAttribute
+
+instance Eq1 JsxAttribute where liftEq = genericLiftEq
+instance Ord1 JsxAttribute where liftCompare = genericLiftCompare
+instance Show1 JsxAttribute where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable JsxAttribute
 
 newtype JsxFragment a = JsxFragment { terms :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically JsxFragment
+
+instance Eq1 JsxFragment where liftEq = genericLiftEq
+instance Ord1 JsxFragment where liftCompare = genericLiftCompare
+instance Show1 JsxFragment where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable JsxFragment
 
 data JsxNamespaceName a = JsxNamespaceName { left :: a, right :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically JsxNamespaceName
+
+instance Eq1 JsxNamespaceName where liftEq = genericLiftEq
+instance Ord1 JsxNamespaceName where liftCompare = genericLiftCompare
+instance Show1 JsxNamespaceName where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable JsxNamespaceName

--- a/src/Language/TSX/Syntax/JSX.hs
+++ b/src/Language/TSX/Syntax/JSX.hs
@@ -11,7 +11,7 @@ import           Diffing.Algorithm
 
 
 data JsxElement a = JsxElement { jsxOpeningElement :: !a,  jsxElements :: ![a], jsxClosingElement :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 JsxElement where liftEq = genericLiftEq
 instance Ord1 JsxElement where liftCompare = genericLiftCompare
@@ -20,7 +20,7 @@ instance Show1 JsxElement where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable JsxElement
 
 newtype JsxText a = JsxText { contents :: T.Text }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 JsxText where liftEq = genericLiftEq
 instance Ord1 JsxText where liftCompare = genericLiftCompare
@@ -29,7 +29,7 @@ instance Show1 JsxText where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable JsxText
 
 newtype JsxExpression a = JsxExpression { jsxExpression :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 JsxExpression where liftEq = genericLiftEq
 instance Ord1 JsxExpression where liftCompare = genericLiftCompare
@@ -38,7 +38,7 @@ instance Show1 JsxExpression where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable JsxExpression
 
 data JsxOpeningElement a = JsxOpeningElement { jsxOpeningElementIdentifier :: !a, jsxOpeningElementTypeArguments :: a, jsxAttributes :: ![a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 JsxOpeningElement where liftEq = genericLiftEq
 instance Ord1 JsxOpeningElement where liftCompare = genericLiftCompare
@@ -47,7 +47,7 @@ instance Show1 JsxOpeningElement where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable JsxOpeningElement
 
 newtype JsxClosingElement a = JsxClosingElement { jsxClosingElementIdentifier :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 JsxClosingElement where liftEq = genericLiftEq
 instance Ord1 JsxClosingElement where liftCompare = genericLiftCompare
@@ -56,7 +56,7 @@ instance Show1 JsxClosingElement where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable JsxClosingElement
 
 data JsxSelfClosingElement a = JsxSelfClosingElement { jsxSelfClosingElementIdentifier :: !a, jsxSelfClosingElementAttributes :: ![a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 JsxSelfClosingElement where liftEq = genericLiftEq
 instance Ord1 JsxSelfClosingElement where liftCompare = genericLiftCompare
@@ -65,7 +65,7 @@ instance Show1 JsxSelfClosingElement where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable JsxSelfClosingElement
 
 data JsxAttribute a = JsxAttribute { jsxAttributeTarget :: !a, jsxAttributeValue :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 JsxAttribute where liftEq = genericLiftEq
 instance Ord1 JsxAttribute where liftCompare = genericLiftCompare
@@ -74,7 +74,7 @@ instance Show1 JsxAttribute where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable JsxAttribute
 
 newtype JsxFragment a = JsxFragment { terms :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 JsxFragment where liftEq = genericLiftEq
 instance Ord1 JsxFragment where liftCompare = genericLiftCompare
@@ -83,7 +83,7 @@ instance Show1 JsxFragment where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable JsxFragment
 
 data JsxNamespaceName a = JsxNamespaceName { left :: a, right :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 JsxNamespaceName where liftEq = genericLiftEq
 instance Ord1 JsxNamespaceName where liftCompare = genericLiftCompare

--- a/src/Language/TypeScript/Syntax/Import.hs
+++ b/src/Language/TypeScript/Syntax/Import.hs
@@ -15,7 +15,7 @@ import qualified Data.Map.Strict as Map
 import Data.Aeson (ToJSON)
 
 data Import a = Import { importSymbols :: ![Alias], importFrom :: ImportPath }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Import where liftEq = genericLiftEq
 instance Ord1 Import where liftCompare = genericLiftCompare
@@ -48,7 +48,7 @@ instance Evaluatable Import where
     unit
 
 data QualifiedAliasedImport a = QualifiedAliasedImport { qualifiedAliasedImportAlias :: !a, qualifiedAliasedImportFrom :: ImportPath }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 QualifiedAliasedImport where liftEq = genericLiftEq
 instance Ord1 QualifiedAliasedImport where liftCompare = genericLiftCompare
@@ -70,7 +70,7 @@ instance Evaluatable QualifiedAliasedImport where
     unit
 
 newtype SideEffectImport a = SideEffectImport { sideEffectImportFrom :: ImportPath }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 SideEffectImport where liftEq = genericLiftEq
 instance Ord1 SideEffectImport where liftCompare = genericLiftCompare
@@ -84,7 +84,7 @@ instance Evaluatable SideEffectImport where
 
 -- | Qualified Export declarations
 newtype QualifiedExport a = QualifiedExport { qualifiedExportSymbols :: [Alias] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 QualifiedExport where liftEq = genericLiftEq
 instance Ord1 QualifiedExport where liftCompare = genericLiftCompare
@@ -106,14 +106,14 @@ instance Evaluatable QualifiedExport where
     unit
 
 data Alias = Alias { aliasValue :: Name, aliasName :: Name }
-  deriving (Eq, Generic, Hashable, Ord, Show, ToJSON, NFData)
+  deriving (Eq, Generic, Hashable, Ord, Show, ToJSON)
 
 toTuple :: Alias -> (Name, Name)
 toTuple Alias{..} = (aliasValue, aliasName)
 
 -- | Qualified Export declarations that export from another module.
 data QualifiedExportFrom a = QualifiedExportFrom { qualifiedExportFrom :: ImportPath, qualifiedExportFromSymbols :: ![Alias]}
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 QualifiedExportFrom where liftEq = genericLiftEq
 instance Ord1 QualifiedExportFrom where liftCompare = genericLiftCompare
@@ -138,7 +138,7 @@ instance Evaluatable QualifiedExportFrom where
     unit
 
 newtype DefaultExport a = DefaultExport { defaultExport :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 DefaultExport where liftEq = genericLiftEq
 instance Ord1 DefaultExport where liftCompare = genericLiftCompare
@@ -164,7 +164,7 @@ instance Evaluatable DefaultExport where
     unit
 
 data ImportRequireClause a = ImportRequireClause { importRequireIdentifier :: !a, importRequireSubject :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ImportRequireClause where liftEq = genericLiftEq
 instance Ord1 ImportRequireClause where liftCompare = genericLiftCompare
@@ -173,7 +173,7 @@ instance Show1 ImportRequireClause where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ImportRequireClause
 
 newtype ImportClause a = ImportClause { importClauseElements :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ImportClause where liftEq = genericLiftEq
 instance Ord1 ImportClause where liftCompare = genericLiftCompare
@@ -182,7 +182,7 @@ instance Show1 ImportClause where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ImportClause
 
 data ImportAlias a = ImportAlias { importAliasSubject :: !a, importAlias :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ImportAlias where liftEq = genericLiftEq
 instance Ord1 ImportAlias where liftCompare = genericLiftCompare

--- a/src/Language/TypeScript/Syntax/Import.hs
+++ b/src/Language/TypeScript/Syntax/Import.hs
@@ -16,7 +16,10 @@ import Data.Aeson (ToJSON)
 
 data Import a = Import { importSymbols :: ![Alias], importFrom :: ImportPath }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Import
+
+instance Eq1 Import where liftEq = genericLiftEq
+instance Ord1 Import where liftCompare = genericLiftCompare
+instance Show1 Import where liftShowsPrec = genericLiftShowsPrec
 
   -- http://www.typescriptlang.org/docs/handbook/module-resolution.html
 instance Evaluatable Import where
@@ -46,7 +49,10 @@ instance Evaluatable Import where
 
 data QualifiedAliasedImport a = QualifiedAliasedImport { qualifiedAliasedImportAlias :: !a, qualifiedAliasedImportFrom :: ImportPath }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically QualifiedAliasedImport
+
+instance Eq1 QualifiedAliasedImport where liftEq = genericLiftEq
+instance Ord1 QualifiedAliasedImport where liftCompare = genericLiftCompare
+instance Show1 QualifiedAliasedImport where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable QualifiedAliasedImport where
   eval _ _ (QualifiedAliasedImport aliasTerm importPath) = do
@@ -65,7 +71,10 @@ instance Evaluatable QualifiedAliasedImport where
 
 newtype SideEffectImport a = SideEffectImport { sideEffectImportFrom :: ImportPath }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically SideEffectImport
+
+instance Eq1 SideEffectImport where liftEq = genericLiftEq
+instance Ord1 SideEffectImport where liftCompare = genericLiftCompare
+instance Show1 SideEffectImport where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable SideEffectImport where
   eval _ _ (SideEffectImport importPath) = do
@@ -76,7 +85,10 @@ instance Evaluatable SideEffectImport where
 -- | Qualified Export declarations
 newtype QualifiedExport a = QualifiedExport { qualifiedExportSymbols :: [Alias] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically QualifiedExport
+
+instance Eq1 QualifiedExport where liftEq = genericLiftEq
+instance Ord1 QualifiedExport where liftCompare = genericLiftCompare
+instance Show1 QualifiedExport where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable QualifiedExport where
   eval _ _ (QualifiedExport exportSymbols) = do
@@ -102,7 +114,10 @@ toTuple Alias{..} = (aliasValue, aliasName)
 -- | Qualified Export declarations that export from another module.
 data QualifiedExportFrom a = QualifiedExportFrom { qualifiedExportFrom :: ImportPath, qualifiedExportFromSymbols :: ![Alias]}
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically QualifiedExportFrom
+
+instance Eq1 QualifiedExportFrom where liftEq = genericLiftEq
+instance Ord1 QualifiedExportFrom where liftCompare = genericLiftCompare
+instance Show1 QualifiedExportFrom where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable QualifiedExportFrom where
   eval _ _ (QualifiedExportFrom importPath exportSymbols) = do
@@ -124,7 +139,10 @@ instance Evaluatable QualifiedExportFrom where
 
 newtype DefaultExport a = DefaultExport { defaultExport :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically DefaultExport
+
+instance Eq1 DefaultExport where liftEq = genericLiftEq
+instance Ord1 DefaultExport where liftCompare = genericLiftCompare
+instance Show1 DefaultExport where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable DefaultExport where
   eval eval _ (DefaultExport term) = do
@@ -147,18 +165,27 @@ instance Evaluatable DefaultExport where
 
 data ImportRequireClause a = ImportRequireClause { importRequireIdentifier :: !a, importRequireSubject :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically ImportRequireClause
+
+instance Eq1 ImportRequireClause where liftEq = genericLiftEq
+instance Ord1 ImportRequireClause where liftCompare = genericLiftCompare
+instance Show1 ImportRequireClause where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ImportRequireClause
 
 newtype ImportClause a = ImportClause { importClauseElements :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically ImportClause
+
+instance Eq1 ImportClause where liftEq = genericLiftEq
+instance Ord1 ImportClause where liftCompare = genericLiftCompare
+instance Show1 ImportClause where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ImportClause
 
 data ImportAlias a = ImportAlias { importAliasSubject :: !a, importAlias :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically ImportAlias
+
+instance Eq1 ImportAlias where liftEq = genericLiftEq
+instance Ord1 ImportAlias where liftCompare = genericLiftCompare
+instance Show1 ImportAlias where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ImportAlias

--- a/src/Language/TypeScript/Syntax/Import.hs
+++ b/src/Language/TypeScript/Syntax/Import.hs
@@ -15,7 +15,7 @@ import qualified Data.Map.Strict as Map
 import Data.Aeson (ToJSON)
 
 data Import a = Import { importSymbols :: ![Alias], importFrom :: ImportPath }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Import
 
   -- http://www.typescriptlang.org/docs/handbook/module-resolution.html
@@ -45,7 +45,7 @@ instance Evaluatable Import where
     unit
 
 data QualifiedAliasedImport a = QualifiedAliasedImport { qualifiedAliasedImportAlias :: !a, qualifiedAliasedImportFrom :: ImportPath }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically QualifiedAliasedImport
 
 instance Evaluatable QualifiedAliasedImport where
@@ -64,7 +64,7 @@ instance Evaluatable QualifiedAliasedImport where
     unit
 
 newtype SideEffectImport a = SideEffectImport { sideEffectImportFrom :: ImportPath }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically SideEffectImport
 
 instance Evaluatable SideEffectImport where
@@ -75,7 +75,7 @@ instance Evaluatable SideEffectImport where
 
 -- | Qualified Export declarations
 newtype QualifiedExport a = QualifiedExport { qualifiedExportSymbols :: [Alias] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically QualifiedExport
 
 instance Evaluatable QualifiedExport where
@@ -101,7 +101,7 @@ toTuple Alias{..} = (aliasValue, aliasName)
 
 -- | Qualified Export declarations that export from another module.
 data QualifiedExportFrom a = QualifiedExportFrom { qualifiedExportFrom :: ImportPath, qualifiedExportFromSymbols :: ![Alias]}
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically QualifiedExportFrom
 
 instance Evaluatable QualifiedExportFrom where
@@ -123,7 +123,7 @@ instance Evaluatable QualifiedExportFrom where
     unit
 
 newtype DefaultExport a = DefaultExport { defaultExport :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically DefaultExport
 
 instance Evaluatable DefaultExport where
@@ -146,19 +146,19 @@ instance Evaluatable DefaultExport where
     unit
 
 data ImportRequireClause a = ImportRequireClause { importRequireIdentifier :: !a, importRequireSubject :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically ImportRequireClause
 
 instance Evaluatable ImportRequireClause
 
 newtype ImportClause a = ImportClause { importClauseElements :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically ImportClause
 
 instance Evaluatable ImportClause
 
 data ImportAlias a = ImportAlias { importAliasSubject :: !a, importAlias :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically ImportAlias
 
 instance Evaluatable ImportAlias

--- a/src/Language/TypeScript/Syntax/JavaScript.hs
+++ b/src/Language/TypeScript/Syntax/JavaScript.hs
@@ -14,19 +14,19 @@ import           Diffing.Algorithm
 import           Language.TypeScript.Resolution
 
 newtype ImplementsClause a = ImplementsClause { implementsClauseTypes :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically ImplementsClause
 
 instance Evaluatable ImplementsClause
 
 data OptionalParameter a = OptionalParameter { optionalParameterContext :: ![a], optionalParameterSubject :: !a, optionalParameterAccessControl :: AccessControl }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically OptionalParameter
 
 instance Evaluatable OptionalParameter
 
 data RequiredParameter a = RequiredParameter { requiredParameterContext :: [a], requiredParameterSubject :: a, requiredParameterValue :: a, requiredParameterAccessControl :: AccessControl }
-  deriving (Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically RequiredParameter
 
 instance Declarations1 RequiredParameter where
@@ -55,14 +55,14 @@ instance Evaluatable RequiredParameter where
     pure rhs
 
 data RestParameter a = RestParameter { restParameterContext :: ![a], restParameterSubject :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically RestParameter
 
 instance Evaluatable RestParameter
 
 
 data JavaScriptRequire a = JavaScriptRequire { javascriptRequireIden :: !a, javascriptRequireFrom :: ImportPath }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically JavaScriptRequire
 
 instance Evaluatable JavaScriptRequire where
@@ -85,32 +85,32 @@ instance Evaluatable JavaScriptRequire where
     unit
 
 data Debugger a = Debugger
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Debugger
 
 instance Evaluatable Debugger
 
 data Super a = Super
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Super
 
 instance Evaluatable Super
 
 data Undefined a = Undefined
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Undefined
 
 instance Evaluatable Undefined
 
 data With a = With { withExpression :: !a, withBody :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically With
 
 instance Evaluatable With
 
 -- | A sequence expression such as Javascript or C's comma operator.
 data AnnotatedExpression a = AnnotatedExpression { expression :: !a, typeAnnotation :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, Ord, Show, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
   deriving (Eq1, Show1, Ord1) via Generically AnnotatedExpression
 
 instance Evaluatable AnnotatedExpression where

--- a/src/Language/TypeScript/Syntax/JavaScript.hs
+++ b/src/Language/TypeScript/Syntax/JavaScript.hs
@@ -15,19 +15,28 @@ import           Language.TypeScript.Resolution
 
 newtype ImplementsClause a = ImplementsClause { implementsClauseTypes :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically ImplementsClause
+
+instance Eq1 ImplementsClause where liftEq = genericLiftEq
+instance Ord1 ImplementsClause where liftCompare = genericLiftCompare
+instance Show1 ImplementsClause where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ImplementsClause
 
 data OptionalParameter a = OptionalParameter { optionalParameterContext :: ![a], optionalParameterSubject :: !a, optionalParameterAccessControl :: AccessControl }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically OptionalParameter
+
+instance Eq1 OptionalParameter where liftEq = genericLiftEq
+instance Ord1 OptionalParameter where liftCompare = genericLiftCompare
+instance Show1 OptionalParameter where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable OptionalParameter
 
 data RequiredParameter a = RequiredParameter { requiredParameterContext :: [a], requiredParameterSubject :: a, requiredParameterValue :: a, requiredParameterAccessControl :: AccessControl }
   deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically RequiredParameter
+
+instance Eq1 RequiredParameter where liftEq = genericLiftEq
+instance Ord1 RequiredParameter where liftCompare = genericLiftCompare
+instance Show1 RequiredParameter where liftShowsPrec = genericLiftShowsPrec
 
 instance Declarations1 RequiredParameter where
   liftDeclaredName declaredName RequiredParameter{..} = declaredName requiredParameterSubject
@@ -56,14 +65,20 @@ instance Evaluatable RequiredParameter where
 
 data RestParameter a = RestParameter { restParameterContext :: ![a], restParameterSubject :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically RestParameter
+
+instance Eq1 RestParameter where liftEq = genericLiftEq
+instance Ord1 RestParameter where liftCompare = genericLiftCompare
+instance Show1 RestParameter where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable RestParameter
 
 
 data JavaScriptRequire a = JavaScriptRequire { javascriptRequireIden :: !a, javascriptRequireFrom :: ImportPath }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically JavaScriptRequire
+
+instance Eq1 JavaScriptRequire where liftEq = genericLiftEq
+instance Ord1 JavaScriptRequire where liftCompare = genericLiftCompare
+instance Show1 JavaScriptRequire where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable JavaScriptRequire where
   eval _ _ (JavaScriptRequire aliasTerm importPath) = do
@@ -86,32 +101,47 @@ instance Evaluatable JavaScriptRequire where
 
 data Debugger a = Debugger
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Debugger
+
+instance Eq1 Debugger where liftEq = genericLiftEq
+instance Ord1 Debugger where liftCompare = genericLiftCompare
+instance Show1 Debugger where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Debugger
 
 data Super a = Super
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Super
+
+instance Eq1 Super where liftEq = genericLiftEq
+instance Ord1 Super where liftCompare = genericLiftCompare
+instance Show1 Super where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Super
 
 data Undefined a = Undefined
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Undefined
+
+instance Eq1 Undefined where liftEq = genericLiftEq
+instance Ord1 Undefined where liftCompare = genericLiftCompare
+instance Show1 Undefined where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Undefined
 
 data With a = With { withExpression :: !a, withBody :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically With
+
+instance Eq1 With where liftEq = genericLiftEq
+instance Ord1 With where liftCompare = genericLiftCompare
+instance Show1 With where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable With
 
 -- | A sequence expression such as Javascript or C's comma operator.
 data AnnotatedExpression a = AnnotatedExpression { expression :: !a, typeAnnotation :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
-  deriving (Eq1, Show1, Ord1) via Generically AnnotatedExpression
+
+instance Eq1 AnnotatedExpression where liftEq = genericLiftEq
+instance Ord1 AnnotatedExpression where liftCompare = genericLiftCompare
+instance Show1 AnnotatedExpression where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable AnnotatedExpression where
   eval eval _ (AnnotatedExpression a b) = eval b >> eval a

--- a/src/Language/TypeScript/Syntax/JavaScript.hs
+++ b/src/Language/TypeScript/Syntax/JavaScript.hs
@@ -14,7 +14,7 @@ import           Diffing.Algorithm
 import           Language.TypeScript.Resolution
 
 newtype ImplementsClause a = ImplementsClause { implementsClauseTypes :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ImplementsClause where liftEq = genericLiftEq
 instance Ord1 ImplementsClause where liftCompare = genericLiftCompare
@@ -23,7 +23,7 @@ instance Show1 ImplementsClause where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ImplementsClause
 
 data OptionalParameter a = OptionalParameter { optionalParameterContext :: ![a], optionalParameterSubject :: !a, optionalParameterAccessControl :: AccessControl }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 OptionalParameter where liftEq = genericLiftEq
 instance Ord1 OptionalParameter where liftCompare = genericLiftCompare
@@ -32,7 +32,7 @@ instance Show1 OptionalParameter where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable OptionalParameter
 
 data RequiredParameter a = RequiredParameter { requiredParameterContext :: [a], requiredParameterSubject :: a, requiredParameterValue :: a, requiredParameterAccessControl :: AccessControl }
-  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 RequiredParameter where liftEq = genericLiftEq
 instance Ord1 RequiredParameter where liftCompare = genericLiftCompare
@@ -64,7 +64,7 @@ instance Evaluatable RequiredParameter where
     pure rhs
 
 data RestParameter a = RestParameter { restParameterContext :: ![a], restParameterSubject :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 RestParameter where liftEq = genericLiftEq
 instance Ord1 RestParameter where liftCompare = genericLiftCompare
@@ -74,7 +74,7 @@ instance Evaluatable RestParameter
 
 
 data JavaScriptRequire a = JavaScriptRequire { javascriptRequireIden :: !a, javascriptRequireFrom :: ImportPath }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 JavaScriptRequire where liftEq = genericLiftEq
 instance Ord1 JavaScriptRequire where liftCompare = genericLiftCompare
@@ -100,7 +100,7 @@ instance Evaluatable JavaScriptRequire where
     unit
 
 data Debugger a = Debugger
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Debugger where liftEq = genericLiftEq
 instance Ord1 Debugger where liftCompare = genericLiftCompare
@@ -109,7 +109,7 @@ instance Show1 Debugger where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Debugger
 
 data Super a = Super
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Super where liftEq = genericLiftEq
 instance Ord1 Super where liftCompare = genericLiftCompare
@@ -118,7 +118,7 @@ instance Show1 Super where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Super
 
 data Undefined a = Undefined
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Undefined where liftEq = genericLiftEq
 instance Ord1 Undefined where liftCompare = genericLiftCompare
@@ -127,7 +127,7 @@ instance Show1 Undefined where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Undefined
 
 data With a = With { withExpression :: !a, withBody :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 With where liftEq = genericLiftEq
 instance Ord1 With where liftCompare = genericLiftCompare
@@ -137,7 +137,7 @@ instance Evaluatable With
 
 -- | A sequence expression such as Javascript or C's comma operator.
 data AnnotatedExpression a = AnnotatedExpression { expression :: !a, typeAnnotation :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 AnnotatedExpression where liftEq = genericLiftEq
 instance Ord1 AnnotatedExpression where liftCompare = genericLiftCompare

--- a/src/Language/TypeScript/Syntax/TypeScript.hs
+++ b/src/Language/TypeScript/Syntax/TypeScript.hs
@@ -18,82 +18,121 @@ import qualified Data.Abstract.ScopeGraph as ScopeGraph
 -- | ShorthandPropertyIdentifier used in object patterns such as var baz = { foo } to mean var baz = { foo: foo }
 newtype ShorthandPropertyIdentifier a = ShorthandPropertyIdentifier { contents :: T.Text }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically ShorthandPropertyIdentifier
+
+instance Eq1 ShorthandPropertyIdentifier where liftEq = genericLiftEq
+instance Ord1 ShorthandPropertyIdentifier where liftCompare = genericLiftCompare
+instance Show1 ShorthandPropertyIdentifier where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ShorthandPropertyIdentifier
 
 data Union a = Union { unionLeft :: !a, unionRight :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Union
+
+instance Eq1 Union where liftEq = genericLiftEq
+instance Ord1 Union where liftCompare = genericLiftCompare
+instance Show1 Union where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Language.TypeScript.Syntax.TypeScript.Union
 
 data Intersection a = Intersection { intersectionLeft :: !a, intersectionRight :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Intersection
+
+instance Eq1 Intersection where liftEq = genericLiftEq
+instance Ord1 Intersection where liftCompare = genericLiftCompare
+instance Show1 Intersection where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Intersection
 
 data AmbientFunction a = AmbientFunction { ambientFunctionContext :: ![a], ambientFunctionIdentifier :: !a, ambientFunctionParameters :: ![a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically AmbientFunction
+
+instance Eq1 AmbientFunction where liftEq = genericLiftEq
+instance Ord1 AmbientFunction where liftCompare = genericLiftCompare
+instance Show1 AmbientFunction where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable AmbientFunction
 
 newtype Tuple a = Tuple { tupleElements :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Tuple
+
+instance Eq1 Tuple where liftEq = genericLiftEq
+instance Ord1 Tuple where liftCompare = genericLiftCompare
+instance Show1 Tuple where liftShowsPrec = genericLiftShowsPrec
 
 -- This is a tuple type, not a tuple value, so we can't lean on the shared Tuple value
 instance Evaluatable Tuple
 
 data Constructor a = Constructor { constructorTypeParameters :: !a, constructorFormalParameters :: ![a], constructorType :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Constructor
+
+instance Eq1 Constructor where liftEq = genericLiftEq
+instance Ord1 Constructor where liftCompare = genericLiftCompare
+instance Show1 Constructor where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Language.TypeScript.Syntax.TypeScript.Constructor
 
 
 newtype Annotation a = Annotation { annotationType :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Annotation
+
+instance Eq1 Annotation where liftEq = genericLiftEq
+instance Ord1 Annotation where liftCompare = genericLiftCompare
+instance Show1 Annotation where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Annotation
 
 newtype Decorator a = Decorator { decoratorTerm :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Decorator
+
+instance Eq1 Decorator where liftEq = genericLiftEq
+instance Ord1 Decorator where liftCompare = genericLiftCompare
+instance Show1 Decorator where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Decorator
 
 newtype ComputedPropertyName a = ComputedPropertyName { propertyName :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically ComputedPropertyName
+
+instance Eq1 ComputedPropertyName where liftEq = genericLiftEq
+instance Ord1 ComputedPropertyName where liftCompare = genericLiftCompare
+instance Show1 ComputedPropertyName where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ComputedPropertyName
 
 newtype Constraint a = Constraint { constraintType :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Constraint
+
+instance Eq1 Constraint where liftEq = genericLiftEq
+instance Ord1 Constraint where liftCompare = genericLiftCompare
+instance Show1 Constraint where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Constraint
 
 data NestedIdentifier a = NestedIdentifier { left :: !a, right :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically NestedIdentifier
+
+instance Eq1 NestedIdentifier where liftEq = genericLiftEq
+instance Ord1 NestedIdentifier where liftCompare = genericLiftCompare
+instance Show1 NestedIdentifier where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable NestedIdentifier
 
 newtype AmbientDeclaration a = AmbientDeclaration { ambientDeclarationBody :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically AmbientDeclaration
+
+instance Eq1 AmbientDeclaration where liftEq = genericLiftEq
+instance Ord1 AmbientDeclaration where liftCompare = genericLiftCompare
+instance Show1 AmbientDeclaration where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable AmbientDeclaration where
   eval eval _ (AmbientDeclaration body) = eval body
 
 data EnumDeclaration a = EnumDeclaration { enumDeclarationIdentifier :: !a, enumDeclarationBody :: ![a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically EnumDeclaration
+
+instance Eq1 EnumDeclaration where liftEq = genericLiftEq
+instance Ord1 EnumDeclaration where liftCompare = genericLiftCompare
+instance Show1 EnumDeclaration where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable EnumDeclaration
 
@@ -102,7 +141,10 @@ instance Declarations a => Declarations (EnumDeclaration a) where
 
 newtype ExtendsClause a = ExtendsClause { extendsClauses :: [a] }
   deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically ExtendsClause
+
+instance Eq1 ExtendsClause where liftEq = genericLiftEq
+instance Ord1 ExtendsClause where liftCompare = genericLiftCompare
+instance Show1 ExtendsClause where liftShowsPrec = genericLiftShowsPrec
 
 instance Declarations1 ExtendsClause where
   liftDeclaredName _ (ExtendsClause [])                 = Nothing
@@ -117,56 +159,83 @@ instance Evaluatable ExtendsClause where
 
 data PropertySignature a = PropertySignature { modifiers :: [a], propertySignaturePropertyName :: a, propertySignatureAccessControl :: AccessControl }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically PropertySignature
+
+instance Eq1 PropertySignature where liftEq = genericLiftEq
+instance Ord1 PropertySignature where liftCompare = genericLiftCompare
+instance Show1 PropertySignature where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable PropertySignature
 
 data CallSignature a = CallSignature { callSignatureTypeParameters :: !a, callSignatureParameters :: ![a], callSignatureType :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically CallSignature
+
+instance Eq1 CallSignature where liftEq = genericLiftEq
+instance Ord1 CallSignature where liftCompare = genericLiftCompare
+instance Show1 CallSignature where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable CallSignature
 
 -- | Todo: Move type params and type to context
 data ConstructSignature a = ConstructSignature { constructSignatureTypeParameters :: !a, constructSignatureParameters :: ![a], constructSignatureType :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically ConstructSignature
+
+instance Eq1 ConstructSignature where liftEq = genericLiftEq
+instance Ord1 ConstructSignature where liftCompare = genericLiftCompare
+instance Show1 ConstructSignature where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ConstructSignature
 
 data IndexSignature a = IndexSignature { subject :: a, subjectType :: a, typeAnnotation :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically IndexSignature
+
+instance Eq1 IndexSignature where liftEq = genericLiftEq
+instance Ord1 IndexSignature where liftCompare = genericLiftCompare
+instance Show1 IndexSignature where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable IndexSignature
 
 data AbstractMethodSignature a = AbstractMethodSignature { abstractMethodSignatureContext :: ![a], abstractMethodSignatureName :: a, abstractMethodSignatureParameters :: [a], abstractMethodAccessControl :: AccessControl }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically AbstractMethodSignature
+
+instance Eq1 AbstractMethodSignature where liftEq = genericLiftEq
+instance Ord1 AbstractMethodSignature where liftCompare = genericLiftCompare
+instance Show1 AbstractMethodSignature where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable AbstractMethodSignature
 
 data ForOf a = ForOf { forOfBinding :: !a, forOfSubject :: !a, forOfBody :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically ForOf
+
+instance Eq1 ForOf where liftEq = genericLiftEq
+instance Ord1 ForOf where liftCompare = genericLiftCompare
+instance Show1 ForOf where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ForOf
 
 data LabeledStatement a = LabeledStatement { labeledStatementIdentifier :: !a, labeledStatementSubject :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically LabeledStatement
+
+instance Eq1 LabeledStatement where liftEq = genericLiftEq
+instance Ord1 LabeledStatement where liftCompare = genericLiftCompare
+instance Show1 LabeledStatement where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable LabeledStatement
 
 newtype Update a = Update { updateSubject :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Update
+
+instance Eq1 Update where liftEq = genericLiftEq
+instance Ord1 Update where liftCompare = genericLiftCompare
+instance Show1 Update where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable Update
 
 data Module a = Module { moduleIdentifier :: !a, moduleStatements :: ![a] }
   deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically Module
+
+instance Eq1 Module where liftEq = genericLiftEq
+instance Ord1 Module where liftCompare = genericLiftCompare
+instance Show1 Module where liftShowsPrec = genericLiftShowsPrec
 
 declareModule :: ( AbstractValue term address value m
                  , Carrier sig m
@@ -235,7 +304,10 @@ instance Declarations1 Module where
 
 data InternalModule a = InternalModule { internalModuleIdentifier :: !a, internalModuleStatements :: ![a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically InternalModule
+
+instance Eq1 InternalModule where liftEq = genericLiftEq
+instance Ord1 InternalModule where liftCompare = genericLiftCompare
+instance Show1 InternalModule where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable InternalModule where
   eval eval _ InternalModule{..} =
@@ -246,13 +318,19 @@ instance Declarations a => Declarations (InternalModule a) where
 
 data ClassHeritage a = ClassHeritage { classHeritageExtendsClause :: !a, implementsClause :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically ClassHeritage
+
+instance Eq1 ClassHeritage where liftEq = genericLiftEq
+instance Ord1 ClassHeritage where liftCompare = genericLiftCompare
+instance Show1 ClassHeritage where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ClassHeritage
 
 data AbstractClass a = AbstractClass { abstractClassIdentifier :: !a,  abstractClassTypeParameters :: !a, classHeritage :: ![a], classBody :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically AbstractClass
+
+instance Eq1 AbstractClass where liftEq = genericLiftEq
+instance Ord1 AbstractClass where liftCompare = genericLiftCompare
+instance Show1 AbstractClass where liftShowsPrec = genericLiftShowsPrec
 
 instance Declarations a => Declarations (AbstractClass a) where
   declaredName AbstractClass{..} = declaredName abstractClassIdentifier
@@ -290,6 +368,9 @@ instance Evaluatable AbstractClass where
 
 data MetaProperty a = MetaProperty
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically MetaProperty
+
+instance Eq1 MetaProperty where liftEq = genericLiftEq
+instance Ord1 MetaProperty where liftCompare = genericLiftCompare
+instance Show1 MetaProperty where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable MetaProperty

--- a/src/Language/TypeScript/Syntax/TypeScript.hs
+++ b/src/Language/TypeScript/Syntax/TypeScript.hs
@@ -17,7 +17,7 @@ import qualified Data.Abstract.ScopeGraph as ScopeGraph
 
 -- | ShorthandPropertyIdentifier used in object patterns such as var baz = { foo } to mean var baz = { foo: foo }
 newtype ShorthandPropertyIdentifier a = ShorthandPropertyIdentifier { contents :: T.Text }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ShorthandPropertyIdentifier where liftEq = genericLiftEq
 instance Ord1 ShorthandPropertyIdentifier where liftCompare = genericLiftCompare
@@ -26,7 +26,7 @@ instance Show1 ShorthandPropertyIdentifier where liftShowsPrec = genericLiftShow
 instance Evaluatable ShorthandPropertyIdentifier
 
 data Union a = Union { unionLeft :: !a, unionRight :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Union where liftEq = genericLiftEq
 instance Ord1 Union where liftCompare = genericLiftCompare
@@ -35,7 +35,7 @@ instance Show1 Union where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Language.TypeScript.Syntax.TypeScript.Union
 
 data Intersection a = Intersection { intersectionLeft :: !a, intersectionRight :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Intersection where liftEq = genericLiftEq
 instance Ord1 Intersection where liftCompare = genericLiftCompare
@@ -44,7 +44,7 @@ instance Show1 Intersection where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Intersection
 
 data AmbientFunction a = AmbientFunction { ambientFunctionContext :: ![a], ambientFunctionIdentifier :: !a, ambientFunctionParameters :: ![a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 AmbientFunction where liftEq = genericLiftEq
 instance Ord1 AmbientFunction where liftCompare = genericLiftCompare
@@ -53,7 +53,7 @@ instance Show1 AmbientFunction where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable AmbientFunction
 
 newtype Tuple a = Tuple { tupleElements :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Tuple where liftEq = genericLiftEq
 instance Ord1 Tuple where liftCompare = genericLiftCompare
@@ -63,7 +63,7 @@ instance Show1 Tuple where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Tuple
 
 data Constructor a = Constructor { constructorTypeParameters :: !a, constructorFormalParameters :: ![a], constructorType :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Constructor where liftEq = genericLiftEq
 instance Ord1 Constructor where liftCompare = genericLiftCompare
@@ -73,7 +73,7 @@ instance Evaluatable Language.TypeScript.Syntax.TypeScript.Constructor
 
 
 newtype Annotation a = Annotation { annotationType :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Annotation where liftEq = genericLiftEq
 instance Ord1 Annotation where liftCompare = genericLiftCompare
@@ -82,7 +82,7 @@ instance Show1 Annotation where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Annotation
 
 newtype Decorator a = Decorator { decoratorTerm :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Decorator where liftEq = genericLiftEq
 instance Ord1 Decorator where liftCompare = genericLiftCompare
@@ -91,7 +91,7 @@ instance Show1 Decorator where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Decorator
 
 newtype ComputedPropertyName a = ComputedPropertyName { propertyName :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ComputedPropertyName where liftEq = genericLiftEq
 instance Ord1 ComputedPropertyName where liftCompare = genericLiftCompare
@@ -100,7 +100,7 @@ instance Show1 ComputedPropertyName where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ComputedPropertyName
 
 newtype Constraint a = Constraint { constraintType :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Constraint where liftEq = genericLiftEq
 instance Ord1 Constraint where liftCompare = genericLiftCompare
@@ -109,7 +109,7 @@ instance Show1 Constraint where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Constraint
 
 data NestedIdentifier a = NestedIdentifier { left :: !a, right :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 NestedIdentifier where liftEq = genericLiftEq
 instance Ord1 NestedIdentifier where liftCompare = genericLiftCompare
@@ -118,7 +118,7 @@ instance Show1 NestedIdentifier where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable NestedIdentifier
 
 newtype AmbientDeclaration a = AmbientDeclaration { ambientDeclarationBody :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 AmbientDeclaration where liftEq = genericLiftEq
 instance Ord1 AmbientDeclaration where liftCompare = genericLiftCompare
@@ -128,7 +128,7 @@ instance Evaluatable AmbientDeclaration where
   eval eval _ (AmbientDeclaration body) = eval body
 
 data EnumDeclaration a = EnumDeclaration { enumDeclarationIdentifier :: !a, enumDeclarationBody :: ![a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 EnumDeclaration where liftEq = genericLiftEq
 instance Ord1 EnumDeclaration where liftCompare = genericLiftCompare
@@ -140,7 +140,7 @@ instance Declarations a => Declarations (EnumDeclaration a) where
   declaredName EnumDeclaration{..} = declaredName enumDeclarationIdentifier
 
 newtype ExtendsClause a = ExtendsClause { extendsClauses :: [a] }
-  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ExtendsClause where liftEq = genericLiftEq
 instance Ord1 ExtendsClause where liftCompare = genericLiftCompare
@@ -158,7 +158,7 @@ instance Evaluatable ExtendsClause where
     unit
 
 data PropertySignature a = PropertySignature { modifiers :: [a], propertySignaturePropertyName :: a, propertySignatureAccessControl :: AccessControl }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 PropertySignature where liftEq = genericLiftEq
 instance Ord1 PropertySignature where liftCompare = genericLiftCompare
@@ -167,7 +167,7 @@ instance Show1 PropertySignature where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable PropertySignature
 
 data CallSignature a = CallSignature { callSignatureTypeParameters :: !a, callSignatureParameters :: ![a], callSignatureType :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 CallSignature where liftEq = genericLiftEq
 instance Ord1 CallSignature where liftCompare = genericLiftCompare
@@ -177,7 +177,7 @@ instance Evaluatable CallSignature
 
 -- | Todo: Move type params and type to context
 data ConstructSignature a = ConstructSignature { constructSignatureTypeParameters :: !a, constructSignatureParameters :: ![a], constructSignatureType :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ConstructSignature where liftEq = genericLiftEq
 instance Ord1 ConstructSignature where liftCompare = genericLiftCompare
@@ -186,7 +186,7 @@ instance Show1 ConstructSignature where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ConstructSignature
 
 data IndexSignature a = IndexSignature { subject :: a, subjectType :: a, typeAnnotation :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 IndexSignature where liftEq = genericLiftEq
 instance Ord1 IndexSignature where liftCompare = genericLiftCompare
@@ -195,7 +195,7 @@ instance Show1 IndexSignature where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable IndexSignature
 
 data AbstractMethodSignature a = AbstractMethodSignature { abstractMethodSignatureContext :: ![a], abstractMethodSignatureName :: a, abstractMethodSignatureParameters :: [a], abstractMethodAccessControl :: AccessControl }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 AbstractMethodSignature where liftEq = genericLiftEq
 instance Ord1 AbstractMethodSignature where liftCompare = genericLiftCompare
@@ -204,7 +204,7 @@ instance Show1 AbstractMethodSignature where liftShowsPrec = genericLiftShowsPre
 instance Evaluatable AbstractMethodSignature
 
 data ForOf a = ForOf { forOfBinding :: !a, forOfSubject :: !a, forOfBody :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ForOf where liftEq = genericLiftEq
 instance Ord1 ForOf where liftCompare = genericLiftCompare
@@ -213,7 +213,7 @@ instance Show1 ForOf where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ForOf
 
 data LabeledStatement a = LabeledStatement { labeledStatementIdentifier :: !a, labeledStatementSubject :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 LabeledStatement where liftEq = genericLiftEq
 instance Ord1 LabeledStatement where liftCompare = genericLiftCompare
@@ -222,7 +222,7 @@ instance Show1 LabeledStatement where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable LabeledStatement
 
 newtype Update a = Update { updateSubject :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Update where liftEq = genericLiftEq
 instance Ord1 Update where liftCompare = genericLiftCompare
@@ -231,7 +231,7 @@ instance Show1 Update where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable Update
 
 data Module a = Module { moduleIdentifier :: !a, moduleStatements :: ![a] }
-  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 Module where liftEq = genericLiftEq
 instance Ord1 Module where liftCompare = genericLiftCompare
@@ -303,7 +303,7 @@ instance Declarations1 Module where
   liftDeclaredName declaredName = declaredName . moduleIdentifier
 
 data InternalModule a = InternalModule { internalModuleIdentifier :: !a, internalModuleStatements :: ![a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 InternalModule where liftEq = genericLiftEq
 instance Ord1 InternalModule where liftCompare = genericLiftCompare
@@ -317,7 +317,7 @@ instance Declarations a => Declarations (InternalModule a) where
   declaredName InternalModule{..} = declaredName internalModuleIdentifier
 
 data ClassHeritage a = ClassHeritage { classHeritageExtendsClause :: !a, implementsClause :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ClassHeritage where liftEq = genericLiftEq
 instance Ord1 ClassHeritage where liftCompare = genericLiftCompare
@@ -326,7 +326,7 @@ instance Show1 ClassHeritage where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ClassHeritage
 
 data AbstractClass a = AbstractClass { abstractClassIdentifier :: !a,  abstractClassTypeParameters :: !a, classHeritage :: ![a], classBody :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 AbstractClass where liftEq = genericLiftEq
 instance Ord1 AbstractClass where liftCompare = genericLiftCompare
@@ -367,7 +367,7 @@ instance Evaluatable AbstractClass where
     unit
 
 data MetaProperty a = MetaProperty
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 MetaProperty where liftEq = genericLiftEq
 instance Ord1 MetaProperty where liftCompare = genericLiftCompare

--- a/src/Language/TypeScript/Syntax/TypeScript.hs
+++ b/src/Language/TypeScript/Syntax/TypeScript.hs
@@ -17,82 +17,82 @@ import qualified Data.Abstract.ScopeGraph as ScopeGraph
 
 -- | ShorthandPropertyIdentifier used in object patterns such as var baz = { foo } to mean var baz = { foo: foo }
 newtype ShorthandPropertyIdentifier a = ShorthandPropertyIdentifier { contents :: T.Text }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically ShorthandPropertyIdentifier
 
 instance Evaluatable ShorthandPropertyIdentifier
 
 data Union a = Union { unionLeft :: !a, unionRight :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Union
 
 instance Evaluatable Language.TypeScript.Syntax.TypeScript.Union
 
 data Intersection a = Intersection { intersectionLeft :: !a, intersectionRight :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Intersection
 
 instance Evaluatable Intersection
 
 data AmbientFunction a = AmbientFunction { ambientFunctionContext :: ![a], ambientFunctionIdentifier :: !a, ambientFunctionParameters :: ![a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically AmbientFunction
 
 instance Evaluatable AmbientFunction
 
 newtype Tuple a = Tuple { tupleElements :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Tuple
 
 -- This is a tuple type, not a tuple value, so we can't lean on the shared Tuple value
 instance Evaluatable Tuple
 
 data Constructor a = Constructor { constructorTypeParameters :: !a, constructorFormalParameters :: ![a], constructorType :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Constructor
 
 instance Evaluatable Language.TypeScript.Syntax.TypeScript.Constructor
 
 
 newtype Annotation a = Annotation { annotationType :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Annotation
 
 instance Evaluatable Annotation
 
 newtype Decorator a = Decorator { decoratorTerm :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Decorator
 
 instance Evaluatable Decorator
 
 newtype ComputedPropertyName a = ComputedPropertyName { propertyName :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically ComputedPropertyName
 
 instance Evaluatable ComputedPropertyName
 
 newtype Constraint a = Constraint { constraintType :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Constraint
 
 instance Evaluatable Constraint
 
 data NestedIdentifier a = NestedIdentifier { left :: !a, right :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically NestedIdentifier
 
 instance Evaluatable NestedIdentifier
 
 newtype AmbientDeclaration a = AmbientDeclaration { ambientDeclarationBody :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically AmbientDeclaration
 
 instance Evaluatable AmbientDeclaration where
   eval eval _ (AmbientDeclaration body) = eval body
 
 data EnumDeclaration a = EnumDeclaration { enumDeclarationIdentifier :: !a, enumDeclarationBody :: ![a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically EnumDeclaration
 
 instance Evaluatable EnumDeclaration
@@ -101,7 +101,7 @@ instance Declarations a => Declarations (EnumDeclaration a) where
   declaredName EnumDeclaration{..} = declaredName enumDeclarationIdentifier
 
 newtype ExtendsClause a = ExtendsClause { extendsClauses :: [a] }
-  deriving (Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically ExtendsClause
 
 instance Declarations1 ExtendsClause where
@@ -116,56 +116,56 @@ instance Evaluatable ExtendsClause where
     unit
 
 data PropertySignature a = PropertySignature { modifiers :: [a], propertySignaturePropertyName :: a, propertySignatureAccessControl :: AccessControl }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically PropertySignature
 
 instance Evaluatable PropertySignature
 
 data CallSignature a = CallSignature { callSignatureTypeParameters :: !a, callSignatureParameters :: ![a], callSignatureType :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically CallSignature
 
 instance Evaluatable CallSignature
 
 -- | Todo: Move type params and type to context
 data ConstructSignature a = ConstructSignature { constructSignatureTypeParameters :: !a, constructSignatureParameters :: ![a], constructSignatureType :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically ConstructSignature
 
 instance Evaluatable ConstructSignature
 
 data IndexSignature a = IndexSignature { subject :: a, subjectType :: a, typeAnnotation :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically IndexSignature
 
 instance Evaluatable IndexSignature
 
 data AbstractMethodSignature a = AbstractMethodSignature { abstractMethodSignatureContext :: ![a], abstractMethodSignatureName :: a, abstractMethodSignatureParameters :: [a], abstractMethodAccessControl :: AccessControl }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically AbstractMethodSignature
 
 instance Evaluatable AbstractMethodSignature
 
 data ForOf a = ForOf { forOfBinding :: !a, forOfSubject :: !a, forOfBody :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically ForOf
 
 instance Evaluatable ForOf
 
 data LabeledStatement a = LabeledStatement { labeledStatementIdentifier :: !a, labeledStatementSubject :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically LabeledStatement
 
 instance Evaluatable LabeledStatement
 
 newtype Update a = Update { updateSubject :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Update
 
 instance Evaluatable Update
 
 data Module a = Module { moduleIdentifier :: !a, moduleStatements :: ![a] }
-  deriving (Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically Module
 
 declareModule :: ( AbstractValue term address value m
@@ -234,7 +234,7 @@ instance Declarations1 Module where
   liftDeclaredName declaredName = declaredName . moduleIdentifier
 
 data InternalModule a = InternalModule { internalModuleIdentifier :: !a, internalModuleStatements :: ![a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically InternalModule
 
 instance Evaluatable InternalModule where
@@ -245,13 +245,13 @@ instance Declarations a => Declarations (InternalModule a) where
   declaredName InternalModule{..} = declaredName internalModuleIdentifier
 
 data ClassHeritage a = ClassHeritage { classHeritageExtendsClause :: !a, implementsClause :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically ClassHeritage
 
 instance Evaluatable ClassHeritage
 
 data AbstractClass a = AbstractClass { abstractClassIdentifier :: !a,  abstractClassTypeParameters :: !a, classHeritage :: ![a], classBody :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically AbstractClass
 
 instance Declarations a => Declarations (AbstractClass a) where
@@ -289,7 +289,7 @@ instance Evaluatable AbstractClass where
     unit
 
 data MetaProperty a = MetaProperty
-  deriving (Diffable, Eq, Foldable, Functor,  Generic1, Ord, Show, Traversable, FreeVariables1, Declarations1, ToJSONFields1, Hashable1, NFData1)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically MetaProperty
 
 instance Evaluatable MetaProperty

--- a/src/Language/TypeScript/Syntax/Types.hs
+++ b/src/Language/TypeScript/Syntax/Types.hs
@@ -13,50 +13,50 @@ import qualified Data.Abstract.ScopeGraph as ScopeGraph
 
 -- | Lookup type for a type-level key in a typescript map.
 data LookupType a = LookupType { lookupTypeIdentifier :: a, lookupTypeKey :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically LookupType
 
 instance Evaluatable LookupType
 
 data FunctionType a = FunctionType { functionTypeParameters :: !a, functionFormalParameters :: ![a], functionType :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically FunctionType
 
 instance Evaluatable FunctionType
 
 data TypeParameter a = TypeParameter { typeParameter :: !a, typeParameterConstraint :: !a, typeParameterDefaultType :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically TypeParameter
 
 instance Evaluatable TypeParameter
 
 data TypeAssertion a = TypeAssertion { typeAssertionParameters :: !a, typeAssertionExpression :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically TypeAssertion
 
 instance Evaluatable TypeAssertion
 
 newtype DefaultType a = DefaultType { defaultType :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically DefaultType
 
 instance Evaluatable DefaultType
 
 newtype ParenthesizedType a = ParenthesizedType { parenthesizedType :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically ParenthesizedType
 
 instance Evaluatable ParenthesizedType
 
 newtype PredefinedType a = PredefinedType { predefinedType :: T.Text }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically PredefinedType
 
 -- TODO: Implement Eval instance for PredefinedType
 instance Evaluatable PredefinedType
 
 newtype TypeIdentifier a = TypeIdentifier { contents :: T.Text }
-  deriving (Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically TypeIdentifier
 
 instance Declarations1 TypeIdentifier where
@@ -71,73 +71,73 @@ instance Evaluatable TypeIdentifier where
     unit
 
 data NestedTypeIdentifier a = NestedTypeIdentifier { left :: !a, right :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically NestedTypeIdentifier
 
 instance Evaluatable NestedTypeIdentifier
 
 data GenericType a = GenericType { genericTypeIdentifier :: !a, genericTypeArguments :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically GenericType
 
 instance Evaluatable GenericType
 
 data TypePredicate a = TypePredicate { typePredicateIdentifier :: !a, typePredicateType :: !a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically TypePredicate
 
 instance Evaluatable TypePredicate
 
 newtype ObjectType a = ObjectType { objectTypeElements :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically ObjectType
 
 instance Evaluatable ObjectType
 
 newtype ArrayType a = ArrayType { arrayType :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically ArrayType
 
 instance Evaluatable ArrayType
 
 newtype FlowMaybeType a = FlowMaybeType { flowMaybeType :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically FlowMaybeType
 
 instance Evaluatable FlowMaybeType
 
 newtype TypeQuery a = TypeQuery { typeQuerySubject :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically TypeQuery
 
 instance Evaluatable TypeQuery
 
 newtype IndexTypeQuery a = IndexTypeQuery { indexTypeQuerySubject :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically IndexTypeQuery
 
 instance Evaluatable IndexTypeQuery
 
 newtype TypeArguments a = TypeArguments { typeArguments :: [a] }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically TypeArguments
 
 instance Evaluatable TypeArguments
 
 newtype ThisType a = ThisType { contents :: T.Text }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically ThisType
 
 instance Evaluatable ThisType
 
 newtype ExistentialType a = ExistentialType { contents :: T.Text }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically ExistentialType
 
 instance Evaluatable ExistentialType
 
 newtype LiteralType a = LiteralType { literalTypeSubject :: a }
-  deriving (Declarations1, Diffable, Eq, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, Ord, Show, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
   deriving (Eq1, Show1, Ord1) via Generically LiteralType
 
 instance Evaluatable LiteralType

--- a/src/Language/TypeScript/Syntax/Types.hs
+++ b/src/Language/TypeScript/Syntax/Types.hs
@@ -14,50 +14,74 @@ import qualified Data.Abstract.ScopeGraph as ScopeGraph
 -- | Lookup type for a type-level key in a typescript map.
 data LookupType a = LookupType { lookupTypeIdentifier :: a, lookupTypeKey :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically LookupType
+
+instance Eq1 LookupType where liftEq = genericLiftEq
+instance Ord1 LookupType where liftCompare = genericLiftCompare
+instance Show1 LookupType where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable LookupType
 
 data FunctionType a = FunctionType { functionTypeParameters :: !a, functionFormalParameters :: ![a], functionType :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically FunctionType
+
+instance Eq1 FunctionType where liftEq = genericLiftEq
+instance Ord1 FunctionType where liftCompare = genericLiftCompare
+instance Show1 FunctionType where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable FunctionType
 
 data TypeParameter a = TypeParameter { typeParameter :: !a, typeParameterConstraint :: !a, typeParameterDefaultType :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically TypeParameter
+
+instance Eq1 TypeParameter where liftEq = genericLiftEq
+instance Ord1 TypeParameter where liftCompare = genericLiftCompare
+instance Show1 TypeParameter where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable TypeParameter
 
 data TypeAssertion a = TypeAssertion { typeAssertionParameters :: !a, typeAssertionExpression :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically TypeAssertion
+
+instance Eq1 TypeAssertion where liftEq = genericLiftEq
+instance Ord1 TypeAssertion where liftCompare = genericLiftCompare
+instance Show1 TypeAssertion where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable TypeAssertion
 
 newtype DefaultType a = DefaultType { defaultType :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically DefaultType
+
+instance Eq1 DefaultType where liftEq = genericLiftEq
+instance Ord1 DefaultType where liftCompare = genericLiftCompare
+instance Show1 DefaultType where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable DefaultType
 
 newtype ParenthesizedType a = ParenthesizedType { parenthesizedType :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically ParenthesizedType
+
+instance Eq1 ParenthesizedType where liftEq = genericLiftEq
+instance Ord1 ParenthesizedType where liftCompare = genericLiftCompare
+instance Show1 ParenthesizedType where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ParenthesizedType
 
 newtype PredefinedType a = PredefinedType { predefinedType :: T.Text }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically PredefinedType
+
+instance Eq1 PredefinedType where liftEq = genericLiftEq
+instance Ord1 PredefinedType where liftCompare = genericLiftCompare
+instance Show1 PredefinedType where liftShowsPrec = genericLiftShowsPrec
 
 -- TODO: Implement Eval instance for PredefinedType
 instance Evaluatable PredefinedType
 
 newtype TypeIdentifier a = TypeIdentifier { contents :: T.Text }
   deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically TypeIdentifier
+
+instance Eq1 TypeIdentifier where liftEq = genericLiftEq
+instance Ord1 TypeIdentifier where liftCompare = genericLiftCompare
+instance Show1 TypeIdentifier where liftShowsPrec = genericLiftShowsPrec
 
 instance Declarations1 TypeIdentifier where
   liftDeclaredName _ (TypeIdentifier identifier) = Just (Evaluatable.name identifier)
@@ -72,72 +96,108 @@ instance Evaluatable TypeIdentifier where
 
 data NestedTypeIdentifier a = NestedTypeIdentifier { left :: !a, right :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically NestedTypeIdentifier
+
+instance Eq1 NestedTypeIdentifier where liftEq = genericLiftEq
+instance Ord1 NestedTypeIdentifier where liftCompare = genericLiftCompare
+instance Show1 NestedTypeIdentifier where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable NestedTypeIdentifier
 
 data GenericType a = GenericType { genericTypeIdentifier :: !a, genericTypeArguments :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically GenericType
+
+instance Eq1 GenericType where liftEq = genericLiftEq
+instance Ord1 GenericType where liftCompare = genericLiftCompare
+instance Show1 GenericType where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable GenericType
 
 data TypePredicate a = TypePredicate { typePredicateIdentifier :: !a, typePredicateType :: !a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically TypePredicate
+
+instance Eq1 TypePredicate where liftEq = genericLiftEq
+instance Ord1 TypePredicate where liftCompare = genericLiftCompare
+instance Show1 TypePredicate where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable TypePredicate
 
 newtype ObjectType a = ObjectType { objectTypeElements :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically ObjectType
+
+instance Eq1 ObjectType where liftEq = genericLiftEq
+instance Ord1 ObjectType where liftCompare = genericLiftCompare
+instance Show1 ObjectType where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ObjectType
 
 newtype ArrayType a = ArrayType { arrayType :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically ArrayType
+
+instance Eq1 ArrayType where liftEq = genericLiftEq
+instance Ord1 ArrayType where liftCompare = genericLiftCompare
+instance Show1 ArrayType where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ArrayType
 
 newtype FlowMaybeType a = FlowMaybeType { flowMaybeType :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically FlowMaybeType
+
+instance Eq1 FlowMaybeType where liftEq = genericLiftEq
+instance Ord1 FlowMaybeType where liftCompare = genericLiftCompare
+instance Show1 FlowMaybeType where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable FlowMaybeType
 
 newtype TypeQuery a = TypeQuery { typeQuerySubject :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically TypeQuery
+
+instance Eq1 TypeQuery where liftEq = genericLiftEq
+instance Ord1 TypeQuery where liftCompare = genericLiftCompare
+instance Show1 TypeQuery where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable TypeQuery
 
 newtype IndexTypeQuery a = IndexTypeQuery { indexTypeQuerySubject :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically IndexTypeQuery
+
+instance Eq1 IndexTypeQuery where liftEq = genericLiftEq
+instance Ord1 IndexTypeQuery where liftCompare = genericLiftCompare
+instance Show1 IndexTypeQuery where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable IndexTypeQuery
 
 newtype TypeArguments a = TypeArguments { typeArguments :: [a] }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically TypeArguments
+
+instance Eq1 TypeArguments where liftEq = genericLiftEq
+instance Ord1 TypeArguments where liftCompare = genericLiftCompare
+instance Show1 TypeArguments where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable TypeArguments
 
 newtype ThisType a = ThisType { contents :: T.Text }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically ThisType
+
+instance Eq1 ThisType where liftEq = genericLiftEq
+instance Ord1 ThisType where liftCompare = genericLiftCompare
+instance Show1 ThisType where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ThisType
 
 newtype ExistentialType a = ExistentialType { contents :: T.Text }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically ExistentialType
+
+instance Eq1 ExistentialType where liftEq = genericLiftEq
+instance Ord1 ExistentialType where liftCompare = genericLiftCompare
+instance Show1 ExistentialType where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable ExistentialType
 
 newtype LiteralType a = LiteralType { literalTypeSubject :: a }
   deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
-  deriving (Eq1, Show1, Ord1) via Generically LiteralType
+
+instance Eq1 LiteralType where liftEq = genericLiftEq
+instance Ord1 LiteralType where liftCompare = genericLiftCompare
+instance Show1 LiteralType where liftShowsPrec = genericLiftShowsPrec
 
 instance Evaluatable LiteralType

--- a/src/Language/TypeScript/Syntax/Types.hs
+++ b/src/Language/TypeScript/Syntax/Types.hs
@@ -13,7 +13,7 @@ import qualified Data.Abstract.ScopeGraph as ScopeGraph
 
 -- | Lookup type for a type-level key in a typescript map.
 data LookupType a = LookupType { lookupTypeIdentifier :: a, lookupTypeKey :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 LookupType where liftEq = genericLiftEq
 instance Ord1 LookupType where liftCompare = genericLiftCompare
@@ -22,7 +22,7 @@ instance Show1 LookupType where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable LookupType
 
 data FunctionType a = FunctionType { functionTypeParameters :: !a, functionFormalParameters :: ![a], functionType :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 FunctionType where liftEq = genericLiftEq
 instance Ord1 FunctionType where liftCompare = genericLiftCompare
@@ -31,7 +31,7 @@ instance Show1 FunctionType where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable FunctionType
 
 data TypeParameter a = TypeParameter { typeParameter :: !a, typeParameterConstraint :: !a, typeParameterDefaultType :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 TypeParameter where liftEq = genericLiftEq
 instance Ord1 TypeParameter where liftCompare = genericLiftCompare
@@ -40,7 +40,7 @@ instance Show1 TypeParameter where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable TypeParameter
 
 data TypeAssertion a = TypeAssertion { typeAssertionParameters :: !a, typeAssertionExpression :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 TypeAssertion where liftEq = genericLiftEq
 instance Ord1 TypeAssertion where liftCompare = genericLiftCompare
@@ -49,7 +49,7 @@ instance Show1 TypeAssertion where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable TypeAssertion
 
 newtype DefaultType a = DefaultType { defaultType :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 DefaultType where liftEq = genericLiftEq
 instance Ord1 DefaultType where liftCompare = genericLiftCompare
@@ -58,7 +58,7 @@ instance Show1 DefaultType where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable DefaultType
 
 newtype ParenthesizedType a = ParenthesizedType { parenthesizedType :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ParenthesizedType where liftEq = genericLiftEq
 instance Ord1 ParenthesizedType where liftCompare = genericLiftCompare
@@ -67,7 +67,7 @@ instance Show1 ParenthesizedType where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ParenthesizedType
 
 newtype PredefinedType a = PredefinedType { predefinedType :: T.Text }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 PredefinedType where liftEq = genericLiftEq
 instance Ord1 PredefinedType where liftCompare = genericLiftCompare
@@ -77,7 +77,7 @@ instance Show1 PredefinedType where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable PredefinedType
 
 newtype TypeIdentifier a = TypeIdentifier { contents :: T.Text }
-  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 TypeIdentifier where liftEq = genericLiftEq
 instance Ord1 TypeIdentifier where liftCompare = genericLiftCompare
@@ -95,7 +95,7 @@ instance Evaluatable TypeIdentifier where
     unit
 
 data NestedTypeIdentifier a = NestedTypeIdentifier { left :: !a, right :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 NestedTypeIdentifier where liftEq = genericLiftEq
 instance Ord1 NestedTypeIdentifier where liftCompare = genericLiftCompare
@@ -104,7 +104,7 @@ instance Show1 NestedTypeIdentifier where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable NestedTypeIdentifier
 
 data GenericType a = GenericType { genericTypeIdentifier :: !a, genericTypeArguments :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 GenericType where liftEq = genericLiftEq
 instance Ord1 GenericType where liftCompare = genericLiftCompare
@@ -113,7 +113,7 @@ instance Show1 GenericType where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable GenericType
 
 data TypePredicate a = TypePredicate { typePredicateIdentifier :: !a, typePredicateType :: !a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 TypePredicate where liftEq = genericLiftEq
 instance Ord1 TypePredicate where liftCompare = genericLiftCompare
@@ -122,7 +122,7 @@ instance Show1 TypePredicate where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable TypePredicate
 
 newtype ObjectType a = ObjectType { objectTypeElements :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ObjectType where liftEq = genericLiftEq
 instance Ord1 ObjectType where liftCompare = genericLiftCompare
@@ -131,7 +131,7 @@ instance Show1 ObjectType where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ObjectType
 
 newtype ArrayType a = ArrayType { arrayType :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ArrayType where liftEq = genericLiftEq
 instance Ord1 ArrayType where liftCompare = genericLiftCompare
@@ -140,7 +140,7 @@ instance Show1 ArrayType where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ArrayType
 
 newtype FlowMaybeType a = FlowMaybeType { flowMaybeType :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 FlowMaybeType where liftEq = genericLiftEq
 instance Ord1 FlowMaybeType where liftCompare = genericLiftCompare
@@ -149,7 +149,7 @@ instance Show1 FlowMaybeType where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable FlowMaybeType
 
 newtype TypeQuery a = TypeQuery { typeQuerySubject :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 TypeQuery where liftEq = genericLiftEq
 instance Ord1 TypeQuery where liftCompare = genericLiftCompare
@@ -158,7 +158,7 @@ instance Show1 TypeQuery where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable TypeQuery
 
 newtype IndexTypeQuery a = IndexTypeQuery { indexTypeQuerySubject :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 IndexTypeQuery where liftEq = genericLiftEq
 instance Ord1 IndexTypeQuery where liftCompare = genericLiftCompare
@@ -167,7 +167,7 @@ instance Show1 IndexTypeQuery where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable IndexTypeQuery
 
 newtype TypeArguments a = TypeArguments { typeArguments :: [a] }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 TypeArguments where liftEq = genericLiftEq
 instance Ord1 TypeArguments where liftCompare = genericLiftCompare
@@ -176,7 +176,7 @@ instance Show1 TypeArguments where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable TypeArguments
 
 newtype ThisType a = ThisType { contents :: T.Text }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ThisType where liftEq = genericLiftEq
 instance Ord1 ThisType where liftCompare = genericLiftCompare
@@ -185,7 +185,7 @@ instance Show1 ThisType where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ThisType
 
 newtype ExistentialType a = ExistentialType { contents :: T.Text }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 ExistentialType where liftEq = genericLiftEq
 instance Ord1 ExistentialType where liftCompare = genericLiftCompare
@@ -194,7 +194,7 @@ instance Show1 ExistentialType where liftShowsPrec = genericLiftShowsPrec
 instance Evaluatable ExistentialType
 
 newtype LiteralType a = LiteralType { literalTypeSubject :: a }
-  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, NFData1, ToJSONFields1, Traversable)
+  deriving (Declarations1, Diffable, Foldable, FreeVariables1, Functor, Generic1, Hashable1, ToJSONFields1, Traversable)
 
 instance Eq1 LiteralType where liftEq = genericLiftEq
 instance Ord1 LiteralType where liftCompare = genericLiftCompare

--- a/src/Prologue.hs
+++ b/src/Prologue.hs
@@ -10,7 +10,6 @@ module Prologue
 
 
 import Debug.Trace as X (traceShowM, traceM)
-import Control.DeepSeq as X
 import Data.Bifunctor.Join as X
 import Data.Bits as X
 import Data.ByteString as X (ByteString)


### PR DESCRIPTION
Compile times are bad, especially for syntax modules, so this PR improves things a bit by getting rid of some nice things. This PR:

- [x] 🔥s `Eq`, `Ord`, and `Show` instances for all of the à la carte syntax types. We don’t actually use them, since they’re exclusively used via `Sum`s, whose `Eq`, `Ord`, and `Show` instances use `Eq1`, `Ord1`, and `Show1` instances for the member syntax instead.

- [x] 🔥s the `Generically` mechanism for deriving `Eq1`, `Ord1`, and `Show1` instances using `-XDerivingVia`, instead defining all of these instances with manual calls into the generic mechanisms 😢

- [x] 🔥s all of our `NFData` & `NFData1` instances since we don’t use them any more, no, not even for the benchmarks.

- [x] 🔥s an orphan instance which probably wasn’t helping anything.