### PR TITLE
Higher-order Traversable

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: hlint
       run: |
-        cabal install hlint --installdir=dist-newstyle
+        cabal install hlint --installdir=dist-newstyle --overwrite-policy=always
         dist-newstyle/hlint src semantic-python
 
     - name: Build & test

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: hlint
       run: |
-        cabal install hlint --installdir=dist-newstyle --overwrite-policy=always
+        cabal install hlint --installdir=dist-newstyle
         dist-newstyle/hlint src semantic-python
 
     - name: Build & test

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: hlint
       run: |
-        cabal install hlint --installdir=dist-newstyle
+        test -f dist-newstyle/hlint || cabal install hlint --installdir=dist-newstyle
         dist-newstyle/hlint src semantic-python
 
     - name: Build & test

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -183,7 +183,7 @@ steps:
       #   between actual import and closing bracket.
       #
       # Default: true
-      align: true
+      align: false
 
       # stylish-haskell can detect redundancy of some language pragmas. If this
       # is set to true, it will remove those redundant pragmas. Default: true.

--- a/semantic-go/src/Language/Go/Tags.hs
+++ b/semantic-go/src/Language/Go/Tags.hs
@@ -19,7 +19,6 @@ module Language.Go.Tags
 import           AST.Element
 import           Control.Effect.Reader
 import           Control.Effect.Writer
-import           Data.Monoid (Ap (..))
 import           Data.Text as Text
 import           GHC.Generics
 import           Source.Loc
@@ -96,7 +95,7 @@ gtags
      )
   => t Loc
   -> m ()
-gtags = getAp . Tags.foldMap1 @ToTags (const mempty) (Ap . tags) . Tags.Generics
+gtags = Tags.traverse1_ @ToTags (const (pure ())) tags . Tags.Generics
 
 instance (Generic1 t, Tags.GTraversable1 ToTags (Rep1 t)) => ToTagsBy 'Generic t where
   tags' = gtags

--- a/semantic-go/src/Language/Go/Tags.hs
+++ b/semantic-go/src/Language/Go/Tags.hs
@@ -92,13 +92,13 @@ gtags
   :: ( Has (Reader Source) sig m
      , Has (Writer Tags.Tags) sig m
      , Generic1 t
-     , Tags.GFoldable1 ToTags (Rep1 t)
+     , Tags.GTraversable1 ToTags (Rep1 t)
      )
   => t Loc
   -> m ()
-gtags = getAp . Tags.gfoldMap1 @ToTags (Ap . tags) . from1
+gtags = getAp . Tags.foldMap1 @ToTags (const mempty) (Ap . tags) . Tags.Generics
 
-instance (Generic1 t, Tags.GFoldable1 ToTags (Rep1 t)) => ToTagsBy 'Generic t where
+instance (Generic1 t, Tags.GTraversable1 ToTags (Rep1 t)) => ToTagsBy 'Generic t where
   tags' = gtags
 
 yieldTag :: (Has (Reader Source) sig m, Has (Writer Tags.Tags) sig m) => Text -> Kind -> Loc -> Range -> m ()

--- a/semantic-java/src/Language/Java/Tags.hs
+++ b/semantic-java/src/Language/Java/Tags.hs
@@ -5,7 +5,6 @@ module Language.Java.Tags
 
 import           Control.Effect.Reader
 import           Control.Effect.Writer
-import           Data.Monoid (Ap(..))
 import           GHC.Generics
 import           Source.Loc
 import           Source.Range
@@ -94,7 +93,7 @@ gtags
      )
   => t Loc
   -> m ()
-gtags = getAp . Tags.foldMap1 @ToTags (const mempty) (Ap . tags) . Tags.Generics
+gtags = Tags.traverse1_ @ToTags (const (pure ())) tags . Tags.Generics
 
 instance (Generic1 t, Tags.GTraversable1 ToTags (Rep1 t)) => ToTagsBy 'Generic t where
   tags' = gtags

--- a/semantic-java/src/Language/Java/Tags.hs
+++ b/semantic-java/src/Language/Java/Tags.hs
@@ -90,11 +90,11 @@ gtags
   :: ( Has (Reader Source) sig m
      , Has (Writer Tags.Tags) sig m
      , Generic1 t
-     , Tags.GFoldable1 ToTags (Rep1 t)
+     , Tags.GTraversable1 ToTags (Rep1 t)
      )
   => t Loc
   -> m ()
-gtags = getAp . Tags.gfoldMap1 @ToTags (Ap . tags) . from1
+gtags = getAp . Tags.foldMap1 @ToTags (const mempty) (Ap . tags) . Tags.Generics
 
-instance (Generic1 t, Tags.GFoldable1 ToTags (Rep1 t)) => ToTagsBy 'Generic t where
+instance (Generic1 t, Tags.GTraversable1 ToTags (Rep1 t)) => ToTagsBy 'Generic t where
   tags' = gtags

--- a/semantic-python/src/Language/Python/Tags.hs
+++ b/semantic-python/src/Language/Python/Tags.hs
@@ -80,7 +80,7 @@ keywordFunctionCall
   :: ( Has (Reader Source) sig m
      , Has (Writer Tags.Tags) sig m
      , Generic1 t
-     , Tags.GFoldable1 ToTags (Rep1 t)
+     , Tags.GTraversable1 ToTags (Rep1 t)
      )
   => t Loc -> Loc -> Range -> Text -> m ()
 keywordFunctionCall t loc range name = do
