### PR TITLE
Detect and tag functions in variable_declarators

### DIFF
--- a/semantic-tsx/src/Language/TSX/Tags.hs
+++ b/semantic-tsx/src/Language/TSX/Tags.hs
@@ -112,6 +112,19 @@ instance ToTags Tsx.Module where
         _                           -> gtags t
       yield text = yieldTag text Module loc byteRange >> gtags t
 
+instance ToTags Tsx.VariableDeclarator where
+  tags t@Tsx.VariableDeclarator
+    { ann = loc@Loc { byteRange }
+    , name
+    , value = Just (Tsx.Expression expr)
+    } = case (expr, name) of
+          (Prj Tsx.Function{}, Prj Tsx.Identifier { text }) -> yield text
+          (Prj Tsx.ArrowFunction{}, Prj Tsx.Identifier { text }) -> yield text
+          _ -> gtags t
+    where
+      yield text = yieldTag text Function loc byteRange >> gtags t
+  tags t = gtags t
+
 instance (ToTags l, ToTags r) => ToTags (l :+: r) where
   tags (L1 l) = tags l
   tags (R1 r) = tags r
@@ -295,7 +308,7 @@ instance ToTags Tsx.Undefined
 instance ToTags Tsx.UnionType
 instance ToTags Tsx.UpdateExpression
 instance ToTags Tsx.VariableDeclaration
-instance ToTags Tsx.VariableDeclarator
+-- instance ToTags Tsx.VariableDeclarator
 instance ToTags Tsx.WhileStatement
 instance ToTags Tsx.WithStatement
 instance ToTags Tsx.YieldExpression

--- a/semantic-typescript/src/Language/TypeScript/Tags.hs
+++ b/semantic-typescript/src/Language/TypeScript/Tags.hs
@@ -105,6 +105,19 @@ instance ToTags Ts.Module where
         _                          -> gtags t
       yield text = yieldTag text Module loc byteRange >> gtags t
 
+instance ToTags Ts.VariableDeclarator where
+  tags t@Ts.VariableDeclarator
+    { ann = loc@Loc { byteRange }
+    , name
+    , value = Just (Ts.Expression expr)
+    } = case (expr, name) of
+          (Prj Ts.Function{}, Prj Ts.Identifier { text }) -> yield text
+          (Prj Ts.ArrowFunction{}, Prj Ts.Identifier { text }) -> yield text
+          _ -> gtags t
+    where
+      yield text = yieldTag text Function loc byteRange >> gtags t
+  tags t = gtags t
+
 instance (ToTags l, ToTags r) => ToTags (l :+: r) where
   tags (L1 l) = tags l
   tags (R1 r) = tags r
@@ -289,7 +302,7 @@ instance ToTags Ts.Undefined
 instance ToTags Ts.UnionType
 instance ToTags Ts.UpdateExpression
 instance ToTags Ts.VariableDeclaration
-instance ToTags Ts.VariableDeclarator
+-- instance ToTags Ts.VariableDeclarator
 instance ToTags Ts.WhileStatement
 instance ToTags Ts.WithStatement
 instance ToTags Ts.YieldExpression


### PR DESCRIPTION
Picks up a few cases where `variable_declarators` define functions in JavaScript/TypeScript and includes those in the symbols/tags output.