### PR TITLE
Introduce Type data constructor for Kind

### DIFF
--- a/semantic-codeql/src/Language/CodeQL/Tags.hs
+++ b/semantic-codeql/src/Language/CodeQL/Tags.hs
@@ -115,6 +115,14 @@ instance ToTags CodeQL.QualifiedRhs where
           Just (Prj t@CodeQL.PredicateName { text }) -> yieldTag text Call loc byteRange >> gtags t
           _                                          -> gtags t
 
+instance ToTags CodeQL.TypeExpr where
+  tags t@CodeQL.TypeExpr
+    { ann = loc@Loc { byteRange }
+    , name = expr
+    } = case expr of
+          Just (Prj CodeQL.ClassName { text }) -> yieldTag text Type loc byteRange >> gtags t
+          _                                    -> gtags t
+
 instance ToTags CodeQL.HigherOrderTerm
 instance ToTags CodeQL.AddExpr
 instance ToTags CodeQL.Any
@@ -164,7 +172,6 @@ instance ToTags CodeQL.OrderBys
 instance ToTags CodeQL.TypeAliasBody
 instance ToTags CodeQL.Charpred
 instance ToTags CodeQL.ParExpr
-instance ToTags CodeQL.TypeExpr
 instance ToTags CodeQL.IfTerm
 instance ToTags CodeQL.Plus
 instance ToTags CodeQL.TypeLiteral

--- a/semantic-tags/src/Tags/Tag.hs
+++ b/semantic-tags/src/Tags/Tag.hs
@@ -23,5 +23,7 @@ data Kind
   | Module
   -- References
   | Call
+  -- Types
+  | Type
   -- Constant -- TODO: New kind for constant references
   deriving (Bounded, Enum, Eq, Show)


### PR DESCRIPTION
@alexet kindly pointed out that we currently extract type data in the form of class names, but we weren't extracting their relevant type references. This patch introduces `Type` as a data constructor for `Kind`, and introduces a `ToTags` instance for `CodeQL`'s `TypeExpr` syntax to extract the class name and return it as a symbol whose kind is `Type`.

Previously, `CodeQL` in the form of:

```codeql
Expr trailingArgumentIn(FunctionCall fc) {
    fc = this.getACallToThisFunction() and
    result = fc.getArgument(fc.getNumberOfArguments() - 1)
  }
```

Would not extract the `Expr` as a reference. This patch extracts `Expr` now as a `Type`  and indicates the return type of the `trailingArgumentln` predicate in the form of:

```ruby
<Semanticd::Proto::Symbol: symbol: "Expr", kind: "Type", line: "Expr", span: ...
```