### PR TITLE
Make the Span field of a file lazy.

### DIFF
--- a/semantic-analysis/src/Analysis/File.hs
+++ b/semantic-analysis/src/Analysis/File.hs
@@ -16,7 +16,7 @@ import qualified System.Path.PartClass as Path.PartClass
 
 data File a = File
   { filePath :: !Path.AbsRelFile
-  , fileSpan :: {-# UNPACK #-} !Span
+  , fileSpan :: Span
   , fileBody :: !a
   }
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)


### PR DESCRIPTION
Computing the full span of a file with a large (100,000+ line) file
can be very computationally intensive. Switching to a lazy field means
that we don't pay that cost unless we need to.

Big hattip to @tclem for triaging this issue.