### PR TITLE
Expose diffGraph again

### DIFF
--- a/src/Semantic/Api/Diffs.hs
+++ b/src/Semantic/Api/Diffs.hs
@@ -4,6 +4,7 @@ module Semantic.Api.Diffs
   , DiffOutputFormat(..)
 
   , diffTerms
+  , diffGraph
   ) where
 
 import           Analysis.ConstructorName (ConstructorName)


### PR DESCRIPTION
The internal service we use to expose semantic's capabilities over http depends on `diffGraph`, so this just adds it to the module exports again.