### PR TITLE
Give script/repl some better defaults.

### DIFF
--- a/.ghci.repl
+++ b/.ghci.repl
@@ -25,3 +25,24 @@
 :seti -Wno-unsafe
 :seti -Wno-star-is-type
 :seti -Wno-missing-deriving-strategies
+
+-- Turn on some language extensions you use a lot
+:seti -XFlexibleContexts -XOverloadedStrings -XTypeApplications
+
+-- Break on errors
+:seti -fbreak-on-error
+
+-- Automatically show the code around breakpoints
+:set stop :list
+
+-- Use a cyan lambda as the prompt
+:set prompt "\ESC[1;36m\STXλ \ESC[m\STX"
+
+-- Better errors
+:set -ferror-spans -freverse-errors -fprint-expanded-synonyms
+
+-- Better typed holes
+:set -funclutter-valid-hole-fits -fabstract-refinement-hole-fits -frefinement-level-hole-fits=2
+
+-- This usually impairs understanding
+:seti -Wno-type-defaults


### PR DESCRIPTION
Our `.ghci.sample` contains some really useful defaults, like turning
on the most common language extensions and providing better hole
information. This makes things a little nicer.