### PR TITLE
Fix Haddock generation.

### DIFF
--- a/semantic-tags/src/Tags/Tag.hs
+++ b/semantic-tags/src/Tags/Tag.hs
@@ -23,5 +23,5 @@ data Kind
   | Module
   -- References
   | Call
-  -- | Constant -- TODO: New kind for constant references
+  -- Constant -- TODO: New kind for constant references
   deriving (Bounded, Enum, Eq, Show)

--- a/src/Data/Abstract/Evaluatable.hs
+++ b/src/Data/Abstract/Evaluatable.hs
@@ -244,7 +244,7 @@ data EvalError term address value return where
   DerefError          :: value -> EvalError term address value value
   ExportError         :: ModulePath -> Name -> EvalError term address value ()
   FloatFormatError    :: Text -> EvalError term address value Scientific
-  -- ^ Indicates that our evaluator wasn't able to make sense of these literals.
+  -- Indicates that our evaluator wasn't able to make sense of these literals.
   IntegerFormatError  :: Text -> EvalError term address value Integer
   NoNameError         :: term -> EvalError term address value Name
   RationalFormatError :: Text -> EvalError term address value Rational


### PR DESCRIPTION
I found myself wanting a Haddock docset for PHP tags work.
Unfortunately, haddocset is behind a GHC version, so it does not
function correctly. At least HTML works, when you pull these
few Haddock-tag changes in.