### PR TITLE
More specific Haskell version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Put protoc and twirp tooling in its own image
-FROM haskell:8.8.1 as haskell
+FROM haskell:8.8.3 as haskell
 RUN cabal v2-update && \
     cabal v2-install proto-lens-protoc
 RUN which proto-lens-protoc
@@ -22,7 +22,7 @@ COPY --from=haskell /opt/ghc/8.8.1/lib/ghc-8.8.1/* /opt/ghc/8.8.1/lib/ghc-8.8.1/
 ENTRYPOINT ["/protobuf/bin/protoc", "-I/protobuf", "--plugin=protoc-gen-haskell=/usr/local/bin/proto-lens-protoc"]
 
 # Build semantic
-FROM haskell:8.8.1 as build
+FROM haskell:8.8.3 as build
 WORKDIR /build
 
 # Build all of semantic

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN go get github.com/golang/protobuf/proto && \
 COPY --from=haskell /root/.cabal/bin/proto-lens-protoc /usr/local/bin/proto-lens-protoc
 
 # Bit of a hack so that proto-lens-protoc actually runs
-COPY --from=haskell /opt/ghc/8.8.1/lib/ghc-8.8.1/* /opt/ghc/8.8.1/lib/ghc-8.8.1/
+COPY --from=haskell /opt/ghc/8.8.3/lib/ghc-8.8.3/* /opt/ghc/8.8.3/lib/ghc-8.8.3/
 
 ENTRYPOINT ["/protobuf/bin/protoc", "-I/protobuf", "--plugin=protoc-gen-haskell=/usr/local/bin/proto-lens-protoc"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Put protoc and twirp tooling in its own image
-FROM haskell:8.8 as haskell
+FROM haskell:8.8.1 as haskell
 RUN cabal v2-update && \
     cabal v2-install proto-lens-protoc
 RUN which proto-lens-protoc
@@ -22,7 +22,7 @@ COPY --from=haskell /opt/ghc/8.8.1/lib/ghc-8.8.1/* /opt/ghc/8.8.1/lib/ghc-8.8.1/
 ENTRYPOINT ["/protobuf/bin/protoc", "-I/protobuf", "--plugin=protoc-gen-haskell=/usr/local/bin/proto-lens-protoc"]
 
 # Build semantic
-FROM haskell:8.8 as build
+FROM haskell:8.8.1 as build
 WORKDIR /build
 
 # Build all of semantic


### PR DESCRIPTION
Hi there!

Simple fix here.

On current `master` (36de4f6e8e9b41aecb0de0b070b796abd956a163), running `docker build` on the `Dockerfile` results in the following error:

```
Step 10/20 : COPY --from=haskell /opt/ghc/8.8.1/lib/ghc-8.8.1/* /opt/ghc/8.8.1/lib/ghc-8.8.1/
COPY failed: no source files were specified
```

This is because haskell:8.8 is now at 8.8.3 so all the files are in `/opt/ghc/8.8.3`.

Solution is to make the haskell image tag versions more specific.

Hope this is helpful.
Thanks!
Jieren