### PR TITLE
Remove MonadFail from Core compiler.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -41,4 +41,4 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/antitypical/fused-syntax.git
-  tag: c80cb4edb9f4f446a5d104d6fcefb403c9545469
+  tag: 6b412694e64cc275ed06513b3c360f03bb1f04fd

--- a/cabal.project
+++ b/cabal.project
@@ -41,4 +41,4 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/antitypical/fused-syntax.git
-  tag: 5b7512db962d5b3f973002615b8bc86ab074d5aa
+  tag: c80cb4edb9f4f446a5d104d6fcefb403c9545469

--- a/semantic-core/src/Core/Core.hs
+++ b/semantic-core/src/Core/Core.hs
@@ -127,7 +127,7 @@ infixr 1 >>>
 
 unseq :: (Alternative m, Member Core sig) => Term sig a -> m (Term sig a, Term sig a)
 unseq (Alg sig) | Just (a :>> b) <- prj sig = pure (a, b)
-unseq _         = empty
+unseq _                                     = empty
 
 unseqs :: Member Core sig => Term sig a -> NonEmpty (Term sig a)
 unseqs = go
@@ -144,7 +144,7 @@ infixr 1 >>>=
 
 unbind :: (Alternative m, Member Core sig, RightModule sig) => a -> Term sig a -> m (Named a :<- Term sig a, Term sig a)
 unbind n (Alg sig) | Just (Named u a :>>= b) <- prj sig = pure (Named u n :<- a, instantiate1 (pure n) b)
-unbind _ _         = empty
+unbind _ _                                              = empty
 
 unstatement :: (Alternative m, Member Core sig, RightModule sig) => a -> Term sig a -> m (Maybe (Named a) :<- Term sig a, Term sig a)
 unstatement n t = first (first Just) <$> unbind n t <|> first (Nothing :<-) <$> unseq t
@@ -173,7 +173,7 @@ lams names body = foldr lam body names
 
 unlam :: (Alternative m, Member Core sig, RightModule sig) => a -> Term sig a -> m (Named a, Term sig a)
 unlam n (Alg sig) | Just (Lam b) <- prj sig = pure (n <$ b, instantiate1 (pure n) (namedValue b))
-unlam _ _         = empty
+unlam _ _                                   = empty
 
 ($$) :: (Carrier sig m, Member Core sig) => m a -> m a -> m a
 f $$ a = send (f :$ a)

--- a/semantic-core/src/Core/Core.hs
+++ b/semantic-core/src/Core/Core.hs
@@ -188,7 +188,7 @@ infixl 8 $$*
 
 unapply :: (Alternative m, Member Core sig) => Term sig a -> m (Term sig a, Term sig a)
 unapply (Alg sig) | Just (f :$ a) <- prj sig = pure (f, a)
-unapply _         = empty
+unapply _                                    = empty
 
 unapplies :: Member Core sig => Term sig a -> (Term sig a, Stack (Term sig a))
 unapplies core = case unapply core of

--- a/semantic-core/src/Core/Core.hs
+++ b/semantic-core/src/Core/Core.hs
@@ -48,6 +48,7 @@ import Data.Text (Text)
 import GHC.Generics (Generic1)
 import GHC.Stack
 import Source.Span
+import Syntax.Foldable
 import Syntax.Module
 import Syntax.Scope
 import Syntax.Stack
@@ -91,6 +92,7 @@ infixl 9 :.
 infix  3 :=
 
 instance HFunctor Core
+instance HFoldable Core
 instance HTraversable Core
 
 deriving instance (Eq   a, forall a . Eq   a => Eq   (f a), Monad f) => Eq   (Core f a)
@@ -232,9 +234,8 @@ data Ann ann f a
   deriving (Eq, Foldable, Functor, Generic1, Ord, Show, Traversable)
 
 instance HFunctor (Ann ann)
-
-instance HTraversable (Ann ann) where
-  htraverse f (Ann a x) = Ann a <$> f x
+instance HFoldable (Ann ann)
+instance HTraversable (Ann ann)
 
 instance RightModule (Ann ann) where
   Ann l b >>=* f = Ann l (b >>= f)

--- a/semantic-core/src/Core/Core.hs
+++ b/semantic-core/src/Core/Core.hs
@@ -51,6 +51,7 @@ import Syntax.Scope
 import Syntax.Stack
 import Syntax.Module
 import Syntax.Term
