### PR TITLE
Can't take 180 bytes and then convert to Text

### DIFF
--- a/semantic-analysis/semantic-analysis.cabal
+++ b/semantic-analysis/semantic-analysis.cabal
@@ -66,7 +66,7 @@ library
     , pathtype                    ^>= 0.8.1
     , prettyprinter                >= 1.2 && < 2
     , prettyprinter-ansi-terminal ^>= 1.1.1
-    , semantic-source             ^>= 0
+    , semantic-source             ^>= 0.0.1
     , terminal-size               ^>= 0.3
     , text                        ^>= 1.2.3.1
     , transformers                ^>= 0.5

--- a/semantic-ast/semantic-ast.cabal
+++ b/semantic-ast/semantic-ast.cabal
@@ -42,7 +42,7 @@ library
   -- other-extensions:
   build-depends:       base ^>= 4.13
                      , tree-sitter ^>= 0.8
-                     , semantic-source ^>= 0.0
+                     , semantic-source ^>= 0.0.1
                      , tree-sitter-python ^>= 0.8.1
                      , bytestring ^>= 0.10.8.2
                      , optparse-applicative >= 0.14.3 && < 0.16

--- a/semantic-core/semantic-core.cabal
+++ b/semantic-core/semantic-core.cabal
@@ -54,7 +54,7 @@ library
     , prettyprinter                >= 1.2.1 && < 2
     , prettyprinter-ansi-terminal ^>= 1.1.1
     , semantic-analysis           ^>= 0
-    , semantic-source             ^>= 0
+    , semantic-source             ^>= 0.0.1
     , text                        ^>= 1.2.3.1
     , trifecta                     >= 2 && < 2.2
     , unordered-containers        ^>= 0.2.10
@@ -69,7 +69,7 @@ test-suite test
       base
     , semantic-analysis
     , semantic-core
-    , semantic-source ^>= 0
+    , semantic-source ^>= 0.0.1
     , fused-effects
     , fused-syntax
     , hedgehog ^>= 1

--- a/semantic-go/semantic-go.cabal
+++ b/semantic-go/semantic-go.cabal
@@ -25,7 +25,7 @@ common haskell
                      , fused-syntax
                      , parsers ^>= 0.12.10
                      , semantic-core ^>= 0.0
-                     , semantic-source ^>= 0.0
+                     , semantic-source ^>= 0.0.1
                      , semantic-tags ^>= 0.0
                      , text ^>= 1.2.3
                      , tree-sitter ^>= 0.8

--- a/semantic-go/src/Language/Go/Tags.hs
+++ b/semantic-go/src/Language/Go/Tags.hs
@@ -82,8 +82,7 @@ gtags = Tags.traverse1_ @ToTags (const (pure ())) tags . Tags.Generics
 yieldTag :: (Has (Reader Source) sig m, Has (Writer Tags.Tags) sig m) => Text -> Kind -> Loc -> Range -> m ()
 yieldTag name kind loc range = do
   src <- ask @Source
-  let sliced = slice src range
-  Tags.yield (Tag name kind loc (Tags.firstLine sliced) Nothing)
+  Tags.yield (Tag name kind loc (Tags.firstLine src range) Nothing)
 
 
 instance ToTags Go.ArgumentList

--- a/semantic-java/semantic-java.cabal
+++ b/semantic-java/semantic-java.cabal
@@ -25,7 +25,7 @@ library
   build-depends:
       base              >= 4.13 && < 5
     , fused-effects    ^>= 1.0
-    , semantic-source  ^>= 0.0
+    , semantic-source  ^>= 0.0.1
     , semantic-tags    ^>= 0.0
     , tree-sitter      ^>= 0.8
     , tree-sitter-java ^>= 0.6.1

--- a/semantic-java/src/Language/Java/Tags.hs
+++ b/semantic-java/src/Language/Java/Tags.hs
@@ -49,12 +49,12 @@ instance ToTags Java.MethodDeclaration where
     , body
     } = do
       src <- ask @Source
-      let sliced = slice src range
+      let line = Tags.firstLine src range
             { end = case body of
               Just Java.Block { ann = Loc Range { end } _ } -> end
               Nothing                                       -> end range
             }