@@ -162,11 +162,11 @@ gtags
   :: ( Has (Reader Source) sig m
      , Has (Writer Tags.Tags) sig m
      , Generic1 t
-     , Tags.GFoldable1 ToTags (Rep1 t)
+     , Tags.GTraversable1 ToTags (Rep1 t)
      )
   => t Loc
   -> m ()
-gtags = getAp . Tags.gfoldMap1 @ToTags (Ap . tags) . from1
+gtags = getAp . Tags.foldMap1 @ToTags (const mempty) (Ap . tags) . Tags.Generics
 
-instance (Generic1 t, Tags.GFoldable1 ToTags (Rep1 t)) => ToTagsBy 'Generic t where
+instance (Generic1 t, Tags.GTraversable1 ToTags (Rep1 t)) => ToTagsBy 'Generic t where
   tags' = gtags

--- a/semantic-python/src/Language/Python/Tags.hs
+++ b/semantic-python/src/Language/Python/Tags.hs
@@ -20,7 +20,6 @@ import           AST.Element
 import           Control.Effect.Reader
 import           Control.Effect.Writer
 import           Data.Maybe (listToMaybe)
-import           Data.Monoid (Ap(..))
 import           Data.List.NonEmpty (NonEmpty(..))
 import           Data.Text as Text
 import           GHC.Generics
@@ -166,7 +165,7 @@ gtags
      )
   => t Loc
   -> m ()
-gtags = getAp . Tags.foldMap1 @ToTags (const mempty) (Ap . tags) . Tags.Generics
+gtags = Tags.traverse1_ @ToTags (const (pure ())) tags . Tags.Generics
 
 instance (Generic1 t, Tags.GTraversable1 ToTags (Rep1 t)) => ToTagsBy 'Generic t where
   tags' = gtags

--- a/semantic-ruby/src/Language/Ruby/Tags.hs
+++ b/semantic-ruby/src/Language/Ruby/Tags.hs
@@ -22,7 +22,6 @@ import           Control.Effect.Reader
 import           Control.Effect.State
 import           Control.Effect.Writer
 import           Control.Monad
-import           Data.Monoid (Ap (..))
 import           Data.Foldable
 import           Data.Text as Text
 import           GHC.Generics
@@ -311,7 +310,7 @@ gtags
      )
   => t Loc
   -> m ()
-gtags = getAp . Tags.foldMap1 @ToTags (const mempty) (Ap . tags) . Tags.Generics
+gtags = Tags.traverse1_ @ToTags (const (pure ())) tags . Tags.Generics
 
 instance (Generic1 t, Tags.GTraversable1 ToTags (Rep1 t)) => ToTagsBy 'Generic t where
   tags' = gtags

--- a/semantic-ruby/src/Language/Ruby/Tags.hs
+++ b/semantic-ruby/src/Language/Ruby/Tags.hs
@@ -153,7 +153,7 @@ yieldMethodNameTag
      , Has (Reader Source) sig m
      , Has (Writer Tags.Tags) sig m
      , Generic1 t
-     , Tags.GFoldable1 ToTags (Rep1 t)
+     , Tags.GTraversable1 ToTags (Rep1 t)
      ) => t Loc -> Loc -> Range -> Rb.MethodName Loc -> m ()
 yieldMethodNameTag t loc range (Rb.MethodName expr) = enterScope True $ case expr of
   Prj Rb.Identifier { text = name } -> yield name
@@ -307,11 +307,11 @@ gtags
      , Has (Writer Tags.Tags) sig m
      , Has (State [Text]) sig m
      , Generic1 t
-     , Tags.GFoldable1 ToTags (Rep1 t)
+     , Tags.GTraversable1 ToTags (Rep1 t)
      )
   => t Loc
   -> m ()
-gtags = getAp . Tags.gfoldMap1 @ToTags (Ap . tags) . from1
+gtags = getAp . Tags.foldMap1 @ToTags (const mempty) (Ap . tags) . Tags.Generics
 
-instance (Generic1 t, Tags.GFoldable1 ToTags (Rep1 t)) => ToTagsBy 'Generic t where
+instance (Generic1 t, Tags.GTraversable1 ToTags (Rep1 t)) => ToTagsBy 'Generic t where
   tags' = gtags

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE AllowAmbiguousTypes   #-}
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 module Tags.Tagging.Precise
 ( Tags
 , ToTags(..)

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -6,6 +6,7 @@ module Tags.Tagging.Precise
 , runTagging
 , firstLine
 , GFoldable1(..)
+, GTraversable1(..)
 ) where
 
 import Control.Carrier.Reader
@@ -76,3 +77,6 @@ instance (Foldable f, GFoldable1 c g) => GFoldable1 c (f :.: g) where
 
 instance GFoldable1 c U1 where
   gfoldMap1 _ _ = mempty
+
+
+class GTraversable1 c t where

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -97,6 +97,8 @@ instance GFoldable1 c U1 where
 
 -- FIXME: move Traversable1 into semantic-ast.
 -- FIXME: derive Traversable1 instances for TH-generated syntax types.
