### PR TITLE
Remove Timeout carrier and implement it with liftWith.

### DIFF
--- a/semantic.cabal
+++ b/semantic.cabal
@@ -119,6 +119,7 @@ library
                      , Control.Effect.Parse
                      , Control.Effect.REPL
                      , Control.Effect.Sum.Project
+                     , Control.Effect.Timeout
                      -- Datatypes for abstract interpretation
                      , Data.Abstract.Address.Hole
                      , Data.Abstract.Address.Monovariant
@@ -240,7 +241,6 @@ library
                      , Semantic.Telemetry.Error
                      , Semantic.Telemetry.Log
                      , Semantic.Telemetry.Stat
-                     , Semantic.Timeout
                      , Semantic.Util
                      , Semantic.Util.Pretty
                      , Semantic.Version

--- a/src/Control/Carrier/Parse/Measured.hs
+++ b/src/Control/Carrier/Parse/Measured.hs
@@ -21,6 +21,7 @@ import           Control.Algebra
 import           Control.Effect.Error
 import           Control.Effect.Parse
 import           Control.Effect.Reader
+import           Control.Effect.Timeout
 import           Control.Effect.Trace
 import           Control.Exception
 import           Control.Monad
@@ -35,7 +36,6 @@ import           Parsing.TreeSitter
 import           Semantic.Config
 import           Semantic.Task (TaskSession (..))
 import           Semantic.Telemetry
-import           Semantic.Timeout
 import           Source.Source (Source)
 
 newtype ParseC m a = ParseC { runParse :: m a }
@@ -44,7 +44,6 @@ newtype ParseC m a = ParseC { runParse :: m a }
 instance ( Has (Error SomeException) sig m
          , Has (Reader TaskSession) sig m
          , Has Telemetry sig m
-         , Has Timeout sig m
          , Has Trace sig m
          , MonadIO m
          )
@@ -53,10 +52,17 @@ instance ( Has (Error SomeException) sig m
   alg (R other)                 = ParseC (alg (handleCoercible other))
 
 -- | Parse a 'Blob' in 'IO'.
-runParser :: (Has (Error SomeException) sig m, Has (Reader TaskSession) sig m, Has Telemetry sig m, Has Timeout sig m, Has Trace sig m, MonadIO m)
-          => Blob
-          -> Parser term
-          -> m term
+runParser ::
+  ( Has (Error SomeException) sig m
+  , Has (Reader TaskSession) sig m
+  , Has Telemetry sig m
+  , Has (Lift IO) sig m
+  , Has Trace sig m
+  , MonadIO m
+  )
+  => Blob
+  -> Parser term
+  -> m term
 runParser blob@Blob{..} parser = case parser of
   ASTParser language ->
     time "parse.tree_sitter_ast_parse" languageTag $ do
@@ -70,7 +76,7 @@ runParser blob@Blob{..} parser = case parser of
 
   AssignmentParser    parser assignment -> runAssignment Assignment.assign    parser blob assignment
 
-  where 
+  where
     languageTag = [("language" :: String, show (blobLanguage blob))]
     executeParserAction act = do
       -- Test harnesses can specify that parsing must fail, for testing purposes.
@@ -90,7 +96,6 @@ runAssignment
      , Has (Error SomeException) sig m
      , Has (Reader TaskSession) sig m
      , Has Telemetry sig m
-     , Has Timeout sig m
      , Has Trace sig m
      , MonadIO m
      )

--- a/src/Control/Carrier/Parse/Measured.hs
+++ b/src/Control/Carrier/Parse/Measured.hs
@@ -19,6 +19,7 @@ module Control.Carrier.Parse.Measured
 import qualified Assigning.Assignment as Assignment
 import           Control.Algebra
 import           Control.Effect.Error
+import           Control.Effect.Lift
 import           Control.Effect.Parse
 import           Control.Effect.Reader
 import           Control.Effect.Timeout
