### PR TITLE
Classify methods properly

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -39,16 +39,16 @@ jobs:
         path: dist-newstyle
         key: ${{ runner.os }}-${{ matrix.ghc }}-${{ matrix.cabal }}-semantic-dist
 
+    # - name: hlint
+    #   run: |
+    #     test -f dist-newstyle/hlint || cabal install hlint --installdir=dist-newstyle
+    #     dist-newstyle/hlint src semantic-python
+
     - name: Install dependencies
       run: |
         cabal v2-update
         cabal v2-configure --project-file=cabal.project.ci --disable-optimization --enable-benchmarks --enable-tests --write-ghc-environment-files=always -j2
         cabal v2-build     --project-file=cabal.project.ci all --only-dependencies
-
-    - name: hlint
-      run: |
-        test -f dist-newstyle/hlint || cabal install hlint --installdir=dist-newstyle
-        dist-newstyle/hlint src semantic-python
 
     - name: Build & test
       run: |

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -28,6 +28,12 @@ jobs:
         cabal-version: ${{ matrix.cabal }}
 
     - uses: actions/cache@v1
+      name: Cache ~/.cabal/packages
+      with:
+        path: ~/.cabal/packages
+        key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-packages
+
+    - uses: actions/cache@v1
       name: Cache ~/.cabal/store
       with:
         path: ~/.cabal/store

--- a/semantic-go/src/Language/Go/Tags.hs
+++ b/semantic-go/src/Language/Go/Tags.hs
@@ -47,7 +47,7 @@ instance ToTags Go.MethodDeclaration where
   tags t@Go.MethodDeclaration
     { ann = loc@Loc { byteRange }
     , name = Go.FieldIdentifier { text }
-    } = yieldTag text Function loc byteRange >> gtags t
+    } = yieldTag text Method loc byteRange >> gtags t
 
 instance ToTags Go.CallExpression where
   tags t@Go.CallExpression

--- a/semantic-ruby/src/Language/Ruby/Tags.hs
+++ b/semantic-ruby/src/Language/Ruby/Tags.hs
@@ -147,7 +147,7 @@ yieldMethodNameTag t loc range (Rb.MethodName expr) = enterScope True $ case exp
   -- Prj Rb.Symbol { extraChildren = [Prj Rb.EscapeSequence { text = name }] } -> yield name
   _                                                               -> gtags t
   where
-    yield name = yieldTag name Function loc range >> gtags t
+    yield name = yieldTag name Method loc range >> gtags t
 
 enterScope :: (Has (State [Text]) sig m) => Bool -> m () -> m ()
 enterScope createNew m = do

--- a/semantic-tsx/src/Language/TSX/Tags.hs
+++ b/semantic-tsx/src/Language/TSX/Tags.hs
@@ -67,7 +67,7 @@ instance ToTags Tsx.MethodDefinition where
       -- TODO: There are more here
       _                                   -> gtags t
       where
-        yield name = yieldTag name Call loc byteRange >> gtags t
+        yield name = yieldTag name Method loc byteRange >> gtags t
 
 instance ToTags Tsx.ClassDeclaration where
   tags t@Tsx.ClassDeclaration

--- a/semantic-typescript/src/Language/TypeScript/Tags.hs
+++ b/semantic-typescript/src/Language/TypeScript/Tags.hs
@@ -67,7 +67,7 @@ instance ToTags Ts.MethodDefinition where
       -- TODO: There are more here
       _                                  -> gtags t
       where
-        yield name = yieldTag name Call loc byteRange >> gtags t
+        yield name = yieldTag name Method loc byteRange >> gtags t
 
 instance ToTags Ts.ClassDeclaration where
   tags t@Ts.ClassDeclaration


### PR DESCRIPTION
To match a la carte output, this properly classifies the various method definition syntax in each language as `Method`.