### PR TITLE
semantic-source 0.0.1.0

### DIFF
--- a/semantic-source/CHANGELOG.md
+++ b/semantic-source/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Adds an `NFData` instance for `Source`.
 
+- Decodes to `Text` leniently instead of throwing exceptions.
+
 
 # 0.0.0.1
 

--- a/semantic-source/semantic-source.cabal
+++ b/semantic-source/semantic-source.cabal
@@ -48,7 +48,7 @@ library
     Source.Span
   build-depends:
       aeson          ^>= 1.4.2.0
-    , base            >= 4.13 && < 5
+    , base            >= 4.12 && < 5
     , bytestring     ^>= 0.10.8.2
     , deepseq        ^>= 1.4.4.0
     , generic-monoid ^>= 0.1.0.0

--- a/semantic-source/semantic-source.cabal
+++ b/semantic-source/semantic-source.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.4
 
 name:                semantic-source
-version:             0.0.0.1
+version:             0.0.1.0
 synopsis:            Types and functionality for working with source code
 description:         Types and functionality for working with source code (program text).
 homepage:            https://github.com/github/semantic/tree/master/semantic-source#readme


### PR DESCRIPTION
`semantic-source` needs a new hackage release.