### PR TITLE
warnings

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -30,6 +30,9 @@ package semantic-python
 package semantic-tags
   ghc-options: -Werror
 
+package semantic-ast
+  ghc-options: -Werror
+
 source-repository-package
   type: git
   location: https://github.com/tclem/proto-lens-jsonpb

--- a/semantic-ast/semantic-ast.cabal
+++ b/semantic-ast/semantic-ast.cabal
@@ -18,7 +18,25 @@ extra-source-files:  CHANGELOG.md
 
 tested-with:         GHC == 8.6.5
 
+common haskell
+  default-language:    Haskell2010
+  ghc-options:
+    -Weverything
+    -Wno-missing-local-signatures
+    -Wno-missing-import-lists
+    -Wno-implicit-prelude
+    -Wno-safe
+    -Wno-unsafe
+    -Wno-name-shadowing
+    -Wno-monomorphism-restriction
+    -Wno-missed-specialisations
+    -Wno-all-missed-specialisations
+    -Wno-star-is-type
+  if (impl(ghc >= 8.8))
+    ghc-options: -Wno-missing-deriving-strategies
+
 library
+  import:              haskell
   exposed-modules:
   -- other-modules:
   -- other-extensions:
@@ -33,6 +51,7 @@ library
   default-language:    Haskell2010
 
 executable semantic-ast
+  import:              haskell
   main-is:             Main.hs
   -- other-modules:
   -- other-extensions:

--- a/semantic-ast/src/Main.hs
+++ b/semantic-ast/src/Main.hs
@@ -3,14 +3,13 @@
 
 module Main (main) where
 
-import System.Environment
 import TreeSitter.Unmarshal
 import qualified TreeSitter.Python.AST as AST
 import qualified TreeSitter.Python as Python
 import Source.Range
 import Source.Span
 import Data.ByteString.Char8
-import Data.ByteString (pack, readFile, ByteString)
+import Data.ByteString (readFile)
 import System.IO (FilePath)
 import Options.Applicative hiding (style)
 import Data.Semigroup ((<>))

--- a/semantic-ast/src/Main.hs
+++ b/semantic-ast/src/Main.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+
 module Main (main) where
 
 import System.Environment


### PR DESCRIPTION
Emulating the status quo for the rest of the `semantic-` packages, hoping this will drive better messages. h/t @patrickt for the pro-tip. 