### PR TITLE
Only use -Werror in CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -42,8 +42,8 @@ jobs:
     - name: Install dependencies
       run: |
         cabal v2-update
-        cabal v2-configure --disable-optimization --enable-benchmarks --enable-tests --write-ghc-environment-files=always -j2
-        cabal v2-build all --only-dependencies
+        cabal v2-configure --project-file=cabal.project.ci --disable-optimization --enable-benchmarks --enable-tests --write-ghc-environment-files=always -j2
+        cabal v2-build     --project-file=cabal.project.ci all --only-dependencies
 
     - name: hlint
       run: |
@@ -52,9 +52,9 @@ jobs:
 
     - name: Build & test
       run: |
-        cabal v2-build
-        cabal v2-run semantic:test
-        cabal v2-run semantic-core:test
-        cabal v2-run semantic-python:test
+        cabal v2-build --project-file=cabal.project.ci
+        cabal v2-run   --project-file=cabal.project.ci semantic:test
+        cabal v2-run   --project-file=cabal.project.ci semantic-core:test
+        cabal v2-run   --project-file=cabal.project.ci semantic-python:test
         cd semantic-source; cabal v2-run --project-file=cabal.project.ci semantic-source:test; cd ..
         cd semantic-source; cabal v2-run --project-file=cabal.project.ci semantic-source:doctest -- src; cd ..

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -56,5 +56,5 @@ jobs:
         cabal v2-run semantic:test
         cabal v2-run semantic-core:test
         cabal v2-run semantic-python:test
-        cd semantic-source; cabal v2-run semantic-source:test; cd ..
-        cd semantic-source; cabal v2-run semantic-source:doctest -- src; cd ..
+        cd semantic-source; cabal v2-run --project-file=cabal.project.ci semantic-source:test; cd ..
+        cd semantic-source; cabal v2-run --project-file=cabal.project.ci semantic-source:doctest -- src; cd ..

--- a/cabal.project
+++ b/cabal.project
@@ -15,6 +15,7 @@ packages: .
           semantic-tags
 
 -- Packages brought in from other repos instead of hackage
+-- ATTENTION: remember to update cabal.project.ci when bumping SHAs here!
 source-repository-package
   type: git
   location: https://github.com/tclem/proto-lens-jsonpb

--- a/cabal.project
+++ b/cabal.project
@@ -11,36 +11,6 @@ packages: .
           semantic-typescript
           semantic-tags
 
-package semantic
-  ghc-options: -Werror
-
-package semantic-analysis
-  ghc-options: -Werror
-
-package semantic-core
-  ghc-options: -Werror
-
-package semantic-go
-  ghc-options: -Werror
-
-package semantic-java
-  ghc-options: -Werror
-
-package semantic-json
-  ghc-options: -Werror
-
-package semantic-python
-  ghc-options: -Werror
-
-package semantic-ruby
-  ghc-options: -Werror
-
-package semantic-tags
-  ghc-options: -Werror
-
-package semantic-ast
-  ghc-options: -Werror
-
 source-repository-package
   type: git
   location: https://github.com/tclem/proto-lens-jsonpb

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,4 @@
+-- Local packages
 packages: .
           semantic-analysis
           semantic-ast
@@ -11,6 +12,7 @@ packages: .
           semantic-typescript
           semantic-tags
 
+-- Packages brought in from other repos instead of hackage
 source-repository-package
   type: git
   location: https://github.com/tclem/proto-lens-jsonpb

--- a/cabal.project
+++ b/cabal.project
@@ -11,8 +11,6 @@ packages: .
           semantic-typescript
           semantic-tags
 
-jobs: $ncpus
-
 package semantic
   ghc-options: -Werror
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,5 @@
+-- ATTENTION: care must be taken to keep this file in sync with cabal.project.ci. If you add a package here, add it there (and add a package stanza with ghc-options to enable errors in CI at the bottom of that file).
+
 -- Local packages
 packages: .
           semantic-analysis

--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -12,6 +12,24 @@ packages: .
           semantic-typescript
           semantic-tags
 
+-- Packages brought in from other repos instead of hackage
+source-repository-package
+  type: git
+  location: https://github.com/tclem/proto-lens-jsonpb
+  tag: 5d40444be689bef1e12cbe38da0261283775ec64
+
+source-repository-package
+  type: git
+  location: https://github.com/antitypical/fused-syntax.git
+  tag: d11e14581217590a5c67f79cbaeee35ac8acee6a
+
+source-repository-package
+  type: git
+  location: https://github.com/fused-effects/fused-effects-readline.git
+  tag: 7a96949c77c73c6e5975c8d6171ffb63eb76b467
+
+
+-- Treat warnings as errors for CI builds
 package semantic
   ghc-options: -Werror
 
@@ -47,19 +65,3 @@ package semantic-tsx
 
 package semantic-typescript
   ghc-options: -Werror
-
--- Packages brought in from other repos instead of hackage
-source-repository-package
-  type: git
-  location: https://github.com/tclem/proto-lens-jsonpb
-  tag: 5d40444be689bef1e12cbe38da0261283775ec64
-
-source-repository-package
-  type: git
-  location: https://github.com/antitypical/fused-syntax.git
-  tag: d11e14581217590a5c67f79cbaeee35ac8acee6a
-
-source-repository-package
-  type: git
-  location: https://github.com/fused-effects/fused-effects-readline.git
-  tag: 7a96949c77c73c6e5975c8d6171ffb63eb76b467

