### PR TITLE
Compile Python lambdas.

### DIFF
--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -321,7 +321,7 @@ instance Compile Py.Lambda where
           unparam _ = Nothing
       body' <- compile body cc next
       let params = maybe [] unparams parameters
-      pure . locate it. . lams (catMaybes (fmap unparam params)) $ body'
+      pure . locate it . lams (catMaybes (fmap unparam params)) $ body'
 
 instance Compile Py.List
 instance Compile Py.ListComprehension

--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -311,7 +311,18 @@ instance Compile Py.ImportFromStatement
 instance Compile Py.ImportStatement
 instance Compile Py.Integer
 
-instance Compile Py.Lambda
+instance Compile Py.Lambda where
+  compile it@Py.Lambda
+    { body
+    , parameters
+    } cc next = do
+      let unparams (Py.LambdaParameters _ ps) = toList ps
+          unparam (Py.Parameter (Prj (Py.Identifier _pann pname))) = Just . named' . Name $ pname
+          unparam _ = Nothing
+      body' <- compile body cc next
+      let params = maybe [] unparams parameters
+      pure . locate it. . lams (catMaybes (fmap unparam params)) $ body'
+
 instance Compile Py.List
 instance Compile Py.ListComprehension
 instance Compile Py.ListSplat

--- a/semantic-python/test/fixtures/4-01-lambda-literals.py
+++ b/semantic-python/test/fixtures/4-01-lambda-literals.py
@@ -1,0 +1,4 @@
+# CHECK-TREE: { const <- \x -> \y -> x; y <- const #true #true; z <- const #false #false; #record { const: const, y : y, z: z, }}
+const = lambda x, y: x
+y = const(True, True)
+z = const(False, False)


### PR DESCRIPTION
Lambdas are so hilariously crippled in Python that they're
significantly easier to compile than functions. Indeed, the resulting
core looks much like a function definition, without a `rec` binding.