### PR TITLE
Propagate module/path information into generated scope graphs.

### DIFF
--- a/semantic-scope-graph/src/Control/Carrier/Sketch/ScopeGraph.hs
+++ b/semantic-scope-graph/src/Control/Carrier/Sketch/ScopeGraph.hs
@@ -26,24 +26,26 @@ import           Control.Carrier.Fresh.Strict
 import           Control.Carrier.Reader
 import           Control.Carrier.State.Strict
 import           Control.Effect.ScopeGraph
+import           Data.Module (ModuleInfo)
 import qualified Data.ScopeGraph as ScopeGraph
 import           Data.Semilattice.Lower
-import qualified System.Path as Path
 
 type SketchC addr m
   = StateC (ScopeGraph Name)
   ( StateC Name
   ( ReaderC Name
+  ( ReaderC ModuleInfo
   ( FreshC m
-  )))
+  ))))
 
 runSketch ::
   (Functor m)
-  => Maybe Path.AbsRelFile
+  => ModuleInfo
   -> SketchC Name m a
   -> m (ScopeGraph Name, a)
-runSketch _rootpath go
+runSketch info go
   = evalFresh 0
+  . runReader @ModuleInfo info
   . runReader @Name rootname
   . evalState @Name rootname
   . runState @(ScopeGraph Name) initialGraph

--- a/semantic-scope-graph/src/Control/Effect/ScopeGraph.hs
+++ b/semantic-scope-graph/src/Control/Effect/ScopeGraph.hs
@@ -64,6 +64,7 @@ type ScopeGraphEff sig m
   = ( Has (State (ScopeGraph Name)) sig m
     , Has (State Name) sig m
     , Has (Reader Name) sig m
+    , Has (Reader Module.ModuleInfo) sig m
     , Has Fresh sig m
     )
 
@@ -84,11 +85,12 @@ declare :: ScopeGraphEff sig m => Name -> Props.Declaration -> m ()
 declare n props = do
   current <- currentScope
   old <- graphInProgress
+  info <- ask
   let Props.Declaration kind relation associatedScope span = props
   let (new, _pos) =
          ScopeGraph.declare
          (ScopeGraph.Declaration n)
-         (lowerBound @Module.ModuleInfo)
+         info
          relation
          ScopeGraph.Public
          span
@@ -103,10 +105,11 @@ reference :: forall sig m . ScopeGraphEff sig m => Text -> Text -> Props.Referen
 reference n decl props = do
   current <- currentScope
   old <- graphInProgress
+  info <- ask
   let new =
          ScopeGraph.reference
          (ScopeGraph.Reference (Name.name n))
-         (lowerBound @Module.ModuleInfo)
+         info
          (Props.Reference.span props)
          (Props.Reference.kind props)
          (ScopeGraph.Declaration (Name.name decl))

--- a/semantic-scope-graph/src/Control/Effect/ScopeGraph/Properties/Reference.hs
+++ b/semantic-scope-graph/src/Control/Effect/ScopeGraph/Properties/Reference.hs
@@ -20,7 +20,7 @@ data Reference = Reference
   { kind     :: ScopeGraph.Kind
   , relation :: ScopeGraph.Relation
   , span     :: Span
-    } deriving (Generic, Show)
+  } deriving (Generic, Show)
 
 instance HasSpan Reference where
   span_ = lens span (\r s -> r { span = s })


### PR DESCRIPTION
By adding a `Reader ModuleInfo` constraint to the scope graph DSL, we
can ensure that newly-introduced declarations and references get this
helpful information (rather than sticking a `lowerBound` in there).