+
+-- | Simultaneous traversal of subterms of kind @*@ and @* -> *@ in an 'Applicative' context.
 class Traversable1 c t where
   -- | Map annotations and subterms of kind @* -> *@ into an 'Applicative' context.
   traverse1

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -95,6 +96,13 @@ class Traversable1 c t where
     -> (forall t' . c t' => t' a -> f (t' b))
     -> t a
     -> f (t b)
+  default traverse1
+    :: (Applicative f, Generic1 t, GTraversable1 c (Rep1 t))
+    => (a -> f b)
+    -> (forall t' . c t' => t' a -> f (t' b))
+    -> t a
+    -> f (t b)
+  traverse1 f g = fmap to1 . gtraverse1 @c f g . from1
 
 class GTraversable1 c t where
   -- | Generically map annotations and subterms of kind @* -> *@ into an 'Applicative' context.

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -82,19 +82,20 @@ instance GFoldable1 c U1 where
 class GTraversable1 c t where
   gtraverse1
     :: Applicative f
-    => (forall t' . c t' => t' a -> f (t' b))
+    => (a -> f b)
+    -> (forall t' . c t' => t' a -> f (t' b))
     -> t a
     -> f (t b)
 
 instance GTraversable1 c f => GTraversable1 c (M1 i c' f) where
-  gtraverse1 f = fmap M1 . gtraverse1 @c f . unM1
+  gtraverse1 f g = fmap M1 . gtraverse1 @c f g . unM1
 
 instance (GTraversable1 c f, GTraversable1 c g) => GTraversable1 c (f :*: g) where
-  gtraverse1 f (l :*: r) = (:*:) <$> gtraverse1 @c f l <*> gtraverse1 @c f r
+  gtraverse1 f g (l :*: r) = (:*:) <$> gtraverse1 @c f g l <*> gtraverse1 @c f g r
 
 instance (GTraversable1 c f, GTraversable1 c g) => GTraversable1 c (f :+: g) where
-  gtraverse1 f (L1 l) = L1 <$> gtraverse1 @c f l
-  gtraverse1 f (R1 r) = R1 <$> gtraverse1 @c f r
+  gtraverse1 f g (L1 l) = L1 <$> gtraverse1 @c f g l
+  gtraverse1 f g (R1 r) = R1 <$> gtraverse1 @c f g r
 
 instance GTraversable1 c (K1 R t) where
-  gtraverse1 _ (K1 k) = pure (K1 k)
+  gtraverse1 _ _ (K1 k) = pure (K1 k)

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -96,6 +96,7 @@ instance GFoldable1 c U1 where
 
 
 -- FIXME: move Traversable1 into semantic-ast.
+-- FIXME: derive Traversable1 instances for TH-generated syntax types.
 class Traversable1 c t where
   -- | Map annotations and subterms of kind @* -> *@ into an 'Applicative' context.
   traverse1

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -6,6 +6,7 @@ module Tags.Tagging.Precise
 , runTagging
 , firstLine
 , GFoldable1(..)
+, Traversable1(..)
 , GTraversable1(..)
 ) where
 
@@ -78,6 +79,14 @@ instance (Foldable f, GFoldable1 c g) => GFoldable1 c (f :.: g) where
 instance GFoldable1 c U1 where
   gfoldMap1 _ _ = mempty
 
+
+class Traversable1 c t where
+  traverse1
+    :: Applicative f
+    => (a -> f b)
+    -> (forall t' . c t' => t' a -> f (t' b))
+    -> t a
+    -> f (t b)
 
 class GTraversable1 c t where
   -- | Generically map annotations and subterms of kind @* -> *@ into an 'Applicative' context.

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -90,6 +90,7 @@ instance GFoldable1 c U1 where
 
 
 class Traversable1 c t where
+  -- | Map annotations and subterms of kind @* -> *@ into an 'Applicative' context.
   traverse1
     :: Applicative f
     => (a -> f b)

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -99,6 +99,8 @@ instance GFoldable1 c U1 where
 -- FIXME: derive Traversable1 instances for TH-generated syntax types.
 
 -- | Simultaneous traversal of subterms of kind @*@ and @* -> *@ in an 'Applicative' context.
+--
+-- 'Traversable1' can express any combination of first- and second-order mapping, folding, and traversal.
 class Traversable1 c t where
   -- | Map annotations and subterms of kind @* -> *@ into an 'Applicative' context.
   traverse1

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -95,6 +95,7 @@ instance GFoldable1 c U1 where
   gfoldMap1 _ _ = mempty
 
 
+-- FIXME: move Traversable1 into semantic-ast.
 class Traversable1 c t where
   -- | Map annotations and subterms of kind @* -> *@ into an 'Applicative' context.
   traverse1
@@ -115,6 +116,7 @@ foldMap1 :: forall c t b a . (Traversable1 c t, Monoid b) => (a -> b) -> (forall
 foldMap1 f g = getConst . traverse1 @c (Const . f) (Const . g)
 
 
+-- FIXME: move GTraversable1 into semantic-ast.
 class GTraversable1 c t where
   -- | Generically map annotations and subterms of kind @* -> *@ into an 'Applicative' context.
   gtraverse1

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -105,3 +105,6 @@ instance GTraversable1 c Par1 where
 
 instance (Traversable f, GTraversable1 c g) => GTraversable1 c (f :.: g) where
   gtraverse1 f g = fmap Comp1 . traverse (gtraverse1 @c f g) . unComp1
+
+instance GTraversable1 c U1 where
+  gtraverse1 _ _ _ = pure U1

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -21,6 +21,7 @@ module Tags.Tagging.Precise
 , for1
 , foldMap1
 , foldMapDefault1
+, fmapDefault1
 , GTraversable1(..)
 , Generics(..)
 ) where
