### PR TITLE
Remove Lower instances for Span and Pos.

### DIFF
--- a/semantic-source/semantic-source.cabal
+++ b/semantic-source/semantic-source.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.4
 
 name:                semantic-source
-version:             0.0.2.0
+version:             0.1.0.0
 synopsis:            Types and functionality for working with source code
 description:         Types and functionality for working with source code (program text).
 homepage:            https://github.com/github/semantic/tree/master/semantic-source#readme

--- a/semantic-source/src/Source/Span.hs
+++ b/semantic-source/src/Source/Span.hs
@@ -18,7 +18,6 @@ import           Control.DeepSeq (NFData)
 import           Data.Aeson ((.:), (.=))
 import qualified Data.Aeson as A
 import           Data.Hashable (Hashable)
-import           Data.Semilattice.Lower (Lower (..))
 import           GHC.Generics (Generic)
 import           GHC.Stack (SrcLoc (..))
 
@@ -45,10 +44,6 @@ instance A.FromJSON Span where
   parseJSON = A.withObject "Span" $ \o -> Span
     <$> o .: "start"
     <*> o .: "end"
-
-instance Lower Span where
-  lowerBound = Span lowerBound lowerBound
-
 
 -- | Construct a Span with a given value for both its start and end positions.
 point :: Pos -> Span
@@ -82,10 +77,6 @@ instance A.FromJSON Pos where
   parseJSON arr = do
     [ line, col ] <- A.parseJSON arr
     pure $ Pos line col
-
-instance Lower Pos where
-  lowerBound = Pos 0 0
-
 
 line_, column_ :: Lens' Pos Int
 line_   = lens line   (\p l -> p { line   = l })

--- a/semantic-source/src/Source/Span.hs
+++ b/semantic-source/src/Source/Span.hs
@@ -84,7 +84,7 @@ instance A.FromJSON Pos where
     pure $ Pos line col
 
 instance Lower Pos where
-  lowerBound = Pos 1 1
+  lowerBound = Pos 0 0
 
 
 line_, column_ :: Lens' Pos Int


### PR DESCRIPTION
We aren't using these anywhere, and I think they're a net negative, because there's nothing to indicate whether `lowerBound` is one-indexed or zero-indexed by convention. We could provide an `Indexed (n :: Nat)` newtype, or we could delete these instances entirely.