@@ -45,6 +46,7 @@ instance ( Has (Error SomeException) sig m
          , Has (Reader TaskSession) sig m
          , Has Telemetry sig m
          , Has Trace sig m
+         , Has (Lift IO) sig m
          , MonadIO m
          )
       => Algebra (Parse :+: sig) (ParseC m) where
@@ -97,6 +99,7 @@ runAssignment
      , Has (Reader TaskSession) sig m
      , Has Telemetry sig m
      , Has Trace sig m
+     , Has (Lift IO) sig m
      , MonadIO m
      )
   => (Source -> assignment (term Assignment.Loc) -> ast -> Either (Error.Error String) (term Assignment.Loc))

--- a/src/Control/Effect/Timeout.hs
+++ b/src/Control/Effect/Timeout.hs
@@ -6,6 +6,7 @@ module Control.Effect.Timeout
 
 import           Control.Algebra
 import           Control.Effect.Lift
+import           Data.Duration
 import qualified System.Timeout as System
 
 -- | Run an action with a timeout. Returns 'Nothing' when no result is available
@@ -13,10 +14,10 @@ import qualified System.Timeout as System
 -- about not operating over FFI boundaries apply.
 --
 -- Any state changes in the action are discarded iff the timeout fails.
-timeout :: Has (Lift IO) sig m => Int -> m a -> m (Maybe a)
+timeout :: Has (Lift IO) sig m => Duration -> m a -> m (Maybe a)
 timeout n m = liftWith $ \ ctx hdl
   -> maybe
      -- Restore the old state if it timed out.
      (Nothing <$ ctx)
      -- Apply it if it succeeded.
-     (fmap Just) <$> System.timeout n (hdl (m <$ ctx))
+     (fmap Just) <$> System.timeout (toMicroseconds n) (hdl (m <$ ctx))

--- a/src/Control/Effect/Timeout.hs
+++ b/src/Control/Effect/Timeout.hs
@@ -13,7 +13,7 @@ import qualified System.Timeout as System
 -- within the specified duration. Uses 'System.Timeout.timeout' so all caveats
 -- about not operating over FFI boundaries apply.
 --
--- Any state changes in the action are discarded iff the timeout fails.
+-- Any state changes in the action are discarded if the timeout fails.
 timeout :: Has (Lift IO) sig m => Duration -> m a -> m (Maybe a)
 timeout n m = liftWith $ \ ctx hdl
   -> maybe

--- a/src/Control/Effect/Timeout.hs
+++ b/src/Control/Effect/Timeout.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-module Semantic.Timeout
+module Control.Effect.Timeout
 ( timeout
 ) where
 

--- a/src/Semantic/Task.hs
+++ b/src/Semantic/Task.hs
@@ -58,7 +58,6 @@ import           Control.Algebra
 import           Control.Carrier.Error.Either
 import           Control.Carrier.Lift
 import           Control.Carrier.Reader
-import           Control.Effect.Timeout
 import           Control.Effect.Trace
 import           Control.Exception
 import           Control.Monad.IO.Class

--- a/src/Semantic/Task.hs
+++ b/src/Semantic/Task.hs
@@ -58,6 +58,7 @@ import           Control.Algebra
 import           Control.Carrier.Error.Either
 import           Control.Carrier.Lift
 import           Control.Carrier.Reader
+import           Control.Effect.Timeout
 import           Control.Effect.Trace
 import           Control.Exception
 import           Control.Monad.IO.Class
@@ -68,7 +69,6 @@ import           Semantic.Distribute
 import           Semantic.Resolution
 import qualified Semantic.Task.Files as Files
 import           Semantic.Telemetry
-import           Semantic.Timeout
 import           Serializing.Format hiding (Options)
 
 -- | A high-level task producing some result, e.g. parsing, diffing, rendering. 'Task's can also specify explicit concurrency via 'distribute', 'distributeFor', and 'distributeFoldMap'
@@ -108,7 +108,6 @@ runTask taskSession@TaskSession{..} task = do
         run
           = runM
           . withDistribute
-          . withTimeout
           . runError
           . runTelemetry logger statter
           . runTraceInTelemetry

