### PR TITLE
Make True and False real Python objects.

### DIFF
--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -306,8 +306,9 @@ instance Compile Py.IfStatement where
                        <*> compile consequence cc next
                        <*> foldr clause (cc next) alternative)
     where clause (R1 Py.ElseClause{ body }) _ = compile body cc next
-          clause (L1 Py.ElifClause{ condition, consequence }) rest  =
-            if' <$> compile condition pure next <*> compile consequence cc next <*> rest
+          clause (L1 Py.ElifClause{ condition, consequence }) rest = do
+            cond <- compile condition pure next
+            if' (cond ... "__prim") <$> compile consequence cc next <*> rest
 
 
 instance Compile Py.ImportFromStatement

--- a/semantic-python/src/Language/Python/Core.hs
+++ b/semantic-python/src/Language/Python/Core.hs
@@ -265,7 +265,7 @@ instance Compile Py.ExpressionList where
 
 
 instance Compile Py.False where
-  compile it cc _ = cc $ locate it (bool False)
+  compile it cc _ = cc $ locate it (prelude ["False"])
 
 instance Compile Py.Float
 instance Compile Py.ForStatement
@@ -397,7 +397,7 @@ instance Compile Py.String where
 instance Compile Py.Subscript
 
 instance Compile Py.True where
-  compile it cc _next = cc $ locate it (bool True)
+  compile it cc _next = cc $ locate it (prelude ["True"])
 
 instance Compile Py.TryStatement
 

--- a/semantic-python/src/Prelude.score
+++ b/semantic-python/src/Prelude.score
@@ -8,9 +8,11 @@
   // object's superclass is type itself
   object <- type "object" type #record{};
 
-  str <- type "str" object #record { __new__: \prim -> instance #unit prim #record{} };
-
-  bool <- type "bool" object #record { __new: \prim -> instance #unit prim #record{} };
+  // These classes' __new__ slots are incorrect (the first parameter should be the `str`
+  // and `bool` values themselves, not object), but until semantic/#362 is fixed, we can't
+  // use `rec` in the prelude, so for True and False below we call instance manually.
+  str <- type "str" object #record { __new__: \prim -> instance object prim #record{} };
+  bool <- type "bool" object #record { __new__: \prim -> instance object prim #record{} };
 
   True <- instance bool #true #record {};
   False <- instance bool #false #record {};

--- a/semantic-python/src/Prelude.score
+++ b/semantic-python/src/Prelude.score
@@ -10,9 +10,14 @@
 
   str <- type "str" object #record { __new__: \prim -> instance #unit prim #record{} };
 
+  bool <- type "bool" object #record { __new: \prim -> instance #unit prim #record{} };
+
+  True <- instance bool #true #record {};
+  False <- instance bool #false #record {};
+
   // We will fill in the actual definition of these operators
   // pending the presence of more eliminators.
-  not <- \val -> if val then #false else #true;
+  not <- \val -> if val.__prim then False else True;
 
   NoneType <- type "None" object #record { __new__: \prim -> instance #unit prim #record{} };
   None <- NoneType.__slots.__new__ #unit;
@@ -23,6 +28,9 @@
   #record { type: type
           , object: object
           , str: str
+          , bool: bool
+          , False: False
+          , True: True
           , not: not
           , NoneType: NoneType
           , None: None

--- a/semantic-python/test/fixtures/2-04-multiple-assign.py
+++ b/semantic-python/test/fixtures/2-04-multiple-assign.py
@@ -1,2 +1,2 @@
-# CHECK-TREE: { z <- #true; y <- z; x <- y; #record { z : z, y : y, x : x }}
+# CHECK-TREE: { z <- __semantic_prelude.True; y <- z; x <- y; #record { z : z, y : y, x : x }}
 x = y = z = True

--- a/semantic-python/test/fixtures/2-05-function-call.py
+++ b/semantic-python/test/fixtures/2-05-function-call.py
@@ -1,4 +1,4 @@
-# CHECK-TREE: { const <- rec const = \x -> \y -> x; y <- const #true #true; z <- const #false #false; #record { const: const, y : y, z: z, }}
+# CHECK-TREE: { const <- rec const = \x -> \y -> x; y <- const __semantic_prelude.True __semantic_prelude.True; z <- const __semantic_prelude.False __semantic_prelude.False; #record { const: const, y : y, z: z, }}
 def const(x, y): return x
 y = const(True, True)
 z = const(False, False)

--- a/semantic-python/test/fixtures/4-01-lambda-literals.py
+++ b/semantic-python/test/fixtures/4-01-lambda-literals.py
@@ -1,4 +1,3 @@
-# CHECK-TREE: { const <- \x -> \y -> x; y <- const #true #true; z <- const #false #false; #record { const: const, y : y, z: z, }}
+# CHECK-TREE: { const <- \x -> \y -> x; y <- const __semantic_prelude.True __semantic_prelude.True; #record { const: const, y : y }}
 const = lambda x, y: x
 y = const(True, True)
-z = const(False, False)

--- a/semantic-python/test/fixtures/4-03-not-expression.py
+++ b/semantic-python/test/fixtures/4-03-not-expression.py
@@ -1,2 +1,2 @@
-# CHECK-TREE: { x <- __semantic_prelude.not #true; #record { x: x }}
+# CHECK-TREE: { x <- __semantic_prelude.not __semantic_prelude.True; #record { x: x }}
 x = not True


### PR DESCRIPTION
- [ ] Depends on #407. 

Rather than use primitive Core `#true` and `#false` values as Python `True` and `False`, we create a `bool` type and `True` and `False` instances in the prelude, then compile `True` and `False` to them. We also adjust the definition of `not`.