### PR TITLE
Generalize script/fix-broken-cabal-store

### DIFF
--- a/script/fix-broken-cabal-store
+++ b/script/fix-broken-cabal-store
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-ghc_version="$(ghc --numeric-version)"
+store_dir="$HOME/.cabal/store/ghc-$(ghc --numeric-version)"
 
-rm -rf "~/.cabal/store/ghc-$ghc_version/tr-sttr*"
-rm -rf "~/.cabal/store/ghc-$ghc_version/lib/libHStr-sttr*"
-rm -rf "~/.cabal/store/ghc-$ghc_version/package.db/tr-sttr*"
+rm -rf "$store_dir"/tr-sttr*
+rm -rf "$store_dir"/lib/libHStr-sttr*
+rm -rf "$store_dir"/package.db/tr-sttr*

--- a/script/fix-broken-cabal-store
+++ b/script/fix-broken-cabal-store
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-rm -rf ~/.cabal/store/ghc-8.6.5/tr-sttr*
-rm -rf ~/.cabal/store/ghc-8.6.5/lib/libHStr-sttr*
-rm -rf ~/.cabal/store/ghc-8.6.5/package.db/tr-sttr*
+ghc_version="$(ghc --numeric-version)"
+
+rm -rf ~/.cabal/store/ghc-$ghc_version/tr-sttr*
+rm -rf ~/.cabal/store/ghc-$ghc_version/lib/libHStr-sttr*
+rm -rf ~/.cabal/store/ghc-$ghc_version/package.db/tr-sttr*

--- a/script/fix-broken-cabal-store
+++ b/script/fix-broken-cabal-store
@@ -2,6 +2,6 @@
 
 ghc_version="$(ghc --numeric-version)"
 
-rm -rf ~/.cabal/store/ghc-$ghc_version/tr-sttr*
-rm -rf ~/.cabal/store/ghc-$ghc_version/lib/libHStr-sttr*
-rm -rf ~/.cabal/store/ghc-$ghc_version/package.db/tr-sttr*
+rm -rf "~/.cabal/store/ghc-$ghc_version/tr-sttr*"
+rm -rf "~/.cabal/store/ghc-$ghc_version/lib/libHStr-sttr*"
+rm -rf "~/.cabal/store/ghc-$ghc_version/package.db/tr-sttr*"


### PR DESCRIPTION
This fixes the script to accommodate different ghc versions & spaces in paths.