### PR TITLE
Use env bash because /bin/bash does not exists in nixos

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cabal v2-update

--- a/script/build-and-upload
+++ b/script/build-and-upload
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage: script/build-and-upload PROJECT_NAME
 # where PROJECT_NAME is one of the packages present in this repo:

--- a/script/clone-example-repos
+++ b/script/clone-example-repos
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #/ Usage: script/clone-example-repos
 #/
 #/ Clone some example repositories for smoke testing parsing, assignment, and precise ASTs.

--- a/script/fix-broken-cabal-store
+++ b/script/fix-broken-cabal-store
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 store_dir="$HOME/.cabal/store/ghc-$(ghc --numeric-version)"
 

--- a/script/generate-example
+++ b/script/generate-example
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #/ Usage: script/generate-example fileA fileB
 #/        script/generate-example directory
 #/

--- a/script/ghci-flags
+++ b/script/ghci-flags
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Computes the flags for ghcide to pass to ghci. You probably won’t be running this yourself, but rather ghcide will via configuration in hie.yaml.
 
 set -e

--- a/script/ghci-flags-dependencies
+++ b/script/ghci-flags-dependencies
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Computes the paths to files causing changes to the ghci flags. You probably won’t be running this yourself, but rather ghcide will via configuration in hie.yaml.
 
 set -e

--- a/script/profile
+++ b/script/profile
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Usage: script/profile FILE_A FILE_B
 # Builds and runs semantic on the given files with profiling enabled.
 

--- a/script/publish
+++ b/script/publish
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #/ Usage: script/publish
 #/
 #/ Build a docker image of the semantic CLI and publish to the GitHub Package Registry

--- a/script/repl
+++ b/script/repl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Usage: script/repl [ARGS...]
 # Run a repl session capable of loading all of the packages and their individual components. Any passed arguments, e.g. module names or flags, will be passed to ghci.
 


### PR DESCRIPTION
It may sounds strange, but `/bin/bash` does not exists in nixos.  So I replace /bin/bash with `/usr/bin/env bash` so it is easier to develop under nixos.