-      Tags.yield (Tag name Method loc (Tags.firstLine sliced) Nothing)
+      Tags.yield (Tag name Method loc line Nothing)
       gtags t
 
 instance ToTags Java.ClassDeclaration where
@@ -64,8 +64,7 @@ instance ToTags Java.ClassDeclaration where
     , body = Java.ClassBody { ann = Loc Range { start = end } _ }
     } = do
       src <- ask @Source
-      let sliced = slice src (Range start end)
-      Tags.yield (Tag name Class loc (Tags.firstLine sliced) Nothing)
+      Tags.yield (Tag name Class loc (Tags.firstLine src (Range start end)) Nothing)
       gtags t
 
 instance ToTags Java.MethodInvocation where
@@ -74,8 +73,7 @@ instance ToTags Java.MethodInvocation where
     , name = Java.Identifier { text = name }
     } = do
       src <- ask @Source
-      let sliced = slice src range
-      Tags.yield (Tag name Call loc (Tags.firstLine sliced) Nothing)
+      Tags.yield (Tag name Call loc (Tags.firstLine src range) Nothing)
       gtags t
 
 

--- a/semantic-python/semantic-python.cabal
+++ b/semantic-python/semantic-python.cabal
@@ -25,7 +25,7 @@ common haskell
                      , fused-syntax
                      , parsers ^>= 0.12.10
                      , semantic-core ^>= 0.0
-                     , semantic-source ^>= 0.0
+                     , semantic-source ^>= 0.0.1
                      , semantic-tags ^>= 0.0
                      , text ^>= 1.2.3
                      , tree-sitter ^>= 0.8

--- a/semantic-python/src/Language/Python/Tags.hs
+++ b/semantic-python/src/Language/Python/Tags.hs
@@ -117,8 +117,7 @@ instance ToTags Py.Call where
 yieldTag :: (Has (Reader Source) sig m, Has (Writer Tags.Tags) sig m) => Text -> Kind -> Loc -> Range -> Maybe Text -> m ()
 yieldTag name kind loc range docs = do
   src <- ask @Source
-  let sliced = Tags.firstLine (slice src range)
-  Tags.yield (Tag name kind loc sliced docs)
+  Tags.yield (Tag name kind loc (Tags.firstLine src range) docs)
 
 docComment :: Source -> (Py.CompoundStatement :+: Py.SimpleStatement) Loc -> Maybe Text
 docComment src (R1 (Py.SimpleStatement (Prj Py.ExpressionStatement { extraChildren = L1 (Prj (Py.Expression (Prj (Py.PrimaryExpression (Prj Py.String { ann }))))) :|_ }))) = Just (toText (slice src (byteRange ann)))

--- a/semantic-ruby/semantic-ruby.cabal
+++ b/semantic-ruby/semantic-ruby.cabal
@@ -25,7 +25,7 @@ common haskell
                      , fused-syntax
                      , parsers ^>= 0.12.10
                      , semantic-core ^>= 0.0
-                     , semantic-source ^>= 0.0
+                     , semantic-source ^>= 0.0.1
                      , semantic-tags ^>= 0.0
                      , text ^>= 1.2.3
                      , tree-sitter ^>= 0.8

--- a/semantic-ruby/src/Language/Ruby/Tags.hs
+++ b/semantic-ruby/src/Language/Ruby/Tags.hs
@@ -74,8 +74,7 @@ yieldTag :: (Has (Reader Source) sig m, Has (Writer Tags.Tags) sig m) => Text ->
 yieldTag name Call _ _ | name `elem` nameBlacklist = pure ()
 yieldTag name kind loc range = do
   src <- ask @Source
-  let sliced = slice src range
-  Tags.yield (Tag name kind loc (Tags.firstLine sliced) Nothing)
+  Tags.yield (Tag name kind loc (Tags.firstLine src range) Nothing)
 
 instance ToTags Rb.Class where
   tags t@Rb.Class

--- a/semantic-tags/semantic-tags.cabal
+++ b/semantic-tags/semantic-tags.cabal
@@ -26,7 +26,7 @@ library
   build-depends:
       base                >= 4.13 && < 5
     , fused-effects      ^>= 1.0
