### PR TITLE
Remove `readBlobsFromDir` and `codeNavLanguages`.

### DIFF
--- a/src/Data/Blob/IO.hs
+++ b/src/Data/Blob/IO.hs
@@ -12,7 +12,6 @@ module Data.Blob.IO
 import           Analysis.Blob
 import           Analysis.File as File
 import           Analysis.Project
-import qualified Control.Concurrent.Async as Async
 import           Control.Monad.IO.Class
 import           Data.Blob
 import qualified Data.ByteString as B

--- a/src/Data/Blob/IO.hs
+++ b/src/Data/Blob/IO.hs
@@ -5,7 +5,6 @@ module Data.Blob.IO
   ( readBlobFromFile
   , readBlobFromFile'
   , readBlobFromPath
-  , readBlobsFromDir
   , readFilePair
   , readProjectFromPaths
   ) where
@@ -67,11 +66,6 @@ readBlobFromFile' file = do
 -- | Read a blob from the provided absolute or relative path , failing if it can't be found.
 readBlobFromPath :: (MonadFail m, MonadIO m) => Path.AbsRelFile -> m Blob
 readBlobFromPath = readBlobFromFile' . File.fromPath
-
--- | Read all blobs in the directory with Language.supportedExts.
-readBlobsFromDir :: MonadIO m => Path.AbsRelDir -> m [Blob]
-readBlobsFromDir path = liftIO . fmap catMaybes $
-  findFilesInDir path supportedExts mempty >>= Async.mapConcurrently (readBlobFromFile . File.fromPath)
 
 readFilePair :: MonadIO m => File Language -> File Language -> m BlobPair
 readFilePair a b = do

--- a/src/Data/Language.hs
+++ b/src/Data/Language.hs
@@ -7,10 +7,7 @@ module Data.Language
   , aLaCarteLanguageModes
   ) where
 
-import qualified Data.Languages as Lingo
-import qualified Data.Map.Strict as Map
-import qualified Data.Text as T
-import           Source.Language
+import Source.Language
 
 data PerLanguageModes = PerLanguageModes
   { pythonMode     :: LanguageMode

--- a/src/Data/Language.hs
+++ b/src/Data/Language.hs
@@ -5,26 +5,12 @@ module Data.Language
   , defaultLanguageModes
   , preciseLanguageModes
   , aLaCarteLanguageModes
-  , codeNavLanguages
-  , supportedExts
   ) where
 
 import qualified Data.Languages as Lingo
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import           Source.Language
-
-codeNavLanguages :: [Language]
-codeNavLanguages = [Go, Java, Ruby, Python, JavaScript, TypeScript, PHP]
-
-supportedExts :: [String]
-supportedExts = foldr append mempty supportedLanguages
-  where
-    append (Just l) b = fmap T.unpack (Lingo.languageExtensions l) <> b
-    append Nothing  b = b
-    supportedLanguages = fmap lookup (languageToText <$> codeNavLanguages)
-    lookup k = Map.lookup k Lingo.languages
-
 
 data PerLanguageModes = PerLanguageModes
   { pythonMode     :: LanguageMode

--- a/src/Semantic/Task/Files.hs
+++ b/src/Semantic/Task/Files.hs
@@ -47,7 +47,6 @@ import qualified System.Path.IO as IO (withBinaryFile)
 data Source blob where
   FromPath       :: File Language                   -> Source Blob
   FromHandle     :: Handle 'IO.ReadMode             -> Source [Blob]
-  FromDir        :: Path.AbsRelDir                  -> Source [Blob]
   FromPathPair   :: File Language -> File Language  -> Source BlobPair
   FromPairHandle :: Handle 'IO.ReadMode             -> Source [BlobPair]
 
@@ -86,7 +85,6 @@ instance (Has (Error SomeException) sig m, MonadFail m, MonadIO m) => Algebra (F
   alg (L op) = case op of
     Read (FromPath path) k                                    -> readBlobFromFile' path >>= k
     Read (FromHandle handle) k                                -> readBlobsFromHandle handle >>= k
-    Read (FromDir dir) k                                      -> readBlobsFromDir dir >>= k
     Read (FromPathPair p1 p2) k                               -> readFilePair p1 p2 >>= k
     Read (FromPairHandle handle) k                            -> readBlobPairsFromHandle handle >>= k
     ReadProject rootDir dir language excludeDirs k            -> readProjectFromPaths rootDir dir language excludeDirs >>= k

--- a/test/Data/Language/Spec.hs
+++ b/test/Data/Language/Spec.hs
@@ -7,13 +7,7 @@ import           Test.Tasty.HUnit
 
 testTree :: TestTree
 testTree = testGroup "Data.Language"
-  [ testCase "supportedExts returns expected list" $
-      supportedExts @=? [".go",".java",".rb",".builder",".eye",".fcgi",".gemspec",".god",".jbuilder",".mspec",".pluginspec",".podspec",".rabl",".rake",".rbi",".rbuild",".rbw",".rbx",".ru",".ruby",".spec",".thor",".watchr",".py",".cgi",".fcgi",".gyp",".gypi",".lmi",".py3",".pyde",".pyi",".pyp",".pyt",".pyw",".rpy",".smk",".spec",".tac",".wsgi",".xpy",".js","._js",".bones",".cjs",".es",".es6",".frag",".gs",".jake",".jsb",".jscad",".jsfl",".jsm",".jss",".mjs",".njs",".pac",".sjs",".ssjs",".xsjs",".xsjslib",".ts",".php",".aw",".ctp",".fcgi",".inc",".php3",".php4",".php5",".phps",".phpt"]
-
-  , testCase "codeNavLanguages returns expected list" $
-      codeNavLanguages @=? [Go, Java, Ruby, Python, JavaScript, TypeScript, PHP]
-
-  , testCase "languageForFilePath works for languages with ambiguous lingo extensions" $ do
+  [ testCase "languageForFilePath works for languages with ambiguous lingo extensions" $ do
       Language.forPath (Path.relFile "foo.php") @=? PHP
       Language.forPath (Path.relFile "foo.md" ) @=? Markdown
       Language.forPath (Path.relFile "foo.tsx") @=? TSX


### PR DESCRIPTION
These weren't being called anywhere but the tests, and as such are
little more than make-work whenever we add new features.