### PR TITLE
Bump fused-effects version and remove orphan instance.

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -37,7 +37,7 @@ jobs:
       name: Cache ~/.cabal/store
       with:
         path: ~/.cabal/store
-        key: ${{ runner.os }}-${{ matrix.ghc }}-v6-cabal-store
+        key: ${{ runner.os }}-${{ matrix.ghc }}-v7-cabal-store
 
     - uses: actions/cache@v1
       name: Cache dist-newstyle

--- a/semantic-python/semantic-python.cabal
+++ b/semantic-python/semantic-python.cabal
@@ -21,7 +21,7 @@ tested-with:         GHC == 8.6.5
 common haskell
   default-language:    Haskell2010
   build-depends:       base ^>= 4.13
-                     , fused-effects ^>= 1.0
+                     , fused-effects ^>= 1.0.0.1
                      , fused-syntax
                      , parsers ^>= 0.12.10
                      , semantic-analysis ^>= 0

--- a/semantic-python/src/Language/Python/ScopeGraph.hs
+++ b/semantic-python/src/Language/Python/ScopeGraph.hs
@@ -23,7 +23,6 @@ module Language.Python.ScopeGraph
 
 import qualified Analysis.Name as Name
 import           AST.Element
-import           Control.Algebra (Algebra (..), handleCoercible)
 import           Control.Effect.Fresh
 import           Control.Effect.Sketch
 import           Data.Foldable

--- a/semantic-python/src/Language/Python/ScopeGraph.hs
+++ b/semantic-python/src/Language/Python/ScopeGraph.hs
@@ -16,7 +16,6 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Language.Python.ScopeGraph
   ( scopeGraphModule
@@ -38,10 +37,6 @@ import qualified Language.Python.AST as Py
 import           Language.Python.Patterns
 import           ScopeGraph.Convert (Result (..), complete, todo)
 import           Source.Loc
-
--- This orphan instance will perish once it lands in fused-effects.
-instance Algebra sig m => Algebra sig (Ap m) where
-  alg = Ap . alg . handleCoercible
 
 -- This typeclass is internal-only, though it shares the same interface
 -- as the one defined in semantic-scope-graph. The somewhat-unconventional

--- a/src/Analysis/Abstract/Caching/FlowInsensitive.hs
+++ b/src/Analysis/Abstract/Caching/FlowInsensitive.hs
@@ -9,7 +9,6 @@ module Analysis.Abstract.Caching.FlowInsensitive
 , caching
 ) where
 
-import Control.Algebra (Effect)
 import Control.Carrier.Fresh.Strict
 import Control.Carrier.NonDet.Church
 import Control.Carrier.Reader

--- a/src/Analysis/Abstract/Caching/FlowSensitive.hs
+++ b/src/Analysis/Abstract/Caching/FlowSensitive.hs
@@ -11,7 +11,6 @@ module Analysis.Abstract.Caching.FlowSensitive
 , caching
 ) where
 
-import Control.Algebra (Effect)
 import Control.Carrier.Fresh.Strict
 import Control.Carrier.NonDet.Church
 import Control.Carrier.Reader

--- a/src/Semantic/Graph.hs
+++ b/src/Semantic/Graph.hs
@@ -46,7 +46,6 @@ import           Analysis.Abstract.Graph as Graph
 import           Analysis.File
 import           Control.Abstract hiding (String)
 import           Control.Abstract.PythonPackage as PythonPackage
-import           Control.Algebra
 import           Control.Carrier.Fresh.Strict
 import           Control.Carrier.Reader
 import           Control.Carrier.Resumable.Resume


### PR DESCRIPTION
Fused-effects v1.0.0.1 is out now. Don't forget to `cabal update`.