### PR TITLE
Dump precise ASTs from `semantic parse --json`.

### DIFF
--- a/semantic-ast/src/AST/Token.hs
+++ b/semantic-ast/src/AST/Token.hs
@@ -1,10 +1,14 @@
-{-# LANGUAGE DataKinds, DeriveGeneric, DeriveTraversable, KindSignatures #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE KindSignatures #-}
 module AST.Token
 ( Token(..)
 ) where
 
+import Data.Aeson
 import GHC.Generics (Generic, Generic1)
-import GHC.TypeLits (Symbol, Nat)
+import GHC.TypeLits (Nat, Symbol)
 
 -- | An AST node representing a token, indexed by its name and numeric value.
 --
@@ -15,3 +19,5 @@ import GHC.TypeLits (Symbol, Nat)
 -- @
 newtype Token (symName :: Symbol) (symVal :: Nat) a = Token { ann :: a }
   deriving (Eq, Foldable, Functor, Generic, Generic1, Ord, Show, Traversable)
+
+instance ToJSON1 (Token symName val)

--- a/semantic-go/semantic-go.cabal
+++ b/semantic-go/semantic-go.cabal
@@ -21,6 +21,7 @@ tested-with:         GHC == 8.6.5
 common haskell
   default-language:    Haskell2010
   build-depends:       base ^>= 4.13
+                     , aeson ^>= 1.4.4
                      , fused-effects ^>= 1.0
                      , fused-syntax
                      , parsers ^>= 0.12.10

--- a/semantic-go/src/Language/Go.hs
+++ b/semantic-go/src/Language/Go.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -- | Semantic functionality for Go programs.
 module Language.Go
 ( Term(..)
@@ -5,14 +7,19 @@ module Language.Go
 ) where
 
 
+import qualified AST.Unmarshal as TS
+import           Data.Aeson (ToJSON (..), ToJSON1 (..), toJSON1)
 import           Data.Proxy
 import qualified Language.Go.AST as Go
+import qualified Language.Go.Grammar (tree_sitter_go)
 import qualified Language.Go.Tags as GoTags
 import qualified Tags.Tagging.Precise as Tags
-import qualified Language.Go.Grammar (tree_sitter_go)
-import qualified AST.Unmarshal as TS
 
 newtype Term a = Term { getTerm :: Go.SourceFile a }
+  deriving newtype ToJSON1
+
+instance ToJSON a => ToJSON (Term a) where
+  toJSON = toJSON1
 
 instance TS.SymbolMatching Term where
   matchedSymbols _ = TS.matchedSymbols (Proxy :: Proxy Go.SourceFile)

--- a/semantic-java/semantic-java.cabal
+++ b/semantic-java/semantic-java.cabal
@@ -21,6 +21,7 @@ tested-with:         GHC == 8.6.5
 common haskell
   default-language:    Haskell2010
   build-depends:       base ^>= 4.13
+                     , aeson ^>= 1.4.4
                      , fused-effects ^>= 1.0
                      , fused-syntax
                      , parsers ^>= 0.12.10

--- a/semantic-java/src/Language/Java.hs
+++ b/semantic-java/src/Language/Java.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+-- | Semantic functionality for Java programs.
 module Language.Java
 ( Term(..)
 , Language.Java.Grammar.tree_sitter_java

--- a/semantic-java/src/Language/Java.hs
+++ b/semantic-java/src/Language/Java.hs
@@ -1,17 +1,23 @@
--- | Semantic functionality for Java programs.
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Language.Java
 ( Term(..)
 , Language.Java.Grammar.tree_sitter_java
 ) where
 
+import qualified AST.Unmarshal as TS
+import           Data.Aeson (ToJSON (..), ToJSON1, toJSON1)
 import           Data.Proxy
 import qualified Language.Java.AST as Java
+import qualified Language.Java.Grammar (tree_sitter_java)
 import qualified Language.Java.Tags as JavaTags
 import qualified Tags.Tagging.Precise as Tags
-import qualified Language.Java.Grammar (tree_sitter_java)
-import qualified AST.Unmarshal as TS
 
 newtype Term a = Term { getTerm :: Java.Program a }
+  deriving newtype ToJSON1
+
+instance ToJSON a => ToJSON (Term a) where
+  toJSON = toJSON1
 
 instance TS.SymbolMatching Term where
   matchedSymbols _ = TS.matchedSymbols (Proxy :: Proxy Java.Program)

--- a/semantic-json/semantic-json.cabal
+++ b/semantic-json/semantic-json.cabal
@@ -21,6 +21,7 @@ tested-with:         GHC == 8.6.5
 common haskell
   default-language:    Haskell2010
   build-depends:       base ^>= 4.13
+                     , aeson ^>= 1.4.4
                      , fused-effects ^>= 1.0
                      , fused-syntax
                      , parsers ^>= 0.12.10

--- a/semantic-json/src/Language/JSON.hs
+++ b/semantic-json/src/Language/JSON.hs
@@ -1,16 +1,23 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -- | Semantic functionality for JSON programs.
 module Language.JSON
 ( Term(..)
 , TreeSitter.JSON.tree_sitter_json
 ) where
 
+import qualified AST.Unmarshal as TS
+import           Data.Aeson (ToJSON (..), ToJSON1, toJSON1)
 import           Data.Proxy
 import qualified Language.JSON.AST as JSON
 import qualified Tags.Tagging.Precise as Tags
 import qualified TreeSitter.JSON (tree_sitter_json)
-import qualified AST.Unmarshal as TS
 
 newtype Term a = Term { getTerm :: JSON.Document a }
+  deriving newtype ToJSON1
+
+instance ToJSON a => ToJSON (Term a) where
+  toJSON = toJSON1
 
 instance TS.SymbolMatching Term where
   matchedSymbols _ = TS.matchedSymbols (Proxy :: Proxy JSON.Document)

--- a/semantic-json/src/Language/JSON/AST.hs
+++ b/semantic-json/src/Language/JSON/AST.hs
@@ -13,9 +13,9 @@ module Language.JSON.AST
 ( module Language.JSON.AST
 ) where
 
-import           Prelude hiding (String)
 import           AST.GenerateSyntax
 import           Language.Haskell.TH.Syntax (runIO)
+import           Prelude hiding (String)
 import qualified TreeSitter.JSON as JSON (getNodeTypesPath, tree_sitter_json)
 
 runIO JSON.getNodeTypesPath >>= astDeclarationsForLanguage JSON.tree_sitter_json

--- a/semantic-php/semantic-php.cabal
+++ b/semantic-php/semantic-php.cabal
@@ -21,6 +21,7 @@ tested-with:         GHC == 8.6.5
 common haskell
   default-language:    Haskell2010
   build-depends:       base ^>= 4.13
+                     , aeson ^>= 1.4.4
                      , fused-effects ^>= 1.0
                      , fused-syntax
                      , parsers ^>= 0.12.10

--- a/semantic-php/src/Language/PHP.hs
+++ b/semantic-php/src/Language/PHP.hs
@@ -1,16 +1,23 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -- | Semantic functionality for JSON programs.
 module Language.PHP
 ( Term(..)
 , TreeSitter.PHP.tree_sitter_php
 ) where
 
+import qualified AST.Unmarshal as TS
+import           Data.Aeson (ToJSON (..), ToJSON1, toJSON1)
 import           Data.Proxy
 import qualified Language.PHP.AST as PHP
 import qualified Tags.Tagging.Precise as Tags
 import qualified TreeSitter.PHP (tree_sitter_php)
-import qualified AST.Unmarshal as TS
 
 newtype Term a = Term { getTerm :: PHP.Program a }
+  deriving newtype ToJSON1
+
+instance ToJSON a => ToJSON (Term a) where
+  toJSON = toJSON1
 
 instance TS.SymbolMatching Term where
   matchedSymbols _ = TS.matchedSymbols (Proxy :: Proxy PHP.Program)

--- a/semantic-python/semantic-python.cabal
+++ b/semantic-python/semantic-python.cabal
@@ -21,6 +21,7 @@ tested-with:         GHC == 8.6.5
 common haskell
   default-language:    Haskell2010
   build-depends:       base ^>= 4.13
+                     , aeson ^>= 1.4.4
                      , fused-effects ^>= 1.0.0.1
                      , fused-syntax
                      , parsers ^>= 0.12.10
@@ -74,7 +75,6 @@ test-suite compiling
   ghc-options: -threaded
 
   build-depends: semantic-python == 0.0.0.0
-               , aeson ^>= 1.4.4
                , aeson-pretty ^>= 0.8.7
                , bytestring ^>= 0.10.8.2
                , containers ^>= 0.6

--- a/semantic-python/src/Language/Python.hs
+++ b/semantic-python/src/Language/Python.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -- | Semantic functionality for Python programs.
 module Language.Python
 ( Term(..)
@@ -5,6 +7,7 @@ module Language.Python
 ) where
 
 import qualified AST.Unmarshal as TS
+import           Data.Aeson (ToJSON (..), ToJSON1, toJSON1)
 import           Data.Proxy
 import qualified Language.Python.AST as Py
 import qualified Language.Python.Grammar (tree_sitter_python)
@@ -14,6 +17,10 @@ import           Scope.Graph.Convert
 import qualified Tags.Tagging.Precise as Tags
 
 newtype Term a = Term { getTerm :: Py.Module a }
+  deriving newtype ToJSON1
+
+instance ToJSON a => ToJSON (Term a) where
+  toJSON = toJSON1
 
 instance TS.SymbolMatching Term where
   matchedSymbols _ = TS.matchedSymbols (Proxy :: Proxy Py.Module)

--- a/semantic-ruby/semantic-ruby.cabal
+++ b/semantic-ruby/semantic-ruby.cabal
@@ -21,6 +21,7 @@ tested-with:         GHC == 8.6.5
 common haskell
   default-language:    Haskell2010
   build-depends:       base ^>= 4.13
+                     , aeson ^>= 1.4.4
                      , fused-effects ^>= 1.0
                      , fused-syntax
                      , parsers ^>= 0.12.10

--- a/semantic-ruby/src/Language/Ruby.hs
+++ b/semantic-ruby/src/Language/Ruby.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 
 -- | Semantic functionality for Ruby programs.
@@ -8,6 +10,7 @@ module Language.Ruby
 
 import qualified AST.Unmarshal as TS
 import           Control.Carrier.State.Strict
+import           Data.Aeson (ToJSON (..), ToJSON1, toJSON1)
 import           Data.Proxy
 import           Data.Text (Text)
 import qualified Language.Ruby.AST as Rb
@@ -16,6 +19,10 @@ import qualified Language.Ruby.Tags as RbTags
 import qualified Tags.Tagging.Precise as Tags
 
 newtype Term a = Term { getTerm :: Rb.Program a }
+  deriving ToJSON1
+
+instance ToJSON a => ToJSON (Term a) where
+  toJSON = toJSON1
 
 instance TS.SymbolMatching Term where
   matchedSymbols _ = TS.matchedSymbols (Proxy :: Proxy Rb.Program)

--- a/semantic-tsx/semantic-tsx.cabal
+++ b/semantic-tsx/semantic-tsx.cabal
@@ -21,6 +21,7 @@ tested-with:         GHC == 8.6.5
 common haskell
   default-language:    Haskell2010
   build-depends:       base ^>= 4.13
+                     , aeson ^>= 1.4.4
                      , fused-effects ^>= 1.0
                      , fused-syntax
                      , parsers ^>= 0.12.10

--- a/semantic-tsx/src/Language/TSX.hs
+++ b/semantic-tsx/src/Language/TSX.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# OPTIONS_GHC -freduction-depth=0 #-}
 -- | Semantic functionality for TSX programs.
 module Language.TSX
@@ -5,14 +7,19 @@ module Language.TSX
 , Language.TSX.Grammar.tree_sitter_tsx
 ) where
 
+import qualified AST.Unmarshal as TS
+import           Data.Aeson (ToJSON (..), ToJSON1, toJSON1)
 import           Data.Proxy
 import qualified Language.TSX.AST as TSX
+import qualified Language.TSX.Grammar (tree_sitter_tsx)
 import qualified Language.TSX.Tags as TsxTags
 import qualified Tags.Tagging.Precise as Tags
-import qualified Language.TSX.Grammar (tree_sitter_tsx)
-import qualified AST.Unmarshal as TS
 
 newtype Term a = Term { getTerm :: TSX.Program a }
+  deriving newtype ToJSON1
+
+instance ToJSON a => ToJSON (Term a) where
+  toJSON = toJSON1
 
 instance TS.SymbolMatching Term where
   matchedSymbols _ = TS.matchedSymbols (Proxy :: Proxy TSX.Program)

--- a/semantic-typescript/semantic-typescript.cabal
+++ b/semantic-typescript/semantic-typescript.cabal
@@ -21,6 +21,7 @@ tested-with:         GHC == 8.6.5
 common haskell
   default-language:    Haskell2010
   build-depends:       base ^>= 4.13
+                     , aeson ^>= 1.4.4
                      , fused-effects ^>= 1.0
                      , fused-syntax
                      , parsers ^>= 0.12.10

--- a/semantic-typescript/src/Language/TypeScript.hs
+++ b/semantic-typescript/src/Language/TypeScript.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# OPTIONS_GHC -freduction-depth=0 #-}
 -- | Semantic functionality for TypeScript programs.
 module Language.TypeScript
@@ -5,14 +7,19 @@ module Language.TypeScript
 , Language.TypeScript.Grammar.tree_sitter_typescript
 ) where
 