--- a/src/Semantic/Task.hs
+++ b/src/Semantic/Task.hs
@@ -80,9 +80,8 @@ type TaskC
   ( TraceInTelemetryC
   ( TelemetryC
   ( ErrorC SomeException
-  ( TimeoutC
   ( DistributeC
-  ( LiftC IO)))))))))
+  ( LiftC IO))))))))
 
 serialize :: Has (Reader Config) sig m
           => Format input

--- a/src/Semantic/Timeout.hs
+++ b/src/Semantic/Timeout.hs
@@ -1,66 +1,22 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, RankNTypes, UndecidableInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 module Semantic.Timeout
 ( timeout
-, Timeout
-, runTimeout
-, withTimeout
-, TimeoutC(..)
-, Duration(..)
 ) where
 
 import           Control.Algebra
-import           Control.Carrier.Reader
-import           Control.Monad.IO.Class
-import           Control.Monad.IO.Unlift
-import           Data.Duration
+import           Control.Effect.Lift
 import qualified System.Timeout as System
 
 -- | Run an action with a timeout. Returns 'Nothing' when no result is available
 -- within the specified duration. Uses 'System.Timeout.timeout' so all caveats
 -- about not operating over FFI boundaries apply.
-timeout :: Has Timeout sig m => Duration -> m output -> m (Maybe output)
-timeout n = send . flip (Timeout n) pure
-
--- | 'Timeout' effects run other effects, aborting them if they exceed the
--- specified duration.
-data Timeout m k
-  = forall a . Timeout Duration (m a) (Maybe a -> m k)
-
-deriving instance Functor m => Functor (Timeout m)
-
-instance HFunctor Timeout where
-  hmap f (Timeout n task k) = Timeout n (f task) (f . k)
-
-instance Effect Timeout where
-  thread state handler (Timeout n task k) = Timeout n (handler (task <$ state)) (handler . maybe (k Nothing <$ state) (fmap (k . Just)))
-
--- | Evaulate a 'Timeout' effect.
-runTimeout :: (forall x . m x -> IO x)
-           -> TimeoutC m a
-           -> m a
-runTimeout handler = runReader (Handler handler) . runTimeoutC
-
--- | A helper for 'runTimeout' that uses 'withRunInIO' to automatically
--- select a correct unlifting function.
-withTimeout :: MonadUnliftIO m
-            => TimeoutC m a
-            -> m a
-withTimeout r = withRunInIO (\f -> runHandler (Handler f) r)
-
-newtype Handler m = Handler (forall x . m x -> IO x)
-
-runHandler :: Handler m -> TimeoutC m a -> IO a
-runHandler h@(Handler handler) = handler . runReader h . runTimeoutC
-
-newtype TimeoutC m a = TimeoutC { runTimeoutC :: ReaderC (Handler m) m a }
-  deriving (Functor, Applicative, Monad, MonadFail, MonadIO)
-
-instance MonadUnliftIO m => MonadUnliftIO (TimeoutC m) where
-  askUnliftIO = TimeoutC . ReaderC $ \(Handler h) ->
-    withUnliftIO $ \u -> pure (UnliftIO $ \r -> unliftIO u (runTimeout h r))
-
-instance (Algebra sig m, MonadIO m) => Algebra (Timeout :+: sig) (TimeoutC m) where
-  alg (L (Timeout n task k)) = do
-    handler <- TimeoutC ask
-    liftIO (System.timeout (toMicroseconds n) (runHandler handler task)) >>= k
-  alg (R other) = TimeoutC (alg (R (handleCoercible other)))
+--
+-- Any state changes in the action are discarded iff the timeout fails.
+timeout :: Has (Lift IO) sig m => Int -> m a -> m (Maybe a)
+timeout n m = liftWith $ \ ctx hdl
+  -> maybe
+     -- Restore the old state if it timed out.
+     (Nothing <$ ctx)
+     -- Apply it if it succeeded.
+     (fmap Just) <$> System.timeout n (hdl (m <$ ctx))


### PR DESCRIPTION
This carrier is no longer necessary, because we can perform the needed
lifting and state manipulation with `liftWith`.