+import Syntax.Traversable
 
 data Core f a
   -- | Recursive local binding of a name in a scope; strict evaluation of the name in the body will diverge.
@@ -89,6 +90,7 @@ infixl 9 :.
 infix  3 :=
 
 instance HFunctor Core
+instance HTraversable Core
 
 deriving instance (Eq   a, forall a . Eq   a => Eq   (f a), Monad f) => Eq   (Core f a)
 deriving instance (Ord  a, forall a . Eq   a => Eq   (f a)
@@ -230,9 +232,11 @@ data Ann ann f a
 
 instance HFunctor (Ann ann)
 
+instance HTraversable (Ann ann) where
+  htraverse f (Ann a x) = Ann a <$> f x
+
 instance RightModule (Ann ann) where
   Ann l b >>=* f = Ann l (b >>= f)
-
 
 ann :: (Carrier sig m, Member (Ann Span) sig) => HasCallStack => m a -> m a
 ann = annWith callStack

--- a/semantic-python/semantic-python.cabal
+++ b/semantic-python/semantic-python.cabal
@@ -51,6 +51,7 @@ library
   exposed-modules:
     Language.Python
     Language.Python.Core
+    Language.Python.Failure
     Language.Python.Tags
   hs-source-dirs: src
 

--- a/semantic-python/src/Language/Python/Failure.hs
+++ b/semantic-python/src/Language/Python/Failure.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DeriveFoldable, DeriveFunctor, DeriveGeneric, DeriveTraversable, ExistentialQuantification,
-             FlexibleContexts, KindSignatures, LambdaCase, MultiParamTypeClasses, QuantifiedConstraints, RankNTypes,
+             FlexibleContexts, KindSignatures, MultiParamTypeClasses, QuantifiedConstraints, RankNTypes,
              StandaloneDeriving, TypeOperators #-}
 
 module Language.Python.Failure

--- a/semantic-python/src/Language/Python/Failure.hs
+++ b/semantic-python/src/Language/Python/Failure.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DeriveFunctor, DeriveFoldable, DeriveGeneric, DeriveTraversable, ExistentialQuantification, FlexibleContexts, KindSignatures, RankNTypes, StandaloneDeriving #-}
+
+module Language.Python.Failure
+  ( Failure (..)
+  , unimplemented
+  , invariantViolated
+  ) where
+
+import Control.Effect.Carrier
+import Data.Coerce
+import Data.Kind
+
+data Failure (f :: Type -> Type) a
+  = forall a . Show a => Unimplemented a
+  | InvariantViolated String
+
+deriving instance Functor (Failure f)
+
+instance HFunctor Failure where hmap _ = coerce
+
+unimplemented :: (Show ast, Member Failure sig, Carrier sig m) => ast -> m a
+unimplemented x = send . Unimplemented $ x
+
+invariantViolated :: (Member Failure sig, Carrier sig m) => String -> m a
+invariantViolated = send . InvariantViolated

--- a/semantic-python/src/Language/Python/Failure.hs
+++ b/semantic-python/src/Language/Python/Failure.hs
@@ -1,10 +1,12 @@
-{-# LANGUAGE DeriveFunctor, DeriveFoldable, DeriveGeneric, DeriveTraversable, ExistentialQuantification, FlexibleContexts, KindSignatures, RankNTypes, StandaloneDeriving, TypeOperators, QuantifiedConstraints #-}
+{-# LANGUAGE DeriveFoldable, DeriveFunctor, DeriveGeneric, DeriveTraversable, ExistentialQuantification,
+             FlexibleContexts, KindSignatures, LambdaCase, MultiParamTypeClasses, QuantifiedConstraints, RankNTypes,
+             StandaloneDeriving, TypeOperators #-}
 
 module Language.Python.Failure
   ( Failure (..)
   , unimplemented
   , invariantViolated
-  , eliminateFailures
+--  , eliminateFailures
   ) where
 
 import Prelude hiding (fail)
@@ -12,19 +14,30 @@ import Prelude hiding (fail)
 import Control.Effect.Carrier
 import Data.Coerce
 import Data.Kind
-import Syntax.Term
+import Syntax.Module
+import Syntax.Traversable
 
 data Failure (f :: Type -> Type) a
   = forall a . Show a => Unimplemented a
   | InvariantViolated String
 
 instance Show (Failure f a) where
-  show (Unimplemented a) = "unimplemented: " <> show a
+  show (Unimplemented a)     = "unimplemented: " <> show a
   show (InvariantViolated a) = "invariant violated: " <> a
 
 deriving instance Functor (Failure f)
+deriving instance Foldable (Failure f)
+deriving instance Traversable (Failure f)
 
 instance HFunctor Failure where hmap _ = coerce
+
+instance HTraversable Failure where
+  htraverse _ = \case
+    Unimplemented x -> pure (Unimplemented x)
+    InvariantViolated y -> pure (InvariantViolated y)
+
+instance RightModule Failure where
+  a >>=* _ = coerce a
 
 unimplemented :: (Show ast, Member Failure sig, Carrier sig m) => ast -> m a
 unimplemented x = send . Unimplemented $ x
@@ -32,11 +45,15 @@ unimplemented x = send . Unimplemented $ x
 invariantViolated :: (Member Failure sig, Carrier sig m) => String -> m a
 invariantViolated = send . InvariantViolated
 
-eliminateFailures :: forall a sig . (HFunctor sig, forall g . Functor g => Functor (sig g))
-                  => (forall x y . Failure x y -> Term sig y)
-                  -> Term (Failure :+: sig) a
-                  -> Term sig a
-eliminateFailures _ (Var v) = Var v
-eliminateFailures f (Alg (L x)) = f x
-eliminateFailures f (Alg (R other)) = Alg (hmap (eliminateFailures f) other)
+-- eliminateFailures :: forall m a sig . (MonadFail m, HFunctor sig, forall g . Functor g => Functor (sig g))
+--                   => Term (Failure :+: sig) a
+--                   -> m (Term sig a)
+-- eliminateFailures = iter
+--  _
+-- eliminateFailures (Var v) = pure (Var v)
+-- eliminateFailures (Alg (L _x)) = Control.Monad.Fail.fail "encountered failure"
+-- eliminateFailures (Alg (R y)) = Alg <$> (htraverse eliminateFailures y)
+--eliminateFailures (Alg (R other)) = Alg <$> (_hmap (eliminateFailures f) other)
 
+-- htraverse :: Applicative f => (forall a. g a -> f (h a)) -> t g a -> f (t h a)
+-- htraverse _f _x = undefined

--- a/semantic-python/src/Language/Python/Failure.hs
+++ b/semantic-python/src/Language/Python/Failure.hs
@@ -20,11 +20,12 @@ import Syntax.Term
 import Syntax.Traversable
 
 data Failure (f :: Type -> Type) a
-  = forall a . Show a => Unimplemented a
+  = Unimplemented String
   | InvariantViolated String
+    deriving Generic1
 
 instance Show (Failure f a) where
-  show (Unimplemented a)     = "unimplemented: " <> show a
+  show (Unimplemented a)     = "unimplemented: " <> a
   show (InvariantViolated a) = "invariant violated: " <> a
 
 deriving instance Functor (Failure f)
@@ -42,7 +43,7 @@ instance RightModule Failure where
   a >>=* _ = coerce a
 
 unimplemented :: (Show ast, Member Failure sig, Carrier sig m) => ast -> m a
-unimplemented = send . Unimplemented
+unimplemented = send . Unimplemented . show
 
 invariantViolated :: (Member Failure sig, Carrier sig m) => String -> m a
 invariantViolated = send . InvariantViolated

--- a/semantic-python/src/Language/Python/Failure.hs
+++ b/semantic-python/src/Language/Python/Failure.hs
@@ -12,6 +12,7 @@ module Language.Python.Failure
 import Prelude hiding (fail)
 
 import Control.Effect.Carrier
+import Control.Monad.Fail
 import Data.Coerce
 import Data.Kind
 import Syntax.Module
@@ -46,7 +47,7 @@ unimplemented x = send . Unimplemented $ x
 invariantViolated :: (Member Failure sig, Carrier sig m) => String -> m a
 invariantViolated = send . InvariantViolated
 
-eliminateFailures :: (HTraversable sig, RightModule sig)
+eliminateFailures :: (MonadFail m, HTraversable sig, RightModule sig)
                   => Term (Failure :+: sig) a
                   -> Either String (Term sig a)
-eliminateFailures = Syntax.Term.handle (pure . pure) (Left . show)
+eliminateFailures = Syntax.Term.handle (pure . pure) (fail . show)

--- a/semantic-python/src/Language/Python/Failure.hs
+++ b/semantic-python/src/Language/Python/Failure.hs
@@ -49,5 +49,5 @@ invariantViolated = send . InvariantViolated
 
 eliminateFailures :: (MonadFail m, HTraversable sig, RightModule sig)
                   => Term (Failure :+: sig) a
-                  -> Either String (Term sig a)
+                  -> m (Term sig a)
 eliminateFailures = Syntax.Term.handle (pure . pure) (fail . show)

--- a/semantic-python/src/Language/Python/Failure.hs
+++ b/semantic-python/src/Language/Python/Failure.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE DeriveFoldable, DeriveFunctor, DeriveGeneric, DeriveTraversable, ExistentialQuantification,
-             FlexibleContexts, KindSignatures, LambdaCase, MultiParamTypeClasses, QuantifiedConstraints, RankNTypes,
-             StandaloneDeriving, TypeOperators #-}
+{-# LANGUAGE DeriveFoldable, DeriveFunctor, DeriveTraversable, ExistentialQuantification, FlexibleContexts,
+             KindSignatures, LambdaCase, MultiParamTypeClasses, QuantifiedConstraints, RankNTypes, StandaloneDeriving,
+             TypeOperators #-}
 
 module Language.Python.Failure
   ( Failure (..)
@@ -42,7 +42,7 @@ instance RightModule Failure where
   a >>=* _ = coerce a
 
 unimplemented :: (Show ast, Member Failure sig, Carrier sig m) => ast -> m a
-unimplemented x = send . Unimplemented $ x
+unimplemented = send . Unimplemented
 
 invariantViolated :: (Member Failure sig, Carrier sig m) => String -> m a
 invariantViolated = send . InvariantViolated

--- a/semantic-python/src/Language/Python/Failure.hs
+++ b/semantic-python/src/Language/Python/Failure.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE DeriveFoldable, DeriveFunctor, DeriveTraversable, ExistentialQuantification, FlexibleContexts,
-             KindSignatures, LambdaCase, MultiParamTypeClasses, QuantifiedConstraints, RankNTypes, StandaloneDeriving,
-             TypeOperators #-}
+{-# LANGUAGE DeriveFoldable, DeriveFunctor, DeriveGeneric, DeriveTraversable, ExistentialQuantification,
+             FlexibleContexts, KindSignatures, LambdaCase, MultiParamTypeClasses, QuantifiedConstraints, RankNTypes,
+             StandaloneDeriving, TypeOperators #-}
 
 module Language.Python.Failure
   ( Failure (..)
@@ -15,6 +15,8 @@ import Control.Effect.Carrier
 import Control.Monad.Fail
 import Data.Coerce
 import Data.Kind
+import GHC.Generics (Generic1)
+import Syntax.Foldable
 import Syntax.Module
 import Syntax.Term
 import Syntax.Traversable
@@ -32,15 +34,13 @@ deriving instance Functor (Failure f)
 deriving instance Foldable (Failure f)
 deriving instance Traversable (Failure f)
 
-instance HFunctor Failure where hmap _ = coerce
-
-instance HTraversable Failure where
-  htraverse _ = \case
-    Unimplemented x -> pure (Unimplemented x)
-    InvariantViolated y -> pure (InvariantViolated y)
+instance HFunctor Failure
+instance HFoldable Failure
+instance HTraversable Failure
 
 instance RightModule Failure where
   a >>=* _ = coerce a
+
 
 unimplemented :: (Show ast, Member Failure sig, Carrier sig m) => ast -> m a
 unimplemented = send . Unimplemented . show

--- a/semantic-python/src/Language/Python/Failure.hs
+++ b/semantic-python/src/Language/Python/Failure.hs
@@ -1,18 +1,26 @@
-{-# LANGUAGE DeriveFunctor, DeriveFoldable, DeriveGeneric, DeriveTraversable, ExistentialQuantification, FlexibleContexts, KindSignatures, RankNTypes, StandaloneDeriving #-}
+{-# LANGUAGE DeriveFunctor, DeriveFoldable, DeriveGeneric, DeriveTraversable, ExistentialQuantification, FlexibleContexts, KindSignatures, RankNTypes, StandaloneDeriving, TypeOperators, QuantifiedConstraints #-}
 
 module Language.Python.Failure
   ( Failure (..)
   , unimplemented
   , invariantViolated
+  , eliminateFailures
   ) where
+
+import Prelude hiding (fail)
 
 import Control.Effect.Carrier
 import Data.Coerce
 import Data.Kind
+import Syntax.Term
 
 data Failure (f :: Type -> Type) a
   = forall a . Show a => Unimplemented a
   | InvariantViolated String
+
+instance Show (Failure f a) where
+  show (Unimplemented a) = "unimplemented: " <> show a
+  show (InvariantViolated a) = "invariant violated: " <> a
 
 deriving instance Functor (Failure f)
 
@@ -23,3 +31,12 @@ unimplemented x = send . Unimplemented $ x
 
 invariantViolated :: (Member Failure sig, Carrier sig m) => String -> m a
 invariantViolated = send . InvariantViolated
+
+eliminateFailures :: forall a sig . (HFunctor sig, forall g . Functor g => Functor (sig g))
+                  => (forall x y . Failure x y -> Term sig y)
+                  -> Term (Failure :+: sig) a
+                  -> Term sig a
+eliminateFailures _ (Var v) = Var v
+eliminateFailures f (Alg (L x)) = f x
+eliminateFailures f (Alg (R other)) = Alg (hmap (eliminateFailures f) other)
+

--- a/semantic-python/test/Test.hs
+++ b/semantic-python/test/Test.hs
@@ -108,10 +108,6 @@ assertEvaluatesTo core k val = do
 assertTreeEqual :: Term Core Name -> Term Core Name -> HUnit.Assertion
 assertTreeEqual t item = HUnit.assertEqual ("got (pretty)" <> showCore item) t item
 
-eliminateFailures :: Term (Failure :+: Ann Span :+: Core) Name
-                  -> Either String (Term (Ann Span :+: Core) Name)
-eliminateFailures = Syntax.Term.handle (pure . pure) (Left . show)
-
 
 checkPythonFile :: HasCallStack => Path.RelFile -> Tasty.TestTree
 checkPythonFile fp = HUnit.testCaseSteps (Path.toString fp) $ \step -> withFrozenCallStack $ do
@@ -121,7 +117,7 @@ checkPythonFile fp = HUnit.testCaseSteps (Path.toString fp) $ \step -> withFroze
   result <- ByteString.readFile (Path.toString fullPath) >>= TS.parseByteString TSP.tree_sitter_python
 
   -- Run the compiler
-  let coreResult = extractResult
+  let coreResult = eliminateFailures
                    . Control.Effect.run
                    . runReader @Py.Bindings mempty
                    . Py.toplevelCompile @(Failure :+: Ann Span :+: Core) @(Term _)

--- a/semantic-python/test/Test.hs
+++ b/semantic-python/test/Test.hs
@@ -7,6 +7,7 @@ import qualified Analysis.Concrete as Concrete
 import           Analysis.File
 import           Analysis.ScopeGraph
 import           Control.Effect
+import           Control.Effect.Fail
 import           Control.Effect.Reader
 import           Control.Monad hiding (fail)
 import           Control.Monad.Catch
@@ -117,7 +118,9 @@ checkPythonFile fp = HUnit.testCaseSteps (Path.toString fp) $ \step -> withFroze
   result <- ByteString.readFile (Path.toString fullPath) >>= TS.parseByteString TSP.tree_sitter_python
 
   -- Run the compiler
-  let coreResult = eliminateFailures
+  let coreResult = Control.Effect.run
+                   . runFail
+                   . eliminateFailures
                    . Control.Effect.run
                    . runReader @Py.Bindings mempty
                    . Py.toplevelCompile @(Failure :+: Ann Span :+: Core) @(Term _)


### PR DESCRIPTION
- [x] Depends on https://github.com/antitypical/fused-syntax/pull/5

Pulls in a newer `fused-syntax` so we get the helpful `Term.handle` function, and uses that to eliminate `Failure` nodes from a tree _in toto_.

In the future, we probably want more fine-grained failure mechanisms: rather than fail upfront, we should try to preserve as much of the tree as possible (including recursing into the children of nodes that failed). But this will suffice for now, and increases the clarity of the implementation.