### PR TITLE
Silence REPL macro-redefined warnings from the C compiler.

### DIFF
--- a/script/ghci-flags
+++ b/script/ghci-flags
@@ -44,6 +44,8 @@ function flags {
   then add_autogen_includes "$build_dir/semantic-0.10.0.0/noopt/build/autogen"
   fi
 
+  echo "-optP-Wno-macro-redefined"
+
   # .hs source dirs
   # TODO: would be nice to figure this out from cabal.project & the .cabal files
   echo "-isemantic-analysis/src"


### PR DESCRIPTION
In certain cases, use of the REPL can land us in a state where there
are multiple `cabal_macros.h` files being included, leading to
duplicate macro definitions. This does not factor into correctness,
as these duplicates are, well, duplicate definitions, but the warning
is tedious, so this patch passes `-Wno-macro-redefined` to the C compiler.