### PR TITLE
Extract precise tags from Python f-strings

### DIFF
--- a/test/Examples.hs
+++ b/test/Examples.hs
@@ -52,7 +52,7 @@ le = LanguageExample
 examples :: [LanguageExample]
 examples =
   [ le "go" "**/*.go" goFileSkips goDirSkips
-  , le "python" "**/*.py" mempty mempty
+  , le "python" "**/*.py" pythonFileSkips mempty
   , le "ruby" "**/*.rb" rubySkips mempty
   , le "typescript" "**/*.[jt]s" typescriptSkips mempty
   , le "typescript" "**/*.[jt]sx" tsxSkips mempty
@@ -98,6 +98,14 @@ goDirSkips = Path.relDir <$>
   , "go/test/syntax"
   , "go/test/method4.dir"
   , "go/test"
+  ]
+
+pythonFileSkips :: [Path.RelFile]
+pythonFileSkips = Path.relPath <$>
+  [
+  -- Assignment doesn't handle f-strings
+    "thealgorithms/analysis/compression_analysis/psnr.py"
+  , "thealgorithms/maths/greater_common_divisor.py"
   ]
 
 rubySkips :: [Path.RelFile]


### PR DESCRIPTION
Python f-strings can contain embedded expressions:

``` python
def x():
    return 5
f"hello there {x()} people"
```

The precise tagging definitions now traverse into f-strings, and any interpolations that they contain, so that we can generate tags for any function calls that appear in them.