### PR TITLE
Minor style fix for all languages in CLI

### DIFF
--- a/src/Semantic/CLI.hs
+++ b/src/Semantic/CLI.hs
@@ -9,7 +9,7 @@ import           Data.Blob.IO
 import qualified Data.Flag as Flag
 import           Data.Handle
 import qualified Data.Language as Language
-import           Data.List (intercalate)
+import           Data.List (delete, intercalate)
 import           Data.Project
 import           Options.Applicative hiding (style)
 import           Prologue
@@ -158,7 +158,7 @@ graphCommand = command "graph" (info graphArgumentsParser (progDesc "Compute a g
         (x:_) -> pure $! Project (takeDirectory x) blobs (Language.languageForFilePath x) mempty
         _     -> pure $! Project "/" mempty Language.Unknown mempty
 
-    allLanguages = mconcat . intercalate ["|"] . fmap (pure . show) $ [Language.Go .. Language.TSX]
+    allLanguages = intercalate "|" . fmap show . delete Language.Unknown $ [minBound .. maxBound]
     readProjectRecursively = makeReadProjectRecursivelyTask
       <$> option auto (long "language" <> help "The language for the analysis." <> metavar allLanguages)
       <*> optional (pathOption (long "root" <> help "Root directory of project. Optional, defaults to entry file/directory." <> metavar "DIR"))


### PR DESCRIPTION
Makes retrieving all languages insensitive to the ordering of languages
inside the `Language` datatype declaration and removes a couple of
unneeded function calls.