### PR TITLE
Add script to fix corrupted tree-sitter Cabal stores.

### DIFF
--- a/script/fix-broken-cabal-store
+++ b/script/fix-broken-cabal-store
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+rm -rf ~/.cabal/store/ghc-8.6.5/tr-sttr*
+rm -rf ~/.cabal/store/ghc-8.6.5/lib/libHStr-sttr*
+rm -rf ~/.cabal/store/ghc-8.6.5/package.db/tr-sttr*


### PR DESCRIPTION
Based on some knowledge that @robrix dropped in Slack.