+import qualified AST.Unmarshal as TS
+import           Data.Aeson (ToJSON (..), ToJSON1, toJSON1)
 import           Data.Proxy
 import qualified Language.TypeScript.AST as TypeScript
+import qualified Language.TypeScript.Grammar (tree_sitter_typescript)
 import qualified Language.TypeScript.Tags as TsTags
 import qualified Tags.Tagging.Precise as Tags
-import qualified Language.TypeScript.Grammar (tree_sitter_typescript)
-import qualified AST.Unmarshal as TS
 
 newtype Term a = Term { getTerm :: TypeScript.Program a }
+  deriving newtype ToJSON1
+
+instance ToJSON a => ToJSON (Term a) where
+  toJSON = toJSON1
 
 instance TS.SymbolMatching Term where
   matchedSymbols _ = TS.matchedSymbols (Proxy :: Proxy TypeScript.Program)


### PR DESCRIPTION
This performs the following changes:
* makes `GenerateSyntax` declare `ToJSON1` instances for all syntax types, piggybacking on Aeson’s generic stuff;
* implements `ToJSON` instances for the `Term` type for each language, and the `AST.Token` type;
* makes the --json flag use precise parsing by default.

You can recover the old behavior by passing `--ruby-mode=ALaCarte`,
etc., but this is more in keeping with the behavior of `parse --show`
and `parse --sexpression`.