### PR TITLE
Annotate parsed Core terms with their span.

### DIFF
--- a/semantic-core/src/Core/Core.hs
+++ b/semantic-core/src/Core/Core.hs
@@ -226,7 +226,13 @@ infix 3 .=
 
 data Ann ann f a
   = Ann ann (f a)
-  deriving (Eq, Foldable, Functor, Generic1, Ord, Show, Traversable)
+  deriving (Foldable, Functor, Generic1, Show, Traversable)
+
+instance Eq (f a) => Eq (Ann ann f a) where
+  Ann _ x == Ann _ y = x == y
+
+instance Ord (f a) => Ord (Ann ann f a) where
+  compare (Ann _ x) (Ann _ y) = compare x y
 
 instance HFunctor (Ann ann)
 

--- a/semantic-core/src/Core/Parser.hs
+++ b/semantic-core/src/Core/Parser.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE FlexibleContexts, GeneralizedNewtypeDeriving, LambdaCase, TypeOperators #-}
+{-# LANGUAGE ConstraintKinds, FlexibleContexts, GeneralizedNewtypeDeriving, LambdaCase, TypeOperators #-}
 module Core.Parser
   ( core
   , lit
@@ -21,14 +20,14 @@ import           Data.Foldable (foldl')
 import           Data.Function
 import           Data.Int
 import           Data.String
+import qualified Source.Span as Source
 import           Text.Parser.LookAhead (LookAheadParsing)
 import qualified Text.Parser.Token as Token
 import qualified Text.Parser.Token.Highlight as Highlight
 import qualified Text.Parser.Token.Style as Style
 import           Text.Trifecta hiding (ident)
-import qualified Text.Trifecta.Rendering as Trifecta
 import qualified Text.Trifecta.Delta as Trifecta
-import qualified Source.Span as Source
+import qualified Text.Trifecta.Rendering as Trifecta
 
 -- * Identifier styles and derived parsers
 

--- a/semantic-core/src/Core/Parser.hs
+++ b/semantic-core/src/Core/Parser.hs
@@ -141,13 +141,13 @@ name :: (TokenParsing m, Monad m) => m (Named Name)
 name = named' <$> identifier <?> "name"
 
 lit :: CoreParsing sig m t => m (t Name)
-lit = let x `given` n = x <$ reserved n in choice
+lit = let x `given` n = x <$ reserved n in positioned (choice
   [ Core.bool True  `given` "#true"
   , Core.bool False `given` "#false"
   , Core.unit       `given` "#unit"
   , record
   , Core.string <$> stringLiteral
-  ] <?> "literal"
+  ] <?> "literal")
 
 record :: CoreParsing sig m t => m (t Name)
 record = Core.record <$ reserved "#record" <*> braces (field `sepEndBy` comma)

--- a/semantic-core/src/Core/Parser.hs
+++ b/semantic-core/src/Core/Parser.hs
@@ -106,7 +106,7 @@ projection = foldl' (&) <$> atom <*> many (choice [ flip (Core..?)  <$ symbol ".
                                                   ])
 
 atom :: CoreParsing sig m t => m (t Name)
