### PR TITLE
Stat and log for precise ast parse failures

### DIFF
--- a/src/Control/Carrier/Parse/Measured.hs
+++ b/src/Control/Carrier/Parse/Measured.hs
@@ -71,10 +71,14 @@ runParser blob@Blob{..} parser = case parser of
       config <- asks config
       executeParserAction (parseToAST (configTreeSitterParseTimeout config) language blob)
 
-  UnmarshalParser language ->
-    time "parse.tree_sitter_precise_ast_parse" languageTag $ do
+  UnmarshalParser language -> do
+    (time "parse.tree_sitter_precise_ast_parse" languageTag $ do
       config <- asks config
-      executeParserAction (parseToPreciseAST (configTreeSitterParseTimeout config) (configTreeSitterUnmarshalTimeout config) language blob)
+      executeParserAction (parseToPreciseAST (configTreeSitterParseTimeout config) (configTreeSitterUnmarshalTimeout config) language blob))
+    `catchError` (\(SomeException e) -> do
+      writeStat (increment "parse.precise_ast_parse_failures" languageTag)
+      writeLog Error "precise parsing failed" (("task", "parse") : ("exception", "\"" <> displayException e <> "\"") : languageTag)
+      throwError (SomeException e))
 
   AssignmentParser    parser assignment -> runAssignment Assignment.assign    parser blob assignment
 

--- a/src/Parsing/TreeSitter.hs
+++ b/src/Parsing/TreeSitter.hs
@@ -80,7 +80,7 @@ instance Exc.Exception TSParseException where
     ParserTimedOut -> "tree-sitter: parser timed out"
     IncompatibleVersions -> "tree-sitter: incompatible versions"
     UnmarshalTimedOut -> "tree-sitter: unmarshal timed out"
-    UnmarshalFailure s -> "tree-sitter: unmarshal failure - " <> show s
+    UnmarshalFailure s -> "tree-sitter: unmarshal failure: " <> s
 
 runParse
   :: MonadIO m


### PR DESCRIPTION
Brings back some stats for when precise ast parsing fails. Slight adjustment to tree-sitter error message to make formatted logs a bit nicer.