@@ -107,6 +108,10 @@ foldMap1 f g = getConst . traverse1 @c (Const . f) (Const . g)
 -- | This function may be used as a value for 'foldMap' in a 'Foldable' instance.
 foldMapDefault1 :: (Traversable1 Foldable t, Monoid b) => (a -> b) -> t a -> b
 foldMapDefault1 f = foldMap1 @Foldable f (foldMap f)
+
+-- | This function may be used as a value for 'fmap' in a 'Functor' instance.
+fmapDefault1 :: Traversable1 Functor t => (a -> b) -> t a -> t b
+fmapDefault1 f = runIdentity . traverse1 @Functor (Identity . f) (Identity . fmap f)
 
 
 -- FIXME: move GTraversable1 into semantic-ast.

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -24,6 +24,7 @@ module Tags.Tagging.Precise
 , foldMap1
 , foldMapDefault1
 , fmapDefault1
+, traverseDefault1
 , GTraversable1(..)
 , Generics(..)
 ) where
@@ -133,6 +134,10 @@ foldMapDefault1 f = foldMap1 @Foldable f (foldMap f)
 -- | This function may be used as a value for 'fmap' in a 'Functor' instance.
 fmapDefault1 :: Traversable1 Functor t => (a -> b) -> t a -> t b
 fmapDefault1 f = runIdentity . traverse1 @Functor (Identity . f) (Identity . fmap f)
+
+-- | This function may be used as a value for 'traverse' in a 'Traversable' instance.
+traverseDefault1 :: (Traversable1 Traversable t, Applicative f) => (a -> f b) -> t a -> f (t b)
+traverseDefault1 f = traverse1 @Traversable f (traverse f)
 
 
 -- FIXME: move GTraversable1 into semantic-ast.

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -102,7 +102,7 @@ instance GFoldable1 c U1 where
 --
 -- 'Traversable1' can express any combination of first- and second-order mapping, folding, and traversal.
 class Traversable1 c t where
-  -- | Map annotations and subterms of kind @* -> *@ into an 'Applicative' context.
+  -- | Map annotations of kind @*@ and heterogeneously-typed subterms of kind @* -> *@ under some constraint @c@ into an 'Applicative' context.
   --
   -- Note that this traversal is non-recursive: any recursion through subterms must be performed by the second function argument.
   traverse1

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -91,3 +91,7 @@ instance GTraversable1 c f => GTraversable1 c (M1 i c' f) where
 
 instance (GTraversable1 c f, GTraversable1 c g) => GTraversable1 c (f :*: g) where
   gtraverse1 f (l :*: r) = (:*:) <$> gtraverse1 @c f l <*> gtraverse1 @c f r
+
+instance (GTraversable1 c f, GTraversable1 c g) => GTraversable1 c (f :+: g) where
+  gtraverse1 f (L1 l) = L1 <$> gtraverse1 @c f l
+  gtraverse1 f (R1 r) = R1 <$> gtraverse1 @c f r

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -148,3 +150,4 @@ instance GTraversable1 c U1 where
 
 
 newtype Generics t a = Generics { getGenerics :: t a }
+  deriving (Foldable, Functor, Traversable)

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -16,11 +16,13 @@ module Tags.Tagging.Precise
 , firstLine
 , GFoldable1(..)
 , Traversable1(..)
+, foldMap1
 , GTraversable1(..)
 ) where
 
 import Control.Carrier.Reader
 import Control.Carrier.Writer.Strict
+import Data.Functor.Const
 import Data.Functor.Identity
 import Data.Monoid (Endo (..))
 import Data.Text as Text (Text, takeWhile)
@@ -104,6 +106,10 @@ class Traversable1 c t where
     -> t a
     -> f (t b)
   traverse1 f g = fmap to1 . gtraverse1 @c f g . from1
+
+foldMap1 :: forall c t b a . (Traversable1 c t, Monoid b) => (a -> b) -> (forall t' . c t' => t' a -> b) -> t a -> b
+foldMap1 f g = getConst . traverse1 @c (Const . f) (Const . g)
+
 
 class GTraversable1 c t where
   -- | Generically map annotations and subterms of kind @* -> *@ into an 'Applicative' context.

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -102,7 +102,7 @@ instance GFoldable1 c U1 where
 --
 -- 'Traversable1' can express any combination of first- and second-order mapping, folding, and traversal.
 class Traversable1 c t where
-  -- | Map annotations of kind @*@ and heterogeneously-typed subterms of kind @* -> *@ under some constraint @c@ into an 'Applicative' context.
+  -- | Map annotations of kind @*@ and heterogeneously-typed subterms of kind @* -> *@ under some constraint @c@ into an 'Applicative' context. The constraint is necessary to operate on otherwise universally-quantified subterms, since otherwise there would be insufficient information to inspect them at all.
   --
   -- Note that this traversal is non-recursive: any recursion through subterms must be performed by the second function argument.
   traverse1

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -104,6 +104,12 @@ instance GFoldable1 c U1 where
 class Traversable1 c t where
   -- | Map annotations of kind @*@ and heterogeneously-typed subterms of kind @* -> *@ under some constraint @c@ into an 'Applicative' context. The constraint is necessary to operate on otherwise universally-quantified subterms, since otherwise there would be insufficient information to inspect them at all.
   --
+  -- No proxy is provided for the constraint @c@; instead, @-XTypeApplications@ should be used. E.g. here we ignore the annotations and print all the @* -> *@ subterms using 'Show1':
+  --
+  -- @
+  -- 'traverse1' \@'Data.Functor.Classes.Show1' 'pure' (\ t -> t '<$' 'putStrLn' ('Data.Functor.Classes.showsPrec1' 0 t ""))
+  -- @
+  --
   -- Note that this traversal is non-recursive: any recursion through subterms must be performed by the second function argument.
   traverse1
     :: Applicative f

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -150,6 +150,11 @@ instance GTraversable1 c U1 where
   gtraverse1 _ _ _ = pure U1
 
 
+-- | @'Generics' t@ has a 'Traversable1' instance when @'Rep1' t@ has a 'GTraversable1' instance, making this convenient for applying 'traverse1' to 'Generic1' types lacking 'Traversable1' instances:
+--
+-- @
+-- 'getGenerics' '<$>' 'traverse1' f g ('Generics' t) = 'to1' '<$>' 'gtraverse1' f g ('from1' t)
+-- @
 newtype Generics t a = Generics { getGenerics :: t a }
   deriving (Foldable, Functor, Traversable)
 

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
-{-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -182,7 +181,15 @@ instance GTraversable1 c U1 where
 -- 'getGenerics' '<$>' 'traverse1' f g ('Generics' t) = 'to1' '<$>' 'gtraverse1' f g ('from1' t)
 -- @
 newtype Generics t a = Generics { getGenerics :: t a }
-  deriving (Foldable, Functor, Traversable)
+
+instance (Generic1 t, GTraversable1 Foldable (Rep1 t)) => Foldable (Generics t) where
+  foldMap = foldMapDefault1
+
+instance (Generic1 t, GTraversable1 Functor (Rep1 t)) => Functor (Generics t) where
+  fmap = fmapDefault1
+
+instance (Generic1 t, GTraversable1 Foldable (Rep1 t), GTraversable1 Functor (Rep1 t), GTraversable1 Traversable (Rep1 t)) => Traversable (Generics t) where
+  traverse = traverseDefault1
 
 instance (Generic1 t, GTraversable1 c (Rep1 t)) => Traversable1 c (Generics t) where
   traverse1 f g = fmap (Generics . to1) . gtraverse1 @c f g . from1 . getGenerics

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -88,3 +88,6 @@ class GTraversable1 c t where
 
 instance GTraversable1 c f => GTraversable1 c (M1 i c' f) where
   gtraverse1 f = fmap M1 . gtraverse1 @c f . unM1
+
+instance (GTraversable1 c f, GTraversable1 c g) => GTraversable1 c (f :*: g) where
+  gtraverse1 f (l :*: r) = (:*:) <$> gtraverse1 @c f l <*> gtraverse1 @c f r

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Tags.Tagging.Precise
 ( Tags
 , ToTags(..)
@@ -151,3 +152,6 @@ instance GTraversable1 c U1 where
 
 newtype Generics t a = Generics { getGenerics :: t a }
   deriving (Foldable, Functor, Traversable)
+
+instance (Generic1 t, GTraversable1 c (Rep1 t)) => Traversable1 c (Generics t) where
+  traverse1 f g = fmap (Generics . to1) . gtraverse1 @c f g . from1 . getGenerics

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -70,6 +70,8 @@ firstLine = Text.takeWhile (/= '\n') . toText . Source.take 180
 -- | Simultaneous traversal of subterms of kind @*@ and @* -> *@ in an 'Applicative' context.
 --
 -- 'Traversable1' can express any combination of first- and second-order mapping, folding, and traversal.
+--
+-- Note that the @1@ suffix is used in the manner of 'Data.Functor.Classes.Show1' or 'Generic1', rather than 'foldr1'; it’s a higher-order traversal which is simultaneously able to traverse (and alter) annotations.
 class Traversable1 c t where
   -- | Map annotations of kind @*@ and heterogeneously-typed subterms of kind @* -> *@ under some constraint @c@ into an 'Applicative' context. The constraint is necessary to operate on otherwise universally-quantified subterms, since otherwise there would be insufficient information to inspect them at all.
   --

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -20,6 +20,7 @@ module Tags.Tagging.Precise
 , Traversable1(..)
 , for1
 , traverse1_
+, for1_
 , foldMap1
 , foldMapDefault1
 , fmapDefault1
@@ -111,6 +112,15 @@ traverse1_
   -> t a
   -> f ()
 traverse1_ f g = getAp . foldMap1 @c (Ap . void . f) (Ap . void . g)
+
+for1_
+  :: forall c t f a a' a''
+  .  (Traversable1 c t, Applicative f)
+  => t a
+  -> (a -> f a')
+  -> (forall t' . c t' => t' a -> f a'')
+  -> f ()
+for1_ t f g = getAp $ foldMap1 @c (Ap . void . f) (Ap . void . g) t
 
 foldMap1 :: forall c t b a . (Traversable1 c t, Monoid b) => (a -> b) -> (forall t' . c t' => t' a -> b) -> t a -> b
 foldMap1 f g = getConst . traverse1 @c (Const . f) (Const . g)

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -103,6 +103,9 @@ instance GTraversable1 c (K1 R t) where
 instance GTraversable1 c Par1 where
   gtraverse1 f _ (Par1 a) = Par1 <$> f a
 
+instance c t => GTraversable1 c (Rec1 t) where
+  gtraverse1 _ g (Rec1 t) = Rec1 <$> g t
+
 instance (Traversable f, GTraversable1 c g) => GTraversable1 c (f :.: g) where
   gtraverse1 f g = fmap Comp1 . traverse (gtraverse1 @c f g) . unComp1
 

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -17,7 +17,6 @@ module Tags.Tagging.Precise
 , yield
 , runTagging
 , firstLine
-, GFoldable1(..)
 , Traversable1(..)
 , for1
 , foldMap1
@@ -59,41 +58,6 @@ runTagging source
 
 firstLine :: Source -> Text
 firstLine = Text.takeWhile (/= '\n') . toText . Source.take 180
-
-
--- FIXME: move GFoldable1 into semantic-ast.
-class GFoldable1 c t where
-  -- | Generically map functions over fields of kind @* -> *@, monoidally combining the results.
-  gfoldMap1
-    :: Monoid b
-    => (forall f . c f => f a -> b)
-    -> t a
-    -> b
-
-instance GFoldable1 c f => GFoldable1 c (M1 i c' f) where
-  gfoldMap1 alg = gfoldMap1 @c alg . unM1
-
-instance (GFoldable1 c f, GFoldable1 c g) => GFoldable1 c (f :*: g) where
-  gfoldMap1 alg (f :*: g) = gfoldMap1 @c alg f <> gfoldMap1 @c alg g
-
-instance (GFoldable1 c f, GFoldable1 c g) => GFoldable1 c (f :+: g) where
-  gfoldMap1 alg (L1 l) = gfoldMap1 @c alg l
-  gfoldMap1 alg (R1 r) = gfoldMap1 @c alg r
-
-instance GFoldable1 c (K1 R t) where
-  gfoldMap1 _ _ = mempty
-
-instance GFoldable1 c Par1 where
-  gfoldMap1 _ _ = mempty
-
-instance c t => GFoldable1 c (Rec1 t) where
-  gfoldMap1 alg (Rec1 t) = alg t
-
-instance (Foldable f, GFoldable1 c g) => GFoldable1 c (f :.: g) where
-  gfoldMap1 alg = foldMap (gfoldMap1 @c alg) . unComp1
-
-instance GFoldable1 c U1 where
-  gfoldMap1 _ _ = mempty
 
 
 -- FIXME: move Traversable1 into semantic-ast.

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -95,3 +95,6 @@ instance (GTraversable1 c f, GTraversable1 c g) => GTraversable1 c (f :*: g) whe
 instance (GTraversable1 c f, GTraversable1 c g) => GTraversable1 c (f :+: g) where
   gtraverse1 f (L1 l) = L1 <$> gtraverse1 @c f l
   gtraverse1 f (R1 r) = R1 <$> gtraverse1 @c f r
+
+instance GTraversable1 c (K1 R t) where
+  gtraverse1 _ (K1 k) = pure (K1 k)

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -19,6 +19,7 @@ module Tags.Tagging.Precise
 , firstLine
 , GFoldable1(..)
 , Traversable1(..)
+, for1
 , foldMap1
 , GTraversable1(..)
 , Generics(..)
@@ -124,6 +125,15 @@ class Traversable1 c t where
     -> t a
     -> f (t b)
   traverse1 f g = fmap to1 . gtraverse1 @c f g . from1
+
+for1
+  :: forall c t f a b
+  .  (Traversable1 c t, Applicative f)
+  => t a
+  -> (a -> f b)
+  -> (forall t' . c t' => t' a -> f (t' b))
+  -> f (t b)
+for1 t f g = traverse1 @c f g t
 
 foldMap1 :: forall c t b a . (Traversable1 c t, Monoid b) => (a -> b) -> (forall t' . c t' => t' a -> b) -> t a -> b
 foldMap1 f g = getConst . traverse1 @c (Const . f) (Const . g)

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -19,6 +19,7 @@ module Tags.Tagging.Precise
 , firstLine
 , Traversable1(..)
 , for1
+, traverse1_
 , foldMap1
 , foldMapDefault1
 , fmapDefault1
@@ -28,9 +29,10 @@ module Tags.Tagging.Precise
 
 import Control.Carrier.Reader
 import Control.Carrier.Writer.Strict
+import Data.Functor (void)
 import Data.Functor.Const
 import Data.Functor.Identity
-import Data.Monoid (Endo (..))
+import Data.Monoid (Ap (..), Endo (..))
 import Data.Text as Text (Text, takeWhile)
 import GHC.Generics
 import Prelude hiding (span)
@@ -100,6 +102,15 @@ for1
   -> (forall t' . c t' => t' a -> f (t' b))
   -> f (t b)
 for1 t f g = traverse1 @c f g t
+
+traverse1_
+  :: forall c t f a a' a''
+  .  (Traversable1 c t, Applicative f)
+  => (a -> f a')
+  -> (forall t' . c t' => t' a -> f a'')
+  -> t a
+  -> f ()
+traverse1_ f g = getAp . foldMap1 @c (Ap . void . f) (Ap . void . g)
 
 foldMap1 :: forall c t b a . (Traversable1 c t, Monoid b) => (a -> b) -> (forall t' . c t' => t' a -> b) -> t a -> b
 foldMap1 f g = getConst . traverse1 @c (Const . f) (Const . g)

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -102,3 +102,6 @@ instance GTraversable1 c (K1 R t) where
 
 instance GTraversable1 c Par1 where
   gtraverse1 f _ (Par1 a) = Par1 <$> f a
+
+instance (Traversable f, GTraversable1 c g) => GTraversable1 c (f :.: g) where
+  gtraverse1 f g = fmap Comp1 . traverse (gtraverse1 @c f g) . unComp1

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -85,3 +85,6 @@ class GTraversable1 c t where
     => (forall t' . c t' => t' a -> f (t' b))
     -> t a
     -> f (t b)
+
+instance GTraversable1 c f => GTraversable1 c (M1 i c' f) where
+  gtraverse1 f = fmap M1 . gtraverse1 @c f . unM1

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -80,6 +80,7 @@ instance GFoldable1 c U1 where
 
 
 class GTraversable1 c t where
+  -- | Generically map annotations and subterms of kind @* -> *@ into an 'Applicative' context.
   gtraverse1
     :: Applicative f
     => (a -> f b)

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -103,6 +103,8 @@ instance GFoldable1 c U1 where
 -- 'Traversable1' can express any combination of first- and second-order mapping, folding, and traversal.
 class Traversable1 c t where
   -- | Map annotations and subterms of kind @* -> *@ into an 'Applicative' context.
+  --
+  -- Note that this traversal is non-recursive: any recursion through subterms must be performed by the second function argument.
   traverse1
     :: Applicative f
     => (a -> f b)

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -179,6 +179,8 @@ instance GTraversable1 c U1 where
 -- @
 -- 'getGenerics' '<$>' 'traverse1' f g ('Generics' t) = 'to1' '<$>' 'gtraverse1' f g ('from1' t)
 -- @
+--
+-- It further defines its 'Foldable', 'Functor', and 'Traversable' instances thus, making it suitable for use with @-XDerivingVia@.
 newtype Generics t a = Generics { getGenerics :: t a }
 
 instance (Generic1 t, GTraversable1 Foldable (Rep1 t)) => Foldable (Generics t) where

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -80,3 +80,8 @@ instance GFoldable1 c U1 where
 
 
 class GTraversable1 c t where
+  gtraverse1
+    :: Applicative f
+    => (forall t' . c t' => t' a -> f (t' b))
+    -> t a
+    -> f (t b)

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -20,6 +20,7 @@ module Tags.Tagging.Precise
 , Traversable1(..)
 , for1
 , foldMap1
+, foldMapDefault1
 , GTraversable1(..)
 , Generics(..)
 ) where
@@ -101,6 +102,11 @@ for1 t f g = traverse1 @c f g t
 
 foldMap1 :: forall c t b a . (Traversable1 c t, Monoid b) => (a -> b) -> (forall t' . c t' => t' a -> b) -> t a -> b
 foldMap1 f g = getConst . traverse1 @c (Const . f) (Const . g)
+
+
+-- | This function may be used as a value for 'foldMap' in a 'Foldable' instance.
+foldMapDefault1 :: (Traversable1 Foldable t, Monoid b) => (a -> b) -> t a -> b
+foldMapDefault1 f = foldMap1 @Foldable f (foldMap f)
 
 
 -- FIXME: move GTraversable1 into semantic-ast.

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -18,6 +18,7 @@ module Tags.Tagging.Precise
 , Traversable1(..)
 , foldMap1
 , GTraversable1(..)
+, Generics(..)
 ) where
 
 import Control.Carrier.Reader
@@ -144,3 +145,6 @@ instance (Traversable f, GTraversable1 c g) => GTraversable1 c (f :.: g) where
 
 instance GTraversable1 c U1 where
   gtraverse1 _ _ _ = pure U1
+
+
+newtype Generics t a = Generics { getGenerics :: t a }

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -99,3 +99,6 @@ instance (GTraversable1 c f, GTraversable1 c g) => GTraversable1 c (f :+: g) whe
 
 instance GTraversable1 c (K1 R t) where
   gtraverse1 _ _ (K1 k) = pure (K1 k)
+
+instance GTraversable1 c Par1 where
+  gtraverse1 f _ (Par1 a) = Par1 <$> f a

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -180,7 +180,7 @@ instance GTraversable1 c U1 where
 -- 'getGenerics' '<$>' 'traverse1' f g ('Generics' t) = 'to1' '<$>' 'gtraverse1' f g ('from1' t)
 -- @
 --
--- It further defines its 'Foldable', 'Functor', and 'Traversable' instances thus, making it suitable for use with @-XDerivingVia@.
+-- It further defines its 'Foldable', 'Functor', and 'Traversable' instances using 'Traversable1', making it suitable for deriving with @-XDerivingVia@.
 newtype Generics t a = Generics { getGenerics :: t a }
 
 instance (Generic1 t, GTraversable1 Foldable (Rep1 t)) => Foldable (Generics t) where

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -1,4 +1,12 @@
-{-# LANGUAGE AllowAmbiguousTypes, ConstraintKinds, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, RankNTypes, ScopedTypeVariables, TypeApplications, TypeOperators #-}
+{-# LANGUAGE AllowAmbiguousTypes   #-}
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeOperators         #-}
 module Tags.Tagging.Precise
 ( Tags
 , ToTags(..)
@@ -13,13 +21,13 @@ module Tags.Tagging.Precise
 import Control.Carrier.Reader
 import Control.Carrier.Writer.Strict
 import Data.Functor.Identity
-import Data.Monoid (Endo(..))
+import Data.Monoid (Endo (..))
 import Data.Text as Text (Text, takeWhile)
 import GHC.Generics
 import Prelude hiding (span)
-import Source.Loc (Loc(..))
-import Source.Span
+import Source.Loc (Loc (..))
 import Source.Source as Source
+import Source.Span
 import Tags.Tag
 
 type Tags = Endo [Tag]

--- a/semantic-tsx/src/Language/TSX/Tags.hs
+++ b/semantic-tsx/src/Language/TSX/Tags.hs
@@ -21,7 +21,6 @@ import           AST.Element
 import           Control.Effect.Reader
 import           Control.Effect.Writer
 import           Data.Foldable
-import           Data.Monoid (Ap (..))
 import           Data.Text as Text
 import           GHC.Generics
 import           Source.Loc
@@ -137,7 +136,7 @@ gtags
      )
   => t Loc
   -> m ()
-gtags = getAp . Tags.foldMap1 @ToTags (const mempty) (Ap . tags) . Tags.Generics
+gtags = Tags.traverse1_ @ToTags (const (pure ())) tags . Tags.Generics
 
 instance (Generic1 t, Tags.GTraversable1 ToTags (Rep1 t)) => ToTagsBy 'Generic t where
   tags' = gtags

--- a/semantic-tsx/src/Language/TSX/Tags.hs
+++ b/semantic-tsx/src/Language/TSX/Tags.hs
@@ -133,13 +133,13 @@ gtags
   :: ( Has (Reader Source) sig m
      , Has (Writer Tags.Tags) sig m
      , Generic1 t
-     , Tags.GFoldable1 ToTags (Rep1 t)
+     , Tags.GTraversable1 ToTags (Rep1 t)
      )
   => t Loc
   -> m ()
-gtags = getAp . Tags.gfoldMap1 @ToTags (Ap . tags) . from1
+gtags = getAp . Tags.foldMap1 @ToTags (const mempty) (Ap . tags) . Tags.Generics
 
-instance (Generic1 t, Tags.GFoldable1 ToTags (Rep1 t)) => ToTagsBy 'Generic t where
+instance (Generic1 t, Tags.GTraversable1 ToTags (Rep1 t)) => ToTagsBy 'Generic t where
   tags' = gtags
 
 yieldTag :: (Has (Reader Source) sig m, Has (Writer Tags.Tags) sig m) => Text -> Kind -> Loc -> Range -> m ()

--- a/semantic-typescript/src/Language/TypeScript/Tags.hs
+++ b/semantic-typescript/src/Language/TypeScript/Tags.hs
@@ -21,7 +21,6 @@ import           AST.Element
 import           Control.Effect.Reader
 import           Control.Effect.Writer
 import           Data.Foldable
-import           Data.Monoid (Ap (..))
 import           Data.Text as Text
 import           GHC.Generics
 import           Source.Loc
@@ -129,7 +128,7 @@ gtags
      )
   => t Loc
   -> m ()
-gtags = getAp . Tags.foldMap1 @ToTags (const mempty) (Ap . tags) . Tags.Generics
+gtags = Tags.traverse1_ @ToTags (const (pure ())) tags . Tags.Generics
 
 instance (Generic1 t, Tags.GTraversable1 ToTags (Rep1 t)) => ToTagsBy 'Generic t where
   tags' = gtags

--- a/semantic-typescript/src/Language/TypeScript/Tags.hs
+++ b/semantic-typescript/src/Language/TypeScript/Tags.hs
@@ -125,13 +125,13 @@ gtags
   :: ( Has (Reader Source) sig m
      , Has (Writer Tags.Tags) sig m
      , Generic1 t
-     , Tags.GFoldable1 ToTags (Rep1 t)
+     , Tags.GTraversable1 ToTags (Rep1 t)
      )
   => t Loc
   -> m ()
-gtags = getAp . Tags.gfoldMap1 @ToTags (Ap . tags) . from1
+gtags = getAp . Tags.foldMap1 @ToTags (const mempty) (Ap . tags) . Tags.Generics
 
-instance (Generic1 t, Tags.GFoldable1 ToTags (Rep1 t)) => ToTagsBy 'Generic t where
+instance (Generic1 t, Tags.GTraversable1 ToTags (Rep1 t)) => ToTagsBy 'Generic t where
   tags' = gtags
 
 yieldTag :: (Has (Reader Source) sig m, Has (Writer Tags.Tags) sig m) => Text -> Kind -> Loc -> Range -> m ()


### PR DESCRIPTION
This PR replaces the `GFoldable1` class with a `Traversable1` class, its generic counterpart, and a `Generics` newtype suitable for bridging the two until such time as we derive `Traversable1` instances for our TH-generated AST datatypes.