-    , semantic-source    ^>= 0.0
+    , semantic-source    ^>= 0.0.1
     , text               ^>= 1.2.3.1
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -38,6 +38,7 @@ import GHC.Generics
 import Prelude hiding (span)
 import Source.Loc (Loc (..))
 import Source.Source as Source
+import Source.Range (Range)
 import Source.Span
 import Tags.Tag
 
@@ -60,8 +61,9 @@ runTagging source
   . execWriter
   . runReader source
 
-firstLine :: Source -> Text
-firstLine = Text.stripEnd . Text.take 180 . Text.takeWhile (/= '\n') . Source.toText
+-- | Slices a range out of 'Source' and gives back the first line of source up to 180 characters.
+firstLine :: Source -> Range -> Text
+firstLine src = Text.stripEnd . Text.take 180 . Text.takeWhile (/= '\n') . Source.toText . slice src
 
 
 -- FIXME: move Traversable1 into semantic-ast.

--- a/semantic-tags/src/Tags/Tagging/Precise.hs
+++ b/semantic-tags/src/Tags/Tagging/Precise.hs
@@ -33,7 +33,7 @@ import Data.Functor (void)
 import Data.Functor.Const
 import Data.Functor.Identity
 import Data.Monoid (Ap (..), Endo (..))
-import Data.Text as Text (Text, takeWhile, stripEnd)
+import Data.Text as Text (Text, take, takeWhile, stripEnd)
 import GHC.Generics
 import Prelude hiding (span)
 import Source.Loc (Loc (..))
@@ -61,7 +61,7 @@ runTagging source
   . runReader source
 
 firstLine :: Source -> Text
-firstLine = Text.stripEnd . Text.takeWhile (/= '\n') . toText . Source.take 180
+firstLine = Text.stripEnd . Text.take 180 . Text.takeWhile (/= '\n') . Source.toText
 
 
 -- FIXME: move Traversable1 into semantic-ast.

--- a/semantic-tsx/semantic-tsx.cabal
+++ b/semantic-tsx/semantic-tsx.cabal
@@ -25,7 +25,7 @@ common haskell
                      , fused-syntax
                      , parsers ^>= 0.12.10
                      , semantic-core ^>= 0.0
-                     , semantic-source ^>= 0.0
+                     , semantic-source ^>= 0.0.1
                      , semantic-tags ^>= 0.0
                      , text ^>= 1.2.3
                      , tree-sitter ^>= 0.8

--- a/semantic-tsx/src/Language/TSX/Tags.hs
+++ b/semantic-tsx/src/Language/TSX/Tags.hs
@@ -128,8 +128,7 @@ yieldTag :: (Has (Reader Source) sig m, Has (Writer Tags.Tags) sig m) => Text ->
 yieldTag name Call _ _ | name `elem` nameBlacklist = pure ()
 yieldTag name kind loc range = do
   src <- ask @Source
-  let sliced = slice src range
-  Tags.yield (Tag name kind loc (Tags.firstLine sliced) Nothing)
+  Tags.yield (Tag name kind loc (Tags.firstLine src range) Nothing)
 
 instance ToTags Tsx.AbstractClassDeclaration
 instance ToTags Tsx.AbstractMethodSignature

--- a/semantic-typescript/semantic-typescript.cabal
+++ b/semantic-typescript/semantic-typescript.cabal
@@ -25,7 +25,7 @@ common haskell
                      , fused-syntax
                      , parsers ^>= 0.12.10
                      , semantic-core ^>= 0.0
-                     , semantic-source ^>= 0.0
+                     , semantic-source ^>= 0.0.1
                      , semantic-tags ^>= 0.0
                      , text ^>= 1.2.3
                      , tree-sitter ^>= 0.8

--- a/semantic-typescript/src/Language/TypeScript/Tags.hs
+++ b/semantic-typescript/src/Language/TypeScript/Tags.hs
@@ -121,8 +121,7 @@ yieldTag :: (Has (Reader Source) sig m, Has (Writer Tags.Tags) sig m) => Text ->
 yieldTag name Call _ _ | name `elem` nameBlacklist = pure ()
 yieldTag name kind loc range = do
   src <- ask @Source
