### PR TITLE
Unmarshal timeout

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -37,7 +37,7 @@ jobs:
       name: Cache ~/.cabal/store
       with:
         path: ~/.cabal/store
-        key: ${{ runner.os }}-${{ matrix.ghc }}-v2-cabal-store
+        key: ${{ runner.os }}-${{ matrix.ghc }}-v3-cabal-store
 
     - uses: actions/cache@v1
       name: Cache dist-newstyle

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -37,7 +37,7 @@ jobs:
       name: Cache ~/.cabal/store
       with:
         path: ~/.cabal/store
-        key: ${{ runner.os }}-${{ matrix.ghc }}-v1-cabal-store
+        key: ${{ runner.os }}-${{ matrix.ghc }}-v2-cabal-store
 
     - uses: actions/cache@v1
       name: Cache dist-newstyle

--- a/semantic.cabal
+++ b/semantic.cabal
@@ -59,7 +59,7 @@ common dependencies
                      , fused-effects-exceptions ^>= 1
                      , fused-effects-resumable ^>= 0.1
                      , hashable >= 1.2.7 && < 1.4
-                     , tree-sitter ^>= 0.8.0.1
+                     , tree-sitter ^>= 0.8.0.2
                      , mtl ^>= 2.2.2
                      , network ^>= 2.8.0.0
                      , pathtype ^>= 0.8.1
@@ -303,7 +303,7 @@ library
                      , unliftio-core ^>= 0.1.2.0
                      , unordered-containers ^>= 0.2.9.0
                      , vector ^>= 0.12.0.2
-                     , tree-sitter-go ^>= 0.4.1
+                     , tree-sitter-go ^>= 0.4.1.1
                      , tree-sitter-php ^>= 0.2
                      , tree-sitter-python ^>= 0.8.1
                      , tree-sitter-ruby ^>= 0.4.1

--- a/semantic.cabal
+++ b/semantic.cabal
@@ -59,7 +59,7 @@ common dependencies
                      , fused-effects-exceptions ^>= 1
                      , fused-effects-resumable ^>= 0.1
                      , hashable >= 1.2.7 && < 1.4
-                     , tree-sitter ^>= 0.8
+                     , tree-sitter ^>= 0.8.0.1
                      , mtl ^>= 2.2.2
                      , network ^>= 2.8.0.0
                      , pathtype ^>= 0.8.1

--- a/src/Control/Carrier/Parse/Measured.hs
+++ b/src/Control/Carrier/Parse/Measured.hs
@@ -60,7 +60,7 @@ runParser blob@Blob{..} parser = case parser of
   UnmarshalParser language ->
     time "parse.tree_sitter_ast_parse" languageTag $ do
       config <- asks config
-      parseToPreciseAST (configTreeSitterParseTimeout config) language blob
+      parseToPreciseAST (configTreeSitterParseTimeout config) (configTreeSitterUnmarshalTimeout config) language blob
         >>= either (\e -> trace (displayException e) *> throwError (SomeException e)) pure
 
   AssignmentParser    parser assignment -> runAssignment Assignment.assign    parser blob assignment

--- a/src/Control/Carrier/Parse/Simple.hs
+++ b/src/Control/Carrier/Parse/Simple.hs
@@ -51,7 +51,7 @@ runParser timeout blob@Blob{..} parser = case parser of
       >>= either (throwError . SomeException) pure
 
   UnmarshalParser language ->
-    parseToPreciseAST timeout language blob
+    parseToPreciseAST timeout timeout language blob
       >>= either (throwError . SomeException) pure
 
   AssignmentParser    parser assignment ->

--- a/src/Parsing/TreeSitter.hs
+++ b/src/Parsing/TreeSitter.hs
@@ -59,8 +59,8 @@ parseToPreciseAST
   -> Blob
   -> m (Either TSParseException (t Loc))
 parseToPreciseAST parseTimeout unmarshalTimeout language blob = runParse parseTimeout language blob $ \ rootPtr ->
-  TS.withCursor (castPtr rootPtr) $ \ cursor ->
-    withTimeout $
+  withTimeout $
+    TS.withCursor (castPtr rootPtr) $ \ cursor ->
       runReader (TS.UnmarshalState (Source.bytes (blobSource blob)) cursor) (liftIO (peek rootPtr) >>= TS.unmarshalNode)
         `Exc.catch` (Exc.throw . UnmarshalFailure . TS.getUnmarshalError)
   where

--- a/src/Parsing/TreeSitter.hs
+++ b/src/Parsing/TreeSitter.hs
@@ -21,6 +21,7 @@ import           Data.Term
 import           Source.Loc
 import qualified Source.Source as Source
 import           Source.Span
+import qualified System.Timeout as System
 
 import qualified TreeSitter.Cursor as TS
 import qualified TreeSitter.Language as TS
@@ -32,6 +33,7 @@ import qualified TreeSitter.Unmarshal as TS
 data TSParseException
   = ParserTimedOut
   | IncompatibleVersions
+  | UnmarshalTimedOut
   | UnmarshalFailure String
     deriving (Eq, Show, Generic)
 
@@ -52,18 +54,24 @@ parseToPreciseAST
      , TS.Unmarshal t
      )
   => Duration
+  -> Duration
   -> Ptr TS.Language
   -> Blob
   -> m (Either TSParseException (t Loc))
-parseToPreciseAST parseTimeout language blob = runParse parseTimeout language blob $ \ rootPtr ->
+parseToPreciseAST parseTimeout unmarshalTimeout language blob = runParse parseTimeout language blob $ \ rootPtr ->
   TS.withCursor (castPtr rootPtr) $ \ cursor ->
-    runReader (TS.UnmarshalState (Source.bytes (blobSource blob)) cursor) (liftIO (peek rootPtr) >>= TS.unmarshalNode)
-    `Exc.catch` (Exc.throw . UnmarshalFailure . TS.getUnmarshalError)
+    withTimeout $
+      runReader (TS.UnmarshalState (Source.bytes (blobSource blob)) cursor) (liftIO (peek rootPtr) >>= TS.unmarshalNode)
+        `Exc.catch` (Exc.throw . UnmarshalFailure . TS.getUnmarshalError)
+  where
+    withTimeout :: IO a -> IO a
+    withTimeout action = System.timeout (toMicroseconds unmarshalTimeout) action >>= maybeM (Exc.throw UnmarshalTimedOut)
 
 instance Exception TSParseException where
   displayException = \case
     ParserTimedOut -> "tree-sitter: parser timed out"
     IncompatibleVersions -> "tree-sitter: incompatible versions"
+    UnmarshalTimedOut -> "tree-sitter: unmarshal timed out"
     UnmarshalFailure s -> "tree-sitter: unmarshal failure - " <> show s
 
 runParse

--- a/src/Semantic/Config.hs
+++ b/src/Semantic/Config.hs
@@ -43,20 +43,21 @@ data FailOnParseError = FailOnParseError
 
 data Config
   = Config
-  { configAppName                :: String               -- ^ Application name ("semantic")
-  , configHostName               :: String               -- ^ HostName from getHostName
-  , configProcessID              :: ProcessID            -- ^ ProcessID from getProcessID
-  , configStatsHost              :: Stat.Host            -- ^ Host of statsd/datadog (default: "127.0.0.1")
-  , configStatsPort              :: Stat.Port            -- ^ Port of statsd/datadog (default: "28125")
-  , configTreeSitterParseTimeout :: Duration             -- ^ Timeout in milliseconds before canceling tree-sitter parsing (default: 6000).
-  , configAssignmentTimeout      :: Duration             -- ^ Millisecond timeout for assignment (default: 4000)
-  , configMaxTelemetyQueueSize   :: Int                  -- ^ Max size of telemetry queues before messages are dropped (default: 1000).
-  , configIsTerminal             :: Flag IsTerminal      -- ^ Whether a terminal is attached (set automaticaly at runtime).
-  , configLogPrintSource         :: Flag LogPrintSource  -- ^ Whether to print the source reference when logging errors (set automatically at runtime).
-  , configLogFormatter           :: LogFormatter         -- ^ Log formatter to use (set automatically at runtime).
-  , configSHA                    :: String               -- ^ SHA to include in log messages (set automatically).
-  , configFailParsingForTesting  :: Flag FailTestParsing -- ^ Simulate internal parse failure for testing (default: False).
-  , configOptions                :: Options              -- ^ Options configurable via command line arguments.
+  { configAppName                    :: String               -- ^ Application name ("semantic")
+  , configHostName                   :: String               -- ^ HostName from getHostName
+  , configProcessID                  :: ProcessID            -- ^ ProcessID from getProcessID
+  , configStatsHost                  :: Stat.Host            -- ^ Host of statsd/datadog (default: "127.0.0.1")
+  , configStatsPort                  :: Stat.Port            -- ^ Port of statsd/datadog (default: "28125")
+  , configTreeSitterParseTimeout     :: Duration             -- ^ Timeout in milliseconds before canceling tree-sitter parsing (default: 6000).
+  , configTreeSitterUnmarshalTimeout :: Duration             -- ^ Timeout in milliseconds before canceling tree-sitter unmarshalling (default: 4000).
+  , configAssignmentTimeout          :: Duration             -- ^ Millisecond timeout for assignment (default: 4000)
+  , configMaxTelemetyQueueSize       :: Int                  -- ^ Max size of telemetry queues before messages are dropped (default: 1000).
+  , configIsTerminal                 :: Flag IsTerminal      -- ^ Whether a terminal is attached (set automaticaly at runtime).
+  , configLogPrintSource             :: Flag LogPrintSource  -- ^ Whether to print the source reference when logging errors (set automatically at runtime).
+  , configLogFormatter               :: LogFormatter         -- ^ Log formatter to use (set automatically at runtime).
+  , configSHA                        :: String               -- ^ SHA to include in log messages (set automatically).
+  , configFailParsingForTesting      :: Flag FailTestParsing -- ^ Simulate internal parse failure for testing (default: False).
+  , configOptions                    :: Options              -- ^ Options configurable via command line arguments.
   }
 
 -- Options configurable via command line arguments.
@@ -85,6 +86,7 @@ defaultConfig options@Options{..} = do
   (statsHost, statsPort) <- lookupStatsAddr
   size <- envLookupNum 1000 "MAX_TELEMETRY_QUEUE_SIZE"
   parseTimeout <- envLookupNum 6000 "TREE_SITTER_PARSE_TIMEOUT"
+  unmarshalTimeout <- envLookupNum 4000 "TREE_SITTER_UNMARSHAL_TIMEOUT"
   assignTimeout <- envLookupNum 4000 "SEMANTIC_ASSIGNMENT_TIMEOUT"
   pure Config
     { configAppName = "semantic"
@@ -94,6 +96,7 @@ defaultConfig options@Options{..} = do
     , configStatsPort = statsPort
 
     , configTreeSitterParseTimeout = fromMilliseconds parseTimeout
+    , configTreeSitterUnmarshalTimeout = fromMilliseconds unmarshalTimeout
     , configAssignmentTimeout = fromMilliseconds assignTimeout
     , configMaxTelemetyQueueSize = size
     , configIsTerminal = flag IsTerminal isTerminal


### PR DESCRIPTION
We have a timeout that gets passed to tree-sitter as a way to be able to abort parsing across the FFI (important if a parser runs away for some reason or to maintain some other service objective), but with the move away from assignment we no longer use the haskell `System.timeout` to protect the non C aspects of producing an AST. This adds a new config setting that allows us to set a timeout on unmarshalling.