### PR TITLE
Consolidate Scope constructors.

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: hlint
       run: |
-        test -f dist-newstyle/hlint || cabal install hlint --installdir=dist-newstyle
+        test -f dist-newstyle/hlint || cabal install hlint --installdir=dist-newstyle --overwrite-policy=always
         dist-newstyle/hlint src semantic-python
 
     - name: Build & test

--- a/semantic-scope-graph/src/Control/Carrier/Sketch/Fresh.hs
+++ b/semantic-scope-graph/src/Control/Carrier/Sketch/Fresh.hs
@@ -46,7 +46,7 @@ instance Lower (Sketchbook Name) where
   lowerBound =
     let
       initialGraph = ScopeGraph.insertScope n initialScope lowerBound
-      initialScope = ScopeGraph.Scope mempty mempty mempty
+      initialScope = lowerBound
       n = Data.Name.nameI 0
     in
       Sketchbook initialGraph n

--- a/semantic-scope-graph/src/Data/ScopeGraph.hs
+++ b/semantic-scope-graph/src/Data/ScopeGraph.hs
@@ -173,7 +173,7 @@ data Scope address = Scope
   { edges        :: Map EdgeLabel [address]
   , references   :: Map Reference ([ReferenceInfo], Path address)
   , declarations :: Seq (Info address)
-  , domain :: Domain
+  , domain       :: Domain
   } deriving (Eq, Show, Ord)
 
 instance Lower (Scope scopeAddress) where


### PR DESCRIPTION
Best practice here is for record types to have a single constructor,
and to use their constituent fields to indicate any difference of
identity. Small readability wins are nice.