### PR TITLE
Tag Java interfaces and interface implementations.

### DIFF
--- a/semantic-java/src/Language/Java/Tags.hs
+++ b/semantic-java/src/Language/Java/Tags.hs
@@ -82,12 +82,11 @@ instance ToTags Java.MethodInvocation where
 
 instance ToTags Java.InterfaceDeclaration where
   tags t@Java.InterfaceDeclaration
-    { ann = loc@Loc { byteRange = Range { start } }
+    { ann = loc@Loc { byteRange  }
     , name = Java.Identifier { text = name }
-    , body = Java.InterfaceBody { ann = Loc Range { start = end } _ }
     } = do
       src <- ask @Source
-      Tags.yield (Tag name Interface loc (Tags.firstLine src (Range start end)) Nothing)
+      Tags.yield (Tag name Interface loc (Tags.firstLine src byteRange) Nothing)
       gtags t
 
 instance ToTags Java.InterfaceTypeList where

--- a/semantic-java/src/Language/Java/Tags.hs
+++ b/semantic-java/src/Language/Java/Tags.hs
@@ -8,11 +8,12 @@ module Language.Java.Tags
 ( ToTags(..)
 ) where
 
+import           AST.Element
 import           AST.Token
 import           AST.Traversable1
 import           Control.Effect.Reader
 import           Control.Effect.Writer
-import           GHC.Generics ((:+:)(..))
+import           Data.Foldable
 import qualified Language.Java.AST as Java
 import           Source.Loc
 import           Source.Range
@@ -57,6 +58,9 @@ instance ToTags Java.MethodDeclaration where
       Tags.yield (Tag name Method loc line Nothing)
       gtags t
 
+-- TODO: we can coalesce a lot of these instances given proper use of HasField
+-- to do the equivalent of type-generic pattern-matching.
+
 instance ToTags Java.ClassDeclaration where
   tags t@Java.ClassDeclaration
     { ann = loc@Loc { byteRange = Range { start } }
@@ -76,6 +80,24 @@ instance ToTags Java.MethodInvocation where
       Tags.yield (Tag name Call loc (Tags.firstLine src range) Nothing)
       gtags t
 
+instance ToTags Java.InterfaceDeclaration where
+  tags t@Java.InterfaceDeclaration
+    { ann = loc@Loc { byteRange = Range { start } }
+    , name = Java.Identifier { text = name }
+    , body = Java.InterfaceBody { ann = Loc Range { start = end } _ }
+    } = do
+      src <- ask @Source
+      Tags.yield (Tag name Interface loc (Tags.firstLine src (Range start end)) Nothing)
+      gtags t
+
+instance ToTags Java.InterfaceTypeList where
+  tags t@Java.InterfaceTypeList { extraChildren = interfaces } = do
+    src <- ask @Source
+    for_ interfaces $ \x -> case x of
+      Java.Type (Prj (Java.UnannotatedType (Prj (Java.SimpleType ( Prj Java.TypeIdentifier { ann = loc@Loc {byteRange = range}, text = name }))))) ->
+        Tags.yield (Tag name Implementation loc (Tags.firstLine src range) Nothing)
+      _ -> pure ()
+    gtags t
 
 gtags
   :: ( Has (Reader Source) sig m
@@ -153,8 +175,8 @@ instance ToTags Java.InferredParameters
 instance ToTags Java.InstanceofExpression
 instance ToTags Java.IntegralType
 instance ToTags Java.InterfaceBody
-instance ToTags Java.InterfaceDeclaration
-instance ToTags Java.InterfaceTypeList
+--instance ToTags Java.InterfaceDeclaration
+-- instance ToTags Java.InterfaceTypeList
 instance ToTags Java.LabeledStatement
 instance ToTags Java.LambdaExpression
 instance ToTags Java.Literal

--- a/semantic-tags/src/Tags/Tag.hs
+++ b/semantic-tags/src/Tags/Tag.hs
@@ -24,7 +24,9 @@ data Kind
   -- References
   | Call
   | Type
-  -- Just as Call is to Class and Function, Implements is to Interface
+  -- Just as Call is to Class and Function, Implementation is to Interface.
+  -- This suggests that perhaps we should have an Instantiation kind that
+  -- we use for Class.
   | Interface
   | Implementation
   -- Constant -- TODO: New kind for constant references

--- a/semantic-tags/src/Tags/Tag.hs
+++ b/semantic-tags/src/Tags/Tag.hs
@@ -23,7 +23,9 @@ data Kind
   | Module
   -- References
   | Call
-  -- Types
   | Type
+  -- Just as Call is to Class and Function, Implements is to Interface
+  | Interface
+  | Implementation
   -- Constant -- TODO: New kind for constant references
   deriving (Bounded, Enum, Eq, Show)


### PR DESCRIPTION
This patch adds tagging support to Java `InterfaceDeclaration` and
`InterfaceTypeList` nodes. To do so, we add two new constructors to
`Tags.Tag.Kind`: `Interface`, emitted by `InterfaceDeclaration`, and
`Implementation`, emitted by `implements` clauses in Java source. Some
modification of downstream services will be indicated.

Given 
```java
interface Top {
}


class Blah implements Top {}
```

a `semantic parse --json-symbols` invocation emits: 
```json
{
  "files": [
    {
      "path": "/Users/patrickt/src/semantic/test/fixtures/java/corpus/Interface.A.java",
      "language": "Java",
      "symbols": [
        {
          "symbol": "Top",
          "kind": "Interface",
          "line": "interface Top",
          "span": {
            "start": {
              "line": 1,
              "column": 1
            },
            "end": {
              "line": 2,
              "column": 2
            }
          }
        },
        {
          "symbol": "Blah",
          "kind": "Class",
          "line": "class Blah implements Top",
          "span": {
            "start": {
              "line": 5,
              "column": 1
            },
            "end": {
              "line": 5,
              "column": 29
            }
          }
        },
        {
          "symbol": "Top",
          "kind": "Implementation",
          "line": "Top",
          "span": {
            "start": {
              "line": 5,
              "column": 23
            },
            "end": {
              "line": 5,
              "column": 26
            }
          }
        }
      ]
    }
  ]
}
```