-atom = choice
+atom = positioned . choice $
   [ comp
   , lit
   , ident

--- a/semantic-core/src/Core/Parser.hs
+++ b/semantic-core/src/Core/Parser.hs
@@ -91,7 +91,7 @@ core :: CoreParsing sig m t => m (t Name)
 core = runCoreParser expr
 
 expr :: CoreParsing sig m t => m (t Name)
-expr = ifthenelse <|> lambda <|> rec <|> load <|> assign
+expr = positioned (ifthenelse <|> lambda <|> rec <|> load <|> assign)
 
 assign :: CoreParsing sig m t => m (t Name)
 assign = application <**> (symbolic '=' *> rhs <|> pure id) <?> "assignment"

--- a/semantic-core/src/Core/Parser.hs
+++ b/semantic-core/src/Core/Parser.hs
@@ -70,7 +70,7 @@ convertSpan :: Trifecta.Span -> Source.Span
 convertSpan (Trifecta.Span s e _) = Source.Span (convertDelta s) (convertDelta e)
   where
     build :: Int64 -> Int64 -> Source.Pos
-    build l c = Source.Pos (fromIntegral l) (fromIntegral c)
+    build l c = Source.Pos (fromIntegral l + 1) (fromIntegral c)
     convertDelta :: Trifecta.Delta -> Source.Pos
     convertDelta = \case
       Trifecta.Columns c _        -> build 0 c

--- a/semantic-core/test/Test.hs
+++ b/semantic-core/test/Test.hs
@@ -34,7 +34,7 @@ parseEither p = Trifecta.foldResult (Left . show . Trifecta._errDoc) Right . Tri
 prop_roundtrips :: Gen (Term (Ann Span :+: Core) Name) -> Property
 prop_roundtrips gen = property $ do
   input <- forAll gen
-  tripping input (showCore . stripAnnotations) (parseEither (Parse.core <* Trifecta.eof))
+  tripping input (showCore . stripAnnotations) (fmap (stripAnnotations @Span) . parseEither (Parse.core <* Trifecta.eof))
 
 parserProps :: TestTree
 parserProps = testGroup "Parsing: roundtripping"
@@ -49,7 +49,7 @@ parserProps = testGroup "Parsing: roundtripping"
 
 parsesInto :: String -> Term (Ann Span :+: Core) Name -> Assertion
 parsesInto str res = case parseEither Parse.core str of
-  Right x -> x @?= res
+  Right x -> stripAnnotations @Span x @?= stripAnnotations res
   Left m  -> assertFailure m
 
 assert_booleans_parse :: Assertion
@@ -95,7 +95,7 @@ parserSpecs = testGroup "Parsing: simple specs"
 
 assert_roundtrips :: File (Term (Ann Span :+: Core) Name) -> Assertion
 assert_roundtrips (File _ _ core) = case parseEither Parse.core (showCore (stripAnnotations core)) of
-  Right v -> v @?= core
+  Right v -> stripAnnotations @Span v @?= stripAnnotations core
   Left  e -> assertFailure e
 
 parserExamples :: TestTree

--- a/semantic-python/test/Directive.hs
+++ b/semantic-python/test/Directive.hs
@@ -29,7 +29,7 @@ import qualified System.Path as Path
 import qualified System.Path.PartClass as Path.Class
 import           System.Process
 import qualified Text.Parser.Token.Style as Style
-import           Text.Trifecta (CharParsing, TokenParsing (..))
+import           Text.Trifecta (CharParsing, DeltaParsing)
 import qualified Text.Trifecta as Trifecta
 
 {- |
@@ -57,7 +57,7 @@ projects.
 
 -}
 data Directive = JQ ByteString -- | @# CHECK-JQ: expr@
-               | Tree (Term Core Name) -- | @# CHECK-TREE: core@
+               | Tree (Term (Core.Ann Source.Span :+: Core) Name) -- | @# CHECK-TREE: core@
                | Result Text (Concrete (Term (Core.Ann Source.Span :+: Core)) Name) -- | @# CHECK-RESULT key: expected
                | Fails -- | @# CHECK-FAILS@ fails unless translation fails.
                  deriving (Eq, Show)
@@ -80,7 +80,7 @@ readDirectivesFromFile
 
 describe :: Directive -> String
 describe Fails        = "<expect failure>"
-describe (Tree t)     =  Core.Pretty.showCore t
+describe (Tree t)     = Core.Pretty.showCore (Core.stripAnnotations t)
 describe (JQ b)       = ByteString.unpack b
 describe (Result t e) = T.unpack t <> ": " <> show e
 
@@ -92,19 +92,19 @@ jq = do
   void $ Trifecta.string "# CHECK-JQ: "
   JQ . ByteString.pack <$> many (Trifecta.noneOf "\n")
 
-tree :: (Monad m, TokenParsing m) => m Directive
+tree :: (Monad m, DeltaParsing m) => m Directive
 tree = do
   void $ Trifecta.string "# CHECK-TREE: "
   Tree <$> Core.Parser.core
 
-result :: (Monad m, TokenParsing m) => m Directive
+result :: (Monad m, DeltaParsing m) => m Directive
 result = do
   void $ Trifecta.string "# CHECK-RESULT "
   key <- Trifecta.ident Style.haskellIdents
   void $ Trifecta.symbolic ':'
   Result key <$> concrete
 
-concrete :: TokenParsing m => m (Concrete term Name)
+concrete :: DeltaParsing m => m (Concrete term Name)
 concrete = Trifecta.choice
   [ String <$> Trifecta.stringLiteral
   , Bool True <$ Trifecta.symbol "#true"
@@ -112,7 +112,7 @@ concrete = Trifecta.choice
   , Unit <$ Trifecta.symbol "#unit"
   ]
 
-directive :: (Monad m, TokenParsing m) => m Directive
+directive :: DeltaParsing m => m Directive
 directive = Trifecta.choice [ fails, result, jq, tree ]
 
 parseDirective :: ByteString -> Either String Directive

--- a/semantic-python/test/Test.hs
+++ b/semantic-python/test/Test.hs
@@ -132,7 +132,7 @@ checkPythonFile fp = HUnit.testCaseSteps (Path.toString fp) $ \step -> withFroze
       (Right (Right _), Directive.Fails)         -> HUnit.assertFailure "Expected translation to fail"
       (Right (Right item), Directive.Result k v) -> assertEvaluatesTo item k v
       (Right (Right item), Directive.JQ _)       -> assertJQExpressionSucceeds directive result item
-      (Right (Right item), Directive.Tree t)     -> assertTreeEqual (stripAnnotations item) t
+      (Right (Right item), Directive.Tree t)     -> assertTreeEqual (stripAnnotations item) (stripAnnotations t)
 
 milestoneFixtures :: IO Tasty.TestTree
 milestoneFixtures = buildTests <$> readFiles


### PR DESCRIPTION
Trifecta makes this pretty easy with the `spanned` combinator.