-  let sliced = slice src range
-  Tags.yield (Tag name kind loc (Tags.firstLine sliced) Nothing)
+  Tags.yield (Tag name kind loc (Tags.firstLine src range) Nothing)
 
 instance ToTags Ts.AbstractClassDeclaration
 instance ToTags Ts.AbstractMethodSignature

--- a/semantic.cabal
+++ b/semantic.cabal
@@ -67,7 +67,7 @@ common dependencies
                      , recursion-schemes ^>= 5.1
                      , scientific ^>= 0.3.6.2
                      , safe-exceptions ^>= 0.1.7.0
-                     , semantic-source ^>= 0.0
+                     , semantic-source ^>= 0.0.1
                      , semilattices ^>= 0.0.0.3
                      , streaming ^>= 0.2.2.0
                      , text ^>= 1.2.3.1

--- a/src/Tags/Tagging.hs
+++ b/src/Tags/Tagging.hs
@@ -60,12 +60,12 @@ contextualizing source toKind = Streaming.mapMaybeM $ \case
   Exit  x r -> Nothing <$ exitScope (x, r)
   Iden iden loc docsLiteralRange -> fmap go (get @[ContextToken]) where
     go = \case
-      ((x, r):("Context", cr):_) | Just kind <- toKind x -> Just $ Tag iden kind loc (firstLine r) (Just (slice cr))
-      ((x, r):_) | Just kind <- toKind x -> Just $ Tag iden kind loc (firstLine r) (slice <$> docsLiteralRange)
+      ((x, r):("Context", cr):_) | Just kind <- toKind x -> Just $ Tag iden kind loc (firstLine (slice r)) (Just (slice cr))
+      ((x, r):_) | Just kind <- toKind x -> Just $ Tag iden kind loc (firstLine (slice r)) (T.stripEnd . slice <$> docsLiteralRange)
       _ -> Nothing
   where
-    slice = T.stripEnd . Source.toText . Source.slice source
-    firstLine = T.stripEnd . T.takeWhile (/= '\n') . Source.toText . Source.take 180 . Source.slice source
+    slice = Source.toText . Source.slice source
+    firstLine = T.stripEnd . T.take 180 . T.takeWhile (/= '\n')
 
 enterScope, exitScope :: Has (State [ContextToken]) sig m
                       => ContextToken

--- a/src/Tags/Tagging.hs
+++ b/src/Tags/Tagging.hs
@@ -60,12 +60,13 @@ contextualizing source toKind = Streaming.mapMaybeM $ \case
   Exit  x r -> Nothing <$ exitScope (x, r)
   Iden iden loc docsLiteralRange -> fmap go (get @[ContextToken]) where
     go = \case
-      ((x, r):("Context", cr):_) | Just kind <- toKind x -> Just $ Tag iden kind loc (firstLine (slice r)) (Just (slice cr))
-      ((x, r):_) | Just kind <- toKind x -> Just $ Tag iden kind loc (firstLine (slice r)) (T.stripEnd . slice <$> docsLiteralRange)
+      ((x, r):("Context", cr):_) | Just kind <- toKind x -> Just $ Tag iden kind loc (firstLine r) (Just (sliceDocs cr))
+      ((x, r):_) | Just kind <- toKind x -> Just $ Tag iden kind loc (firstLine r) (sliceDocs <$> docsLiteralRange)
       _ -> Nothing
   where
     slice = Source.toText . Source.slice source
-    firstLine = T.stripEnd . T.take 180 . T.takeWhile (/= '\n')
+    sliceDocs = T.stripEnd . slice
+    firstLine = T.stripEnd . T.take 180 . T.takeWhile (/= '\n') . slice
 
 enterScope, exitScope :: Has (State [ContextToken]) sig m
                       => ContextToken

--- a/test/Examples.hs
+++ b/test/Examples.hs
@@ -79,6 +79,8 @@ goFileSkips = Path.relPath <$>
 
   -- Parse errors
   , "go/src/math/big/arith.go" -- Unhandled identifier character: 'ŝ'