--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -1,0 +1,57 @@
+packages: .
+          semantic-analysis
+          semantic-ast
+          semantic-core
+          semantic-go
+          semantic-java
+          semantic-json
+          semantic-python
+          semantic-ruby
+          semantic-tsx
+          semantic-typescript
+          semantic-tags
+
+package semantic
+  ghc-options: -Werror
+
+package semantic-analysis
+  ghc-options: -Werror
+
+package semantic-core
+  ghc-options: -Werror
+
+package semantic-go
+  ghc-options: -Werror
+
+package semantic-java
+  ghc-options: -Werror
+
+package semantic-json
+  ghc-options: -Werror
+
+package semantic-python
+  ghc-options: -Werror
+
+package semantic-ruby
+  ghc-options: -Werror
+
+package semantic-tags
+  ghc-options: -Werror
+
+package semantic-ast
+  ghc-options: -Werror
+
+source-repository-package
+  type: git
+  location: https://github.com/tclem/proto-lens-jsonpb
+  tag: 5d40444be689bef1e12cbe38da0261283775ec64
+
+source-repository-package
+  type: git
+  location: https://github.com/antitypical/fused-syntax.git
+  tag: d11e14581217590a5c67f79cbaeee35ac8acee6a
+
+source-repository-package
+  type: git
+  location: https://github.com/fused-effects/fused-effects-readline.git
+  tag: 7a96949c77c73c6e5975c8d6171ffb63eb76b467

--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -41,6 +41,12 @@ package semantic-ruby
 package semantic-tags
   ghc-options: -Werror
 
+package semantic-tsx
+  ghc-options: -Werror
+
+package semantic-typescript
+  ghc-options: -Werror
+
 source-repository-package
   type: git
   location: https://github.com/tclem/proto-lens-jsonpb

--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -1,4 +1,4 @@
--- ATTENTION: care must be taken to keep this file in sync with cabal.project. If you add a package there, add it here (and add a package stanza with ghc-options to enable errors in CI at the bottom).
+-- ATTENTION: care must be taken to keep this file in sync with cabal.project. If you add a package here, add it there (and add a package stanza with ghc-options to enable errors in CI at the bottom of this file).
 
 -- Local packages
 packages: .

--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -15,6 +15,7 @@ packages: .
           semantic-tags
 
 -- Packages brought in from other repos instead of hackage
+-- ATTENTION: remember to update cabal.project when bumping SHAs here!
 source-repository-package
   type: git
   location: https://github.com/tclem/proto-lens-jsonpb

--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -17,6 +17,9 @@ package semantic
 package semantic-analysis
   ghc-options: -Werror
 
+package semantic-ast
+  ghc-options: -Werror
+
 package semantic-core
   ghc-options: -Werror
 
@@ -36,9 +39,6 @@ package semantic-ruby
   ghc-options: -Werror
 
 package semantic-tags
-  ghc-options: -Werror
-
-package semantic-ast
   ghc-options: -Werror
 
 source-repository-package

--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -1,3 +1,4 @@
+-- Local packages
 packages: .
           semantic-analysis
           semantic-ast
@@ -47,6 +48,7 @@ package semantic-tsx
 package semantic-typescript
   ghc-options: -Werror
 
+-- Packages brought in from other repos instead of hackage
 source-repository-package
   type: git
   location: https://github.com/tclem/proto-lens-jsonpb

--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -1,3 +1,5 @@
+-- ATTENTION: care must be taken to keep this file in sync with cabal.project. If you add a package there, add it here (and add a package stanza with ghc-options to enable errors in CI at the bottom).
+
 -- Local packages
 packages: .
           semantic-analysis

--- a/semantic-source/cabal.project
+++ b/semantic-source/cabal.project
@@ -1,2 +1,4 @@
+-- ATTENTION: care must be taken to keep this file in sync with cabal.project.ci. If you add a package here, add it there (and add a package stanza with ghc-options to enable errors in CI at the bottom of that file).
+
 -- Local packages
 packages: .

--- a/semantic-source/cabal.project
+++ b/semantic-source/cabal.project
@@ -1,4 +1,1 @@
 packages: .
-
-package semantic-source
-  ghc-options: -Werror

--- a/semantic-source/cabal.project
+++ b/semantic-source/cabal.project
@@ -1,1 +1,2 @@
+-- Local packages
 packages: .

--- a/semantic-source/cabal.project.ci
+++ b/semantic-source/cabal.project.ci
@@ -1,0 +1,4 @@
+packages: .
+
+package semantic-source
+  ghc-options: -Werror

--- a/semantic-source/cabal.project.ci
+++ b/semantic-source/cabal.project.ci
@@ -1,4 +1,4 @@
--- ATTENTION: care must be taken to keep this file in sync with cabal.project. If you add a package there, add it here (and add a package stanza with ghc-options to enable errors in CI at the bottom).
+-- ATTENTION: care must be taken to keep this file in sync with cabal.project. If you add a package here, add it there (and add a package stanza with ghc-options to enable errors in CI at the bottom of this file).
 
 -- Local packages
 packages: .

--- a/semantic-source/cabal.project.ci
+++ b/semantic-source/cabal.project.ci
@@ -1,4 +1,7 @@
+-- Local packages
 packages: .
 
+
+-- Treat warnings as errors for CI builds
 package semantic-source
   ghc-options: -Werror

--- a/semantic-source/cabal.project.ci
+++ b/semantic-source/cabal.project.ci
@@ -1,3 +1,5 @@
+-- ATTENTION: care must be taken to keep this file in sync with cabal.project. If you add a package there, add it here (and add a package stanza with ghc-options to enable errors in CI at the bottom).
+
 -- Local packages
 packages: .
 


### PR DESCRIPTION
This PR adds new `cabal.project` files specifically for CI builds, allowing us to enable `-Werror` (“hard mode”) only in CI.

- [x] Fixes #422.