### PR TITLE
Remove Lower instances for Span and Pos.

### DIFF
--- a/semantic-source/semantic-source.cabal
+++ b/semantic-source/semantic-source.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.4
 
 name:                semantic-source
-version:             0.0.2.0
+version:             0.1.0.0
 synopsis:            Types and functionality for working with source code
 description:         Types and functionality for working with source code (program text).
 homepage:            https://github.com/github/semantic/tree/master/semantic-source#readme

--- a/semantic-source/src/Source/Source.hs
+++ b/semantic-source/src/Source/Source.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE DeriveGeneric, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-|
 'Source' models source code, represented as a thin wrapper around a 'B.ByteString' with conveniences for splitting by line, slicing, etc.
 
@@ -37,7 +38,7 @@ import           Data.Aeson (FromJSON (..), withText)
 import qualified Data.ByteString as B
 import           Data.Char (ord)
 import           Data.Maybe (fromMaybe)
-import           Data.Monoid (Last(..))
+import           Data.Monoid (Last (..))
 import           Data.Semilattice.Lower
 import           Data.String (IsString (..))
 import qualified Data.Text as T
@@ -45,7 +46,7 @@ import qualified Data.Text.Encoding as T
 import           Data.Text.Encoding.Error (lenientDecode)
 import           GHC.Generics (Generic)
 import           Source.Range
-import           Source.Span (Span(Span), Pos(..))
+import           Source.Span (Pos (..), Span (Span))
 
 
 -- | The contents of a source file. This is represented as a UTF-8
@@ -75,7 +76,7 @@ totalRange = Range 0 . B.length . bytes
 
 -- | Return a 'Span' that covers the entire text.
 totalSpan :: Source -> Span
-totalSpan source = Span lowerBound (Pos (Prelude.length ranges) (succ (end lastRange - start lastRange))) where
+totalSpan source = Span (Pos 1 1) (Pos (Prelude.length ranges) (succ (end lastRange - start lastRange))) where
   ranges = lineRanges source
   lastRange = fromMaybe lowerBound (getLast (foldMap (Last . Just) ranges))
 

--- a/semantic-source/src/Source/Span.hs
+++ b/semantic-source/src/Source/Span.hs
@@ -18,7 +18,6 @@ import           Control.DeepSeq (NFData)
 import           Data.Aeson ((.:), (.=))
 import qualified Data.Aeson as A
 import           Data.Hashable (Hashable)
-import           Data.Semilattice.Lower (Lower (..))
 import           GHC.Generics (Generic)
 import           GHC.Stack (SrcLoc (..))
 
@@ -45,10 +44,6 @@ instance A.FromJSON Span where
   parseJSON = A.withObject "Span" $ \o -> Span
     <$> o .: "start"
     <*> o .: "end"
-
-instance Lower Span where
-  lowerBound = Span lowerBound lowerBound
-
 
 -- | Construct a Span with a given value for both its start and end positions.
 point :: Pos -> Span
@@ -82,10 +77,6 @@ instance A.FromJSON Pos where
   parseJSON arr = do
     [ line, col ] <- A.parseJSON arr
     pure $ Pos line col
-
-instance Lower Pos where
-  lowerBound = Pos 0 0
-
 
 line_, column_ :: Lens' Pos Int
 line_   = lens line   (\p l -> p { line   = l })

--- a/semantic-source/src/Source/Span.hs
+++ b/semantic-source/src/Source/Span.hs
@@ -84,7 +84,7 @@ instance A.FromJSON Pos where
     pure $ Pos line col
 
 instance Lower Pos where
-  lowerBound = Pos 1 1
+  lowerBound = Pos 0 0
 
 
 line_, column_ :: Lens' Pos Int


### PR DESCRIPTION
We aren't using these anywhere, and I think they're a net negative, because there's nothing to indicate whether `lowerBound` is one-indexed or zero-indexed by convention. We could provide an `Indexed (n :: Nat)` newtype, or we could delete these instances entirely.