+  , "go/src/cmd/go/testdata/src/badpkg/x.go"
+  , "go/src/cmd/go/testdata/src/notest/hello.go"
   , "go/src/cmd/vet/testdata/deadcode.go"
   , "go/src/cmd/vet/testdata/testingpkg/tests_test.go"
   , "moby/vendor/github.com/beorn7/perks/quantile/stream.go" -- Unhandled identifier character: 'ƒ'
@@ -86,11 +88,6 @@ goFileSkips = Path.relPath <$>
   -- A la carte struggles on these
   , "src/cmd/go/testdata/src/notest/hello.go" -- a la carte chokes on ParseError
   , "go/src/cmd/asm/internal/asm/parse.go" -- a la carte spans are off on line 1124
-
-  -- UTF8 encoding issues ("Cannot decode byte '\xe3': Data.Text.Internal.Encoding.decodeUtf8: Invalid UTF-8 stream")
-  , "go/src/text/template/exec_test.go"
-  , "go/src/bufio/bufio_test.go"
-  , "go/doc/progs/go1.go"
   ]
 
 goDirSkips :: [Path.RelDir]
@@ -105,14 +102,8 @@ goDirSkips = Path.relDir <$>
 rubySkips :: [Path.RelFile]
 rubySkips = Path.relFile <$>
   [
-  -- UTF8 encoding issues ("Cannot decode byte '\xe3': Data.Text.Internal.Encoding.decodeUtf8: Invalid UTF-8 stream")
-  -- These are going to be hard to fix as Ruby allows non-utf8 character content in string literals
-    "ruby_spec/optional/capi/string_spec.rb"
-  , "ruby_spec/core/string/b_spec.rb"
-  , "ruby_spec/core/string/shared/encode.rb"
-
   -- Doesn't parse b/c of issue with r<<i
-  , "ruby_spec/core/enumerable/shared/inject.rb"
+    "ruby_spec/core/enumerable/shared/inject.rb"
   -- Doesn't parse
   , "ruby_spec/language/string_spec.rb"
   , "ruby_spec/language/fixtures/freeze_magic_comment_required_diff_enc.rb"
@@ -133,9 +124,6 @@ rubySkips = Path.relFile <$>
 tsxSkips :: [Path.RelFile]
 tsxSkips = Path.relFile <$>
   [
-  -- Cannot decode byte '\xe2': Data.Text.Internal.Encoding.decodeUtf8: Invalid UTF-8 stream
-    "desktop/app/src/ui/clone-repository/clone-github-repository.tsx"
-  , "desktop/app/src/ui/toolbar/revert-progress.tsx"
   ]
 
 typescriptSkips :: [Path.RelFile]
@@ -156,13 +144,6 @@ typescriptSkips = Path.relFile <$>
 
   -- Parse errors
   , "npm/node_modules/slide/lib/async-map-ordered.js"
-
-  -- Cannot decode byte '\xd0': Data.Text.Internal.Encoding.decodeUtf8: Invalid UTF-8 stream
-  , "npm/node_modules/npm-profile/node_modules/make-fetch-happen/node_modules/socks-proxy-agent/node_modules/socks/node_modules/smart-buffer/test/smart-buffer.test.js"
-  , "npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/socks-proxy-agent/node_modules/socks/node_modules/smart-buffer/test/smart-buffer.test.js"
-  , "npm/node_modules/archy/test/multi_line.js"
-  , "npm/node_modules/archy/test/beep.js"
-  , "npm/node_modules/cli-table2/test/cell-test.js"
   ]
 
 buildExamples :: TaskSession -> LanguageExample -> Path.RelDir -> IO Tasty.TestTree


### PR DESCRIPTION
Fixes a bug in slicing out lines of text as part of calculating tags. The issue is that you can't take n bytes (`Source` is a `ByteString`) and then decode to utf8 b/c you might cut off a wide character in the middle. Also should note that we generally want to avoid `decodeUtf8` (and things like `Data.Text.Conversions.toText`) which will throw on non-utf8 characters. Better to use `decodeUtf8'` which returns `Either` or something like `decodeUtf8With lenientDecode` which is a fine trade-off for most of semantic's use cases.