### PR TITLE
Constrain Loc for tags to the identifer

### DIFF
--- a/semantic-java/src/Language/Java/Tags.hs
+++ b/semantic-java/src/Language/Java/Tags.hs
@@ -4,37 +4,39 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
-module Language.Java.Tags
-( ToTags(..)
-) where
 
-import           AST.Element
-import           AST.Token
-import           AST.Traversable1
-import           Control.Effect.Reader
-import           Control.Effect.Writer
-import           Data.Foldable
+module Language.Java.Tags
+  ( ToTags (..),
+  )
+where
+
+import AST.Element
+import AST.Token
+import AST.Traversable1
+import Control.Effect.Reader
+import Control.Effect.Writer
+import Data.Foldable
 import qualified Language.Java.AST as Java
-import           Source.Loc
-import           Source.Range
-import           Source.Source as Source
-import           Tags.Tag
+import Source.Loc
+import Source.Range
+import Source.Source as Source
+import Tags.Tag
 import qualified Tags.Tagging.Precise as Tags
 
 class ToTags t where
-  tags
-    :: ( Has (Reader Source) sig m
-       , Has (Writer Tags.Tags) sig m
-       )
-    => t Loc
-    -> m ()
-  default tags
-    :: ( Has (Reader Source) sig m
-       , Has (Writer Tags.Tags) sig m
-       , Traversable1 ToTags t
-       )
-    => t Loc
-    -> m ()
+  tags ::
+    ( Has (Reader Source) sig m,
+      Has (Writer Tags.Tags) sig m
+    ) =>
+    t Loc ->
+    m ()
+  default tags ::
+    ( Has (Reader Source) sig m,
+      Has (Writer Tags.Tags) sig m,
+      Traversable1 ToTags t
+    ) =>
+    t Loc ->
+    m ()
   tags = gtags
 
 instance (ToTags l, ToTags r) => ToTags (l :+: r) where
@@ -44,67 +46,74 @@ instance (ToTags l, ToTags r) => ToTags (l :+: r) where
 instance ToTags (Token sym n) where tags _ = pure ()
 
 instance ToTags Java.MethodDeclaration where
-  tags t@Java.MethodDeclaration
-    { ann = loc@Loc { byteRange = range }
-    , name = Java.Identifier { text = name }
-    , body
-    } = do
+  tags
+    t@Java.MethodDeclaration
+      { ann = Loc {byteRange = range},
+        name = Java.Identifier {text, ann},
+        body
+      } = do
       src <- ask @Source
-      let line = Tags.firstLine src range
-            { end = case body of
-              Just Java.Block { ann = Loc Range { end } _ } -> end
-              Nothing                                       -> end range
-            }
-      Tags.yield (Tag name Method loc line Nothing)
+      let line =
+            Tags.firstLine
+              src
+              range
+                { end = case body of
+                    Just Java.Block {ann = Loc Range {end} _} -> end
+                    Nothing -> end range
+                }
+      Tags.yield (Tag text Method ann line Nothing)
       gtags t
 
 -- TODO: we can coalesce a lot of these instances given proper use of HasField
 -- to do the equivalent of type-generic pattern-matching.
 
 instance ToTags Java.ClassDeclaration where
-  tags t@Java.ClassDeclaration
-    { ann = loc@Loc { byteRange = Range { start } }
-    , name = Java.Identifier { text = name }
-    , body = Java.ClassBody { ann = Loc Range { start = end } _ }
-    } = do
+  tags
+    t@Java.ClassDeclaration
+      { ann = Loc {byteRange = Range {start}},
+        name = Java.Identifier {text, ann},
+        body = Java.ClassBody {ann = Loc Range {start = end} _}
+      } = do
       src <- ask @Source
-      Tags.yield (Tag name Class loc (Tags.firstLine src (Range start end)) Nothing)
+      Tags.yield (Tag text Class ann (Tags.firstLine src (Range start end)) Nothing)
       gtags t
 
 instance ToTags Java.MethodInvocation where
-  tags t@Java.MethodInvocation
-    { ann = loc@Loc { byteRange = range }
-    , name = Java.Identifier { text = name }
-    } = do
+  tags
+    t@Java.MethodInvocation
+      { ann = Loc {byteRange = range},
+        name = Java.Identifier {text, ann}
+      } = do
       src <- ask @Source
-      Tags.yield (Tag name Call loc (Tags.firstLine src range) Nothing)
+      Tags.yield (Tag text Call ann (Tags.firstLine src range) Nothing)
       gtags t
 
 instance ToTags Java.InterfaceDeclaration where
-  tags t@Java.InterfaceDeclaration
-    { ann = loc@Loc { byteRange  }
-    , name = Java.Identifier { text = name }
-    } = do
+  tags
+    t@Java.InterfaceDeclaration
+      { ann = Loc {byteRange},
+        name = Java.Identifier {text, ann}
+      } = do
       src <- ask @Source
-      Tags.yield (Tag name Interface loc (Tags.firstLine src byteRange) Nothing)
+      Tags.yield (Tag text Interface ann (Tags.firstLine src byteRange) Nothing)
       gtags t
 
 instance ToTags Java.InterfaceTypeList where
-  tags t@Java.InterfaceTypeList { extraChildren = interfaces } = do
+  tags t@Java.InterfaceTypeList {extraChildren = interfaces} = do
     src <- ask @Source
     for_ interfaces $ \x -> case x of
-      Java.Type (Prj (Java.UnannotatedType (Prj (Java.SimpleType ( Prj Java.TypeIdentifier { ann = loc@Loc {byteRange = range}, text = name }))))) ->
+      Java.Type (Prj (Java.UnannotatedType (Prj (Java.SimpleType (Prj Java.TypeIdentifier {ann = loc@Loc {byteRange = range}, text = name}))))) ->
         Tags.yield (Tag name Implementation loc (Tags.firstLine src range) Nothing)
       _ -> pure ()
     gtags t
 
-gtags
-  :: ( Has (Reader Source) sig m
-     , Has (Writer Tags.Tags) sig m
-     , Traversable1 ToTags t
-     )
-  => t Loc
-  -> m ()
+gtags ::
+  ( Has (Reader Source) sig m,
+    Has (Writer Tags.Tags) sig m,
+    Traversable1 ToTags t
+  ) =>
+  t Loc ->
+  m ()
 gtags = traverse1_ @ToTags (const (pure ())) tags
 
 instance ToTags Java.AnnotatedType

--- a/semantic-php/src/Language/PHP/Tags.hs
+++ b/semantic-php/src/Language/PHP/Tags.hs
@@ -5,34 +5,38 @@
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
-module Language.PHP.Tags (tags) where
 
-import           AST.Element
-import           AST.Token
-import           AST.Traversable1
-import           Control.Effect.Reader
-import           Control.Effect.Writer
-import           Data.Text (Text)
+module Language.PHP.Tags
+  ( tags,
+  )
+where
+
+import AST.Element
+import AST.Token
+import AST.Traversable1
+import Control.Effect.Reader
+import Control.Effect.Writer
+import Data.Text (Text)
 import qualified Language.PHP.AST as PHP
-import           Source.Loc
-import           Source.Source as Source
-import           Tags.Tag
+import Source.Loc
+import Source.Source as Source
+import Tags.Tag
 import qualified Tags.Tagging.Precise as Tags
 
 class ToTags t where
-  tags
-    :: ( Has (Reader Source) sig m
-       , Has (Writer Tags.Tags) sig m
-       )
-    => t Loc
-    -> m ()
-  default tags
-    :: ( Has (Reader Source) sig m
-       , Has (Writer Tags.Tags) sig m
-       , Traversable1 ToTags t
-       )
-    => t Loc
-    -> m ()
+  tags ::
+    ( Has (Reader Source) sig m,
+      Has (Writer Tags.Tags) sig m
+    ) =>
+    t Loc ->
+    m ()
+  default tags ::
+    ( Has (Reader Source) sig m,
+      Has (Writer Tags.Tags) sig m,
+      Traversable1 ToTags t
+    ) =>
+    t Loc ->
+    m ()
   tags = gtags
 
 instance ToTags (Token sym n) where tags _ = pure ()
@@ -41,55 +45,56 @@ instance (ToTags l, ToTags r) => ToTags (l :+: r) where
   tags (L1 l) = tags l
   tags (R1 r) = tags r
 
-gtags
-  :: ( Has (Reader Source) sig m
-     , Has (Writer Tags.Tags) sig m
-     , Traversable1 ToTags t
-     )
-  => t Loc
-  -> m ()
+gtags ::
+  ( Has (Reader Source) sig m,
+    Has (Writer Tags.Tags) sig m,
+    Traversable1 ToTags t
+  ) =>
+  t Loc ->
+  m ()
 gtags = traverse1_ @ToTags (const (pure ())) tags
 
 yieldTag :: (Has (Reader Source) sig m, Has (Writer Tags.Tags) sig m) => Text -> Kind -> Loc -> Range -> m ()
-yieldTag name kind loc range = do
+yieldTag name kind loc srcLineRange = do
   src <- ask @Source
-  Tags.yield (Tag name kind loc (Tags.firstLine src range) Nothing)
-
+  Tags.yield (Tag name kind loc (Tags.firstLine src srcLineRange) Nothing)
 
 instance ToTags PHP.FunctionDefinition where
-  tags t@PHP.FunctionDefinition
-    { PHP.ann = loc@Loc { byteRange }
-    , PHP.name = PHP.Name { text }
-    } = yieldTag text Method loc byteRange >> gtags t
+  tags
+    t@PHP.FunctionDefinition
+      { PHP.ann = Loc {byteRange},
+        PHP.name = PHP.Name {text, ann}
+      } = yieldTag text Method ann byteRange >> gtags t
 
 instance ToTags PHP.MethodDeclaration where
-  tags t@PHP.MethodDeclaration
-    { PHP.ann = loc@Loc { byteRange }
-    , PHP.name = PHP.Name { text }
-    } = yieldTag text Function loc byteRange >> gtags t
+  tags
+    t@PHP.MethodDeclaration
+      { PHP.ann = Loc {byteRange},
+        PHP.name = PHP.Name {text, ann}
+      } = yieldTag text Function ann byteRange >> gtags t
 
 instance ToTags PHP.FunctionCallExpression where
-  tags t@PHP.FunctionCallExpression
-    { PHP.ann = loc@Loc { byteRange }
-    , PHP.function = func
-    } = match func
+  tags
+    t@PHP.FunctionCallExpression
+      { PHP.ann = Loc {byteRange},
+        PHP.function = func
+      } = match func
       where
-        yield name = yieldTag name Call loc byteRange >> gtags t
+        yield name loc = yieldTag name Call loc byteRange >> gtags t
         match expr = case expr of
-          Prj (PHP.VariableName { extraChildren = PHP.Name { text } })
-            -> yield text *> gtags t
-          Prj (PHP.QualifiedName { extraChildren = [Prj (PHP.Name { text })] })
-            -> yield text *> gtags t
-          _
-            -> gtags t
+          Prj PHP.VariableName {extraChildren = PHP.Name {text, ann}} -> yield text ann *> gtags t
+          Prj PHP.QualifiedName {extraChildren = [Prj PHP.Name {text, ann}]} -> yield text ann *> gtags t
+          _ -> gtags t
+
 
 instance ToTags PHP.MemberCallExpression where
-  tags t@PHP.MemberCallExpression
-    { PHP.ann = loc@Loc { byteRange }
-    , PHP.name = item
-    } = case item of
-    Prj (PHP.Name { text }) -> yieldTag text Call loc byteRange >> gtags t
-    _                       -> gtags t
+  tags
+    t@PHP.MemberCallExpression
+      { PHP.ann = Loc {byteRange},
+        PHP.name = Prj PHP.Name {text, ann}
+      } = yieldTag text Call ann byteRange >> gtags t
+  tags t = gtags t
+
 
 
 instance ToTags PHP.AnonymousFunctionCreationExpression

--- a/semantic-python/src/Language/Python/Tags.hs
+++ b/semantic-python/src/Language/Python/Tags.hs
@@ -5,40 +5,42 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
-module Language.Python.Tags
-( ToTags(..)
-) where
 
-import           AST.Element
-import           AST.Token
-import           AST.Traversable1
-import           Control.Effect.Reader
-import           Control.Effect.Writer
-import           Data.Foldable
-import           Data.List.NonEmpty (NonEmpty (..))
-import           Data.Maybe (listToMaybe)
-import           Data.Text as Text
+module Language.Python.Tags
+  ( ToTags (..),
+  )
+where
+
+import AST.Element
+import AST.Token
+import AST.Traversable1
+import Control.Effect.Reader
+import Control.Effect.Writer
+import Data.Foldable
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.Maybe (listToMaybe)
+import Data.Text as Text
 import qualified Language.Python.AST as Py
-import           Source.Loc
-import           Source.Range
-import           Source.Source as Source
-import           Tags.Tag
+import Source.Loc
+import Source.Range
+import Source.Source as Source
+import Tags.Tag
 import qualified Tags.Tagging.Precise as Tags
 
 class ToTags t where
-  tags
-    :: ( Has (Reader Source) sig m
-       , Has (Writer Tags.Tags) sig m
-       )
-    => t Loc
-    -> m ()
-  default tags
-    :: ( Has (Reader Source) sig m
-       , Has (Writer Tags.Tags) sig m
-       , Traversable1 ToTags t
-       )
-    => t Loc
-    -> m ()
+  tags ::
+    ( Has (Reader Source) sig m,
+      Has (Writer Tags.Tags) sig m
+    ) =>
+    t Loc ->
+    m ()
+  default tags ::
+    ( Has (Reader Source) sig m,
+      Has (Writer Tags.Tags) sig m,
+      Traversable1 ToTags t
+    ) =>
+    t Loc ->
+    m ()
   tags = gtags
 
 instance (ToTags l, ToTags r) => ToTags (l :+: r) where
@@ -47,97 +49,104 @@ instance (ToTags l, ToTags r) => ToTags (l :+: r) where
 
 instance ToTags (Token sym n) where tags _ = pure ()
 
-keywordFunctionCall
-  :: ( Has (Reader Source) sig m
-     , Has (Writer Tags.Tags) sig m
-     , Traversable1 ToTags t
-     )
-  => t Loc -> Loc -> Range -> Text -> m ()
+keywordFunctionCall ::
+  ( Has (Reader Source) sig m,
+    Has (Writer Tags.Tags) sig m,
+    Traversable1 ToTags t
+  ) =>
+  t Loc ->
+  Loc ->
+  Range ->
+  Text ->
+  m ()
 keywordFunctionCall t loc range name = yieldTag name Function loc range Nothing >> gtags t
 
 instance ToTags Py.String where
-  tags Py.String { extraChildren } = for_ extraChildren $ \ x -> case x of
-    Prj t@Py.Interpolation { } -> tags t
-    _                          -> pure ()
+  tags Py.String {extraChildren} = for_ extraChildren $ \x -> case x of
+    Prj t@Py.Interpolation {} -> tags t
+    _ -> pure ()
 
 instance ToTags Py.Interpolation where
-  tags Py.Interpolation { extraChildren } = for_ extraChildren $ \ x -> case x of
+  tags Py.Interpolation {extraChildren} = for_ extraChildren $ \x -> case x of
     Prj (Py.Expression expr) -> tags expr
-    _                        -> pure ()
+    _ -> pure ()
 
 instance ToTags Py.AssertStatement where
-  tags t@Py.AssertStatement { ann = loc@Loc { byteRange } } = keywordFunctionCall t loc byteRange "assert"
+  tags t@Py.AssertStatement {ann = loc@Loc {byteRange}} = keywordFunctionCall t loc byteRange "assert"
 
 instance ToTags Py.Await where
-  tags t@Py.Await { ann = loc@Loc { byteRange } } = keywordFunctionCall t loc byteRange "await"
+  tags t@Py.Await {ann = loc@Loc {byteRange}} = keywordFunctionCall t loc byteRange "await"
 
 instance ToTags Py.DeleteStatement where
-  tags t@Py.DeleteStatement { ann = loc@Loc { byteRange } } = keywordFunctionCall t loc byteRange "del"
+  tags t@Py.DeleteStatement {ann = loc@Loc {byteRange}} = keywordFunctionCall t loc byteRange "del"
 
 instance ToTags Py.ExecStatement where
-  tags t@Py.ExecStatement { ann = loc@Loc { byteRange } } = keywordFunctionCall t loc byteRange "exec"
+  tags t@Py.ExecStatement {ann = loc@Loc {byteRange}} = keywordFunctionCall t loc byteRange "exec"
 
 instance ToTags Py.GlobalStatement where
-  tags t@Py.GlobalStatement { ann = loc@Loc { byteRange } } = keywordFunctionCall t loc byteRange "global"
+  tags t@Py.GlobalStatement {ann = loc@Loc {byteRange}} = keywordFunctionCall t loc byteRange "global"
 
 instance ToTags Py.NonlocalStatement where
-  tags t@Py.NonlocalStatement { ann = loc@Loc { byteRange } } = keywordFunctionCall t loc byteRange "nonlocal"
+  tags t@Py.NonlocalStatement {ann = loc@Loc {byteRange}} = keywordFunctionCall t loc byteRange "nonlocal"
 
 instance ToTags Py.PrintStatement where
-  tags t@Py.PrintStatement { ann = loc@Loc { byteRange } } = keywordFunctionCall t loc byteRange "print"
+  tags t@Py.PrintStatement {ann = loc@Loc {byteRange}} = keywordFunctionCall t loc byteRange "print"
 
 instance ToTags Py.FunctionDefinition where
-  tags t@Py.FunctionDefinition
-    { ann = loc@Loc { byteRange = Range { start } }
-    , name = Py.Identifier { text = name }
-    , body = Py.Block { ann = Loc Range { start = end } _, extraChildren }
-    } = do
+  tags
+    t@Py.FunctionDefinition
+      { ann = Loc {byteRange = Range {start}},
+        name = Py.Identifier {text, ann},
+        body = Py.Block {ann = Loc Range {start = end} _, extraChildren}
+      } = do
       src <- ask @Source
       let docs = listToMaybe extraChildren >>= docComment src
-      yieldTag name Function loc (Range start end) docs >> gtags t
+      yieldTag text Function ann (Range start end) docs >> gtags t
 
 instance ToTags Py.ClassDefinition where
-  tags t@Py.ClassDefinition
-    { ann = loc@Loc { byteRange = Range { start } }
-    , name = Py.Identifier { text = name }
-    , body = Py.Block { ann = Loc Range { start = end } _, extraChildren }
-    } = do
+  tags
+    t@Py.ClassDefinition
+      { ann = Loc {byteRange = Range {start}},
+        name = Py.Identifier {text, ann},
+        body = Py.Block {ann = Loc Range {start = end} _, extraChildren}
+      } = do
       src <- ask @Source
       let docs = listToMaybe extraChildren >>= docComment src
-      yieldTag name Class loc (Range start end) docs >> gtags t
+      yieldTag text Class ann (Range start end) docs >> gtags t
 
 instance ToTags Py.Call where
-  tags t@Py.Call
-    { ann = loc@Loc { byteRange = range }
-    , function = Py.PrimaryExpression expr
-    } = match expr
-    where
-      match expr = case expr of
-        (Prj Py.Attribute { attribute = Py.Identifier _ name })                                       -> yield name
-        (Prj (Py.Identifier _ name))                                                                  -> yield name
-        (Prj Py.Call { function = Py.PrimaryExpression expr' })                                       -> match expr' -- Nested call expression like this in Python represent creating an instance of a class and calling it: e.g. AClass()()
-        (Prj (Py.ParenthesizedExpression _ (Prj (Py.Expression (Prj (Py.PrimaryExpression expr')))))) -> match expr' -- Parenthesized expressions
-        _                                                                                             -> gtags t
-      yield name = yieldTag name Call loc range Nothing >> gtags t
+  tags
+    t@Py.Call
+      { ann = Loc {byteRange},
+        function = Py.PrimaryExpression expr
+      } = match expr
+      where
+        match expr = case expr of
+          Prj Py.Attribute {attribute = Py.Identifier {text, ann}} -> yield text ann
+          Prj Py.Identifier {text, ann} -> yield text ann
+          Prj Py.Call {function = Py.PrimaryExpression expr'} -> match expr' -- Nested call expression like this in Python represent creating an instance of a class and calling it: e.g. AClass()()
+          Prj (Py.ParenthesizedExpression _ (Prj (Py.Expression (Prj (Py.PrimaryExpression expr'))))) -> match expr' -- Parenthesized expressions
+          _ -> gtags t
+        yield name loc = yieldTag name Call loc byteRange Nothing >> gtags t
 
 yieldTag :: (Has (Reader Source) sig m, Has (Writer Tags.Tags) sig m) => Text -> Kind -> Loc -> Range -> Maybe Text -> m ()
-yieldTag name kind loc range docs = do
+yieldTag name kind loc srcLineRange docs = do
   src <- ask @Source
-  Tags.yield (Tag name kind loc (Tags.firstLine src range) docs)
+  Tags.yield (Tag name kind loc (Tags.firstLine src srcLineRange) docs)
 
 docComment :: Source -> (Py.CompoundStatement :+: Py.SimpleStatement) Loc -> Maybe Text
-docComment src (R1 (Py.SimpleStatement (Prj Py.ExpressionStatement { extraChildren = L1 (Prj (Py.Expression (Prj (Py.PrimaryExpression (Prj Py.String { ann }))))) :|_ }))) = Just (toText (slice src (byteRange ann)))
+docComment src (R1 (Py.SimpleStatement (Prj Py.ExpressionStatement {extraChildren = L1 (Prj (Py.Expression (Prj (Py.PrimaryExpression (Prj Py.String {ann}))))) :| _}))) = Just (toText (slice src (byteRange ann)))
 docComment _ _ = Nothing
 
-
-gtags
-  :: ( Has (Reader Source) sig m
-     , Has (Writer Tags.Tags) sig m
-     , Traversable1 ToTags t
-     )
-  => t Loc
-  -> m ()
+gtags ::
+  ( Has (Reader Source) sig m,
+    Has (Writer Tags.Tags) sig m,
+    Traversable1 ToTags t
+  ) =>
+  t Loc ->
+  m ()
 gtags = traverse1_ @ToTags (const (pure ())) tags
+
 
 instance ToTags Py.AliasedImport
 instance ToTags Py.ArgumentList

--- a/semantic-tsx/src/Language/TSX/Tags.hs
+++ b/semantic-tsx/src/Language/TSX/Tags.hs
@@ -5,152 +5,116 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
-module Language.TSX.Tags
-( ToTags(..)
-) where
 
-import           AST.Element
-import           AST.Token
-import           AST.Traversable1
-import           Control.Effect.Reader
-import           Control.Effect.Writer
-import           Data.Foldable
-import           Data.Text as Text
+module Language.TSX.Tags
+  ( ToTags (..),
+  )
+where
+
+import AST.Element
+import AST.Token
+import AST.Traversable1
+import Control.Effect.Reader
+import Control.Effect.Writer
+import Data.Foldable
+import Data.Text as Text
 import qualified Language.TSX.AST as Tsx
-import           Source.Loc
-import           Source.Source as Source
-import           Tags.Tag
+import Source.Loc
+import Source.Source as Source
+import Tags.Tag
 import qualified Tags.Tagging.Precise as Tags
 
 class ToTags t where
-  tags
-    :: ( Has (Reader Source) sig m
-       , Has (Writer Tags.Tags) sig m
-       )
-    => t Loc
-    -> m ()
-  default tags
-    :: ( Has (Reader Source) sig m
-       , Has (Writer Tags.Tags) sig m
-       , Traversable1 ToTags t
-       )
-    => t Loc
-    -> m ()
+  tags ::
+    ( Has (Reader Source) sig m,
+      Has (Writer Tags.Tags) sig m
+    ) =>
+    t Loc ->
+    m ()
+  default tags ::
+    ( Has (Reader Source) sig m,
+      Has (Writer Tags.Tags) sig m,
+      Traversable1 ToTags t
+    ) =>
+    t Loc ->
+    m ()
   tags = gtags
 
 instance ToTags Tsx.Function where
-  tags t@Tsx.Function
-    { ann = loc@Loc { byteRange }
-    , name = Just Tsx.Identifier { text }
-    } = yieldTag text Function loc byteRange >> gtags t
+  tags t@Tsx.Function {ann = Loc {byteRange}, name = Just Tsx.Identifier {text, ann}} =
+    yieldTag text Function ann byteRange >> gtags t
   tags t = gtags t
 
 instance ToTags Tsx.FunctionSignature where
-  tags t@Tsx.FunctionSignature
-    { ann = loc@Loc { byteRange }
-    , name = Tsx.Identifier { text }
-    } = yieldTag text Function loc byteRange >> gtags t
+  tags t@Tsx.FunctionSignature {ann = Loc {byteRange}, name = Tsx.Identifier {text, ann}} =
+    yieldTag text Function ann byteRange >> gtags t
 
 instance ToTags Tsx.FunctionDeclaration where
-  tags t@Tsx.FunctionDeclaration
-    { ann = loc@Loc { byteRange }
-    , name = Tsx.Identifier { text }
-    } = yieldTag text Function loc byteRange >> gtags t
+  tags t@Tsx.FunctionDeclaration {ann = Loc {byteRange}, name = Tsx.Identifier {text, ann}} =
+    yieldTag text Function ann byteRange >> gtags t
 
 instance ToTags Tsx.MethodDefinition where
-  tags t@Tsx.MethodDefinition
-    { ann = loc@Loc { byteRange }
-    , name
-    } = case name of
-      Prj Tsx.PropertyIdentifier { text } -> yield text
-      -- TODO: There are more here
-      _                                   -> gtags t
-      where
-        yield name = yieldTag name Method loc byteRange >> gtags t
+  tags t@Tsx.MethodDefinition {ann = Loc {byteRange}, name} = case name of
+    Prj Tsx.PropertyIdentifier {text, ann} -> yieldTag text Method ann byteRange >> gtags t
+    _ -> gtags t
 
 instance ToTags Tsx.Pair where
-  tags t@Tsx.Pair
-    { ann = loc@Loc { byteRange }
-    , key
-    , value = Tsx.Expression expr
-    } =  case (key, expr) of
-      (Prj Tsx.PropertyIdentifier { text }, Prj Tsx.Function{}) -> yield text
-      (Prj Tsx.PropertyIdentifier { text }, Prj Tsx.ArrowFunction{}) -> yield text
-      _ -> gtags t
+  tags t@Tsx.Pair {ann = Loc {byteRange}, key, value = Tsx.Expression expr} = case (key, expr) of
+    (Prj Tsx.PropertyIdentifier {text, ann}, Prj Tsx.Function {}) -> yield text ann
+    (Prj Tsx.PropertyIdentifier {text, ann}, Prj Tsx.ArrowFunction {}) -> yield text ann
+    _ -> gtags t
     where
-      yield text = yieldTag text Function loc byteRange >> gtags t
+      yield text loc = yieldTag text Function loc byteRange >> gtags t
 
 instance ToTags Tsx.ClassDeclaration where
-  tags t@Tsx.ClassDeclaration
-    { ann = loc@Loc { byteRange }
-    , name = Tsx.TypeIdentifier { text }
-    } = yieldTag text Class loc byteRange >> gtags t
+  tags t@Tsx.ClassDeclaration {ann = Loc {byteRange}, name = Tsx.TypeIdentifier {text, ann}} =
+    yieldTag text Class ann byteRange >> gtags t
 
 instance ToTags Tsx.CallExpression where
-  tags t@Tsx.CallExpression
-    { ann = loc@Loc { byteRange }
-    , function = Tsx.Expression expr
-    } = match expr
+  tags t@Tsx.CallExpression {ann = Loc {byteRange}, function = Tsx.Expression expr} = match expr
     where
       match expr = case expr of
-        Prj Tsx.Identifier { text } -> yield text
-        Prj Tsx.NewExpression { constructor = Prj Tsx.Identifier { text } } -> yield text
-        Prj Tsx.CallExpression { function = Tsx.Expression expr } -> match expr
-        Prj Tsx.MemberExpression { property = Tsx.PropertyIdentifier { text } } -> yield text
-        Prj Tsx.Function { name = Just Tsx.Identifier { text }} -> yield text
-        Prj Tsx.ParenthesizedExpression { extraChildren } -> for_ extraChildren $ \ x -> case x of
+        Prj Tsx.Identifier {text, ann} -> yield text ann
+        Prj Tsx.NewExpression {constructor = Prj Tsx.Identifier {text, ann}} -> yield text ann
+        Prj Tsx.CallExpression {function = Tsx.Expression expr} -> match expr
+        Prj Tsx.MemberExpression {property = Tsx.PropertyIdentifier {text, ann}} -> yield text ann
+        Prj Tsx.Function {name = Just Tsx.Identifier {text, ann}} -> yield text ann
+        Prj Tsx.ParenthesizedExpression {extraChildren} -> for_ extraChildren $ \x -> case x of
           Prj (Tsx.Expression expr) -> match expr
-          _                         -> tags x
+          _ -> tags x
         _ -> gtags t
-      yield name = yieldTag name Call loc byteRange >> gtags t
+      yield name loc = yieldTag name Call loc byteRange >> gtags t
 
 instance ToTags Tsx.Class where
-  tags t@Tsx.Class
-    { ann = loc@Loc { byteRange }
-    , name = Just Tsx.TypeIdentifier { text }
-    } = yieldTag text Class loc byteRange >> gtags t
+  tags t@Tsx.Class {ann = Loc {byteRange}, name = Just Tsx.TypeIdentifier {text, ann}} =
+    yieldTag text Class ann byteRange >> gtags t
   tags t = gtags t
 
 instance ToTags Tsx.Module where
-  tags t@Tsx.Module
-    { ann = loc@Loc { byteRange }
-    , name
-    } = match name
-    where
-      match expr = case expr of
-        Prj Tsx.Identifier { text } -> yield text
-        -- TODO: Handle NestedIdentifiers and Strings
-        -- Prj Tsx.NestedIdentifier { extraChildren } -> match
-        _                           -> gtags t
-      yield text = yieldTag text Module loc byteRange >> gtags t
+  tags t@Tsx.Module {ann = Loc {byteRange}, name} = case name of
+    Prj Tsx.Identifier {text, ann} -> yieldTag text Module ann byteRange >> gtags t
+    _ -> gtags t
 
 instance ToTags Tsx.VariableDeclarator where
-  tags t@Tsx.VariableDeclarator
-    { ann = loc@Loc { byteRange }
-    , name
-    , value = Just (Tsx.Expression expr)
-    } = case (expr, name) of
-          (Prj Tsx.Function{}, Prj Tsx.Identifier { text }) -> yield text
-          (Prj Tsx.ArrowFunction{}, Prj Tsx.Identifier { text }) -> yield text
-          _ -> gtags t
+  tags t@Tsx.VariableDeclarator {ann = Loc {byteRange}, name, value = Just (Tsx.Expression expr)} =
+    case (expr, name) of
+      (Prj Tsx.Function {}, Prj Tsx.Identifier {text, ann}) -> yield text ann
+      (Prj Tsx.ArrowFunction {}, Prj Tsx.Identifier {text, ann}) -> yield text ann
+      _ -> gtags t
     where
-      yield text = yieldTag text Function loc byteRange >> gtags t
+      yield text loc = yieldTag text Function loc byteRange >> gtags t
   tags t = gtags t
 
 instance ToTags Tsx.AssignmentExpression where
-  tags t@Tsx.AssignmentExpression
-    { ann = loc@Loc { byteRange }
-    , left
-    , right = (Tsx.Expression expr)
-    } = case (left, expr) of
-          (Prj Tsx.Identifier { text }, Prj Tsx.Function{}) -> yield text
-          (Prj Tsx.Identifier { text }, Prj Tsx.ArrowFunction{}) -> yield text
-          (Prj Tsx.MemberExpression { property = Tsx.PropertyIdentifier { text } }, Prj Tsx.Function{}) -> yield text
-          (Prj Tsx.MemberExpression { property = Tsx.PropertyIdentifier { text } }, Prj Tsx.ArrowFunction{}) -> yield text
-          _ -> gtags t
+  tags t@Tsx.AssignmentExpression {ann = Loc {byteRange}, left, right = (Tsx.Expression expr)} =
+    case (left, expr) of
+      (Prj Tsx.Identifier {text, ann}, Prj Tsx.Function {}) -> yield text ann
+      (Prj Tsx.Identifier {text, ann}, Prj Tsx.ArrowFunction {}) -> yield text ann
+      (Prj Tsx.MemberExpression {property = Tsx.PropertyIdentifier {text, ann}}, Prj Tsx.Function {}) -> yield text ann
+      (Prj Tsx.MemberExpression {property = Tsx.PropertyIdentifier {text, ann}}, Prj Tsx.ArrowFunction {}) -> yield text ann
+      _ -> gtags t
     where
-      yield text = yieldTag text Function loc byteRange >> gtags t
-
+      yield text loc = yieldTag text Function loc byteRange >> gtags t
 
 instance (ToTags l, ToTags r) => ToTags (l :+: r) where
   tags (L1 l) = tags l
@@ -158,28 +122,28 @@ instance (ToTags l, ToTags r) => ToTags (l :+: r) where
 
 instance ToTags (Token sym n) where tags _ = pure ()
 
-gtags
-  :: ( Has (Reader Source) sig m
-     , Has (Writer Tags.Tags) sig m
-     , Traversable1 ToTags t
-     )
-  => t Loc
-  -> m ()
+gtags ::
+  ( Has (Reader Source) sig m,
+    Has (Writer Tags.Tags) sig m,
+    Traversable1 ToTags t
+  ) =>
+  t Loc ->
+  m ()
 gtags = traverse1_ @ToTags (const (pure ())) tags
 
 -- These are all valid, but point to built-in functions (e.g. require) that a la
 -- carte doesn't display and since we have nothing to link to yet (can't
 -- jump-to-def), we hide them from the current tags output.
 nameBlacklist :: [Text]
-nameBlacklist =
-  [ "require"
-  ]
+nameBlacklist = ["require"]
 
 yieldTag :: (Has (Reader Source) sig m, Has (Writer Tags.Tags) sig m) => Text -> Kind -> Loc -> Range -> m ()
 yieldTag name Call _ _ | name `elem` nameBlacklist = pure ()
-yieldTag name kind loc range = do
+yieldTag name kind loc srcLineRange = do
   src <- ask @Source
-  Tags.yield (Tag name kind loc (Tags.firstLine src range) Nothing)
+  Tags.yield (Tag name kind loc (Tags.firstLine src srcLineRange) Nothing)
+
+{- ORMOLU_DISABLE -}
 
 instance ToTags Tsx.AbstractClassDeclaration
 instance ToTags Tsx.AbstractMethodSignature
@@ -339,3 +303,5 @@ instance ToTags Tsx.VariableDeclaration
 instance ToTags Tsx.WhileStatement
 instance ToTags Tsx.WithStatement
 instance ToTags Tsx.YieldExpression
+
+{- ORMOLU_ENABLE -}

--- a/semantic-tsx/src/Language/TSX/Tags.hs
+++ b/semantic-tsx/src/Language/TSX/Tags.hs
@@ -144,7 +144,6 @@ yieldTag name kind loc srcLineRange = do
   Tags.yield (Tag name kind loc (Tags.firstLine src srcLineRange) Nothing)
 
 {- ORMOLU_DISABLE -}
-
 instance ToTags Tsx.AbstractClassDeclaration
 instance ToTags Tsx.AbstractMethodSignature
 instance ToTags Tsx.AccessibilityModifier
@@ -303,5 +302,4 @@ instance ToTags Tsx.VariableDeclaration
 instance ToTags Tsx.WhileStatement
 instance ToTags Tsx.WithStatement
 instance ToTags Tsx.YieldExpression
-
 {- ORMOLU_ENABLE -}

--- a/semantic-typescript/src/Language/TypeScript/Tags.hs
+++ b/semantic-typescript/src/Language/TypeScript/Tags.hs
@@ -144,7 +144,6 @@ yieldTag name kind loc srcLineRange = do
   Tags.yield (Tag name kind loc (Tags.firstLine src srcLineRange) Nothing)
 
 {- ORMOLU_DISABLE -}
-
 instance ToTags Ts.AbstractClassDeclaration
 instance ToTags Ts.AbstractMethodSignature
 instance ToTags Ts.AccessibilityModifier
@@ -304,5 +303,4 @@ instance ToTags Ts.VariableDeclaration
 instance ToTags Ts.WhileStatement
 instance ToTags Ts.WithStatement
 instance ToTags Ts.YieldExpression
-
 {- ORMOLU_ENABLE -}

--- a/semantic-typescript/src/Language/TypeScript/Tags.hs
+++ b/semantic-typescript/src/Language/TypeScript/Tags.hs
@@ -5,145 +5,116 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
-module Language.TypeScript.Tags
-( ToTags(..)
-) where
 
-import           AST.Element
-import           AST.Token
-import           AST.Traversable1
-import           Control.Effect.Reader
-import           Control.Effect.Writer
-import           Data.Foldable
-import           Data.Text as Text
+module Language.TypeScript.Tags
+  ( ToTags (..),
+  )
+where
+
+import AST.Element
+import AST.Token
+import AST.Traversable1
+import Control.Effect.Reader
+import Control.Effect.Writer
+import Data.Foldable
+import Data.Text as Text
 import qualified Language.TypeScript.AST as Ts
-import           Source.Loc
-import           Source.Source as Source
-import           Tags.Tag
+import Source.Loc
+import Source.Source as Source
+import Tags.Tag
 import qualified Tags.Tagging.Precise as Tags
 
 class ToTags t where
-  tags
-    :: ( Has (Reader Source) sig m
-       , Has (Writer Tags.Tags) sig m
-       )
-    => t Loc
-    -> m ()
-  default tags
-    :: ( Has (Reader Source) sig m
-       , Has (Writer Tags.Tags) sig m
-       , Traversable1 ToTags t
-       )
-    => t Loc
-    -> m ()
+  tags ::
+    ( Has (Reader Source) sig m,
+      Has (Writer Tags.Tags) sig m
+    ) =>
+    t Loc ->
+    m ()
+  default tags ::
+    ( Has (Reader Source) sig m,
+      Has (Writer Tags.Tags) sig m,
+      Traversable1 ToTags t
+    ) =>
+    t Loc ->
+    m ()
   tags = gtags
 
 instance ToTags Ts.Function where
-  tags t@Ts.Function
-    { ann = loc@Loc { byteRange }
-    , name = Just Ts.Identifier { text }
-    } = yieldTag text Function loc byteRange >> gtags t
+  tags t@Ts.Function {ann = Loc {byteRange}, name = Just Ts.Identifier {text, ann}} =
+    yieldTag text Function ann byteRange >> gtags t
   tags t = gtags t
 
 instance ToTags Ts.FunctionSignature where
-  tags t@Ts.FunctionSignature
-    { ann = loc@Loc { byteRange }
-    , name = Ts.Identifier { text }
-    } = yieldTag text Function loc byteRange >> gtags t
+  tags t@Ts.FunctionSignature {ann = Loc {byteRange}, name = Ts.Identifier {text, ann}} =
+    yieldTag text Function ann byteRange >> gtags t
 
 instance ToTags Ts.FunctionDeclaration where
-  tags t@Ts.FunctionDeclaration
-    { ann = loc@Loc { byteRange }
-    , name = Ts.Identifier { text }
-    } = yieldTag text Function loc byteRange >> gtags t
+  tags t@Ts.FunctionDeclaration {ann = Loc {byteRange}, name = Ts.Identifier {text, ann}} =
+    yieldTag text Function ann byteRange >> gtags t
 
 instance ToTags Ts.MethodDefinition where
-  tags t@Ts.MethodDefinition
-    { ann = loc@Loc { byteRange }
-    , name
-    } = case name of
-      Prj Ts.PropertyIdentifier { text } -> yield text
-      -- TODO: There are more here
-      _                                  -> gtags t
-      where
-        yield name = yieldTag name Method loc byteRange >> gtags t
+  tags t@Ts.MethodDefinition {ann = Loc {byteRange}, name} = case name of
+    Prj Ts.PropertyIdentifier {text, ann} -> yieldTag text Method ann byteRange >> gtags t
+    _ -> gtags t
 
 instance ToTags Ts.Pair where
-  tags t@Ts.Pair
-    { ann = loc@Loc { byteRange }
-    , key
-    , value = Ts.Expression expr
-    } =  case (key, expr) of
-      (Prj Ts.PropertyIdentifier { text }, Prj Ts.Function{}) -> yield text
-      (Prj Ts.PropertyIdentifier { text }, Prj Ts.ArrowFunction{}) -> yield text
-      _ -> gtags t
+  tags t@Ts.Pair {ann = Loc {byteRange}, key, value = Ts.Expression expr} = case (key, expr) of
+    (Prj Ts.PropertyIdentifier {text, ann}, Prj Ts.Function {}) -> yield text ann
+    (Prj Ts.PropertyIdentifier {text, ann}, Prj Ts.ArrowFunction {}) -> yield text ann
+    _ -> gtags t
     where
-      yield text = yieldTag text Function loc byteRange >> gtags t
+      yield text loc = yieldTag text Function loc byteRange >> gtags t
 
 instance ToTags Ts.ClassDeclaration where
-  tags t@Ts.ClassDeclaration
-    { ann = loc@Loc { byteRange }
-    , name = Ts.TypeIdentifier { text }
-    } = yieldTag text Class loc byteRange >> gtags t
+  tags t@Ts.ClassDeclaration {ann = Loc {byteRange}, name = Ts.TypeIdentifier {text, ann}} =
+    yieldTag text Class ann byteRange >> gtags t
 
 instance ToTags Ts.CallExpression where
-  tags t@Ts.CallExpression
-    { ann = loc@Loc { byteRange }
-    , function = Ts.Expression expr
-    } = match expr
+  tags t@Ts.CallExpression {ann = Loc {byteRange}, function = Ts.Expression expr} = match expr
     where
       match expr = case expr of
-        Prj Ts.Identifier { text } -> yield text
-        Prj Ts.NewExpression { constructor = Prj Ts.Identifier { text } } -> yield text
-        Prj Ts.CallExpression { function = Ts.Expression expr } -> match expr
-        Prj Ts.MemberExpression { property = Ts.PropertyIdentifier { text } } -> yield text
-        Prj Ts.Function { name = Just Ts.Identifier { text }} -> yield text
-        Prj Ts.ParenthesizedExpression { extraChildren } -> for_ extraChildren $ \ x -> case x of
+        Prj Ts.Identifier {text, ann} -> yield text ann
+        Prj Ts.NewExpression {constructor = Prj Ts.Identifier {text, ann}} -> yield text ann
+        Prj Ts.CallExpression {function = Ts.Expression expr} -> match expr
+        Prj Ts.MemberExpression {property = Ts.PropertyIdentifier {text, ann}} -> yield text ann
+        Prj Ts.Function {name = Just Ts.Identifier {text, ann}} -> yield text ann
+        Prj Ts.ParenthesizedExpression {extraChildren} -> for_ extraChildren $ \x -> case x of
           Prj (Ts.Expression expr) -> match expr
-          _                        -> tags x
+          _ -> tags x
         _ -> gtags t
-      yield name = yieldTag name Call loc byteRange >> gtags t
+      yield name loc = yieldTag name Call loc byteRange >> gtags t
+
+instance ToTags Ts.Class where
+  tags t@Ts.Class {ann = Loc {byteRange}, name = Just Ts.TypeIdentifier {text, ann}} =
+    yieldTag text Class ann byteRange >> gtags t
+  tags t = gtags t
 
 instance ToTags Ts.Module where
-  tags t@Ts.Module
-    { ann = loc@Loc { byteRange }
-    , name
-    } = match name
-    where
-      match expr = case expr of
-        Prj Ts.Identifier { text } -> yield text
-        -- TODO: Handle NestedIdentifiers and Strings
-        -- Prj Ts.NestedIdentifier { extraChildren } -> match
-        _                          -> gtags t
-      yield text = yieldTag text Module loc byteRange >> gtags t
+  tags t@Ts.Module {ann = Loc {byteRange}, name} = case name of
+    Prj Ts.Identifier {text, ann} -> yieldTag text Module ann byteRange >> gtags t
+    _ -> gtags t
 
 instance ToTags Ts.VariableDeclarator where
-  tags t@Ts.VariableDeclarator
-    { ann = loc@Loc { byteRange }
-    , name
-    , value = Just (Ts.Expression expr)
-    } = case (expr, name) of
-          (Prj Ts.Function{}, Prj Ts.Identifier { text }) -> yield text
-          (Prj Ts.ArrowFunction{}, Prj Ts.Identifier { text }) -> yield text
-          _ -> gtags t
+  tags t@Ts.VariableDeclarator {ann = Loc {byteRange}, name, value = Just (Ts.Expression expr)} =
+    case (expr, name) of
+      (Prj Ts.Function {}, Prj Ts.Identifier {text, ann}) -> yield text ann
+      (Prj Ts.ArrowFunction {}, Prj Ts.Identifier {text, ann}) -> yield text ann
+      _ -> gtags t
     where
-      yield text = yieldTag text Function loc byteRange >> gtags t
+      yield text loc = yieldTag text Function loc byteRange >> gtags t
   tags t = gtags t
 
 instance ToTags Ts.AssignmentExpression where
-  tags t@Ts.AssignmentExpression
-    { ann = loc@Loc { byteRange }
-    , left
-    , right = (Ts.Expression expr)
-    } = case (left, expr) of
-          (Prj Ts.Identifier { text }, Prj Ts.Function{}) -> yield text
-          (Prj Ts.Identifier { text }, Prj Ts.ArrowFunction{}) -> yield text
-          (Prj Ts.MemberExpression { property = Ts.PropertyIdentifier { text } }, Prj Ts.Function{}) -> yield text
-          (Prj Ts.MemberExpression { property = Ts.PropertyIdentifier { text } }, Prj Ts.ArrowFunction{}) -> yield text
-          _ -> gtags t
+  tags t@Ts.AssignmentExpression {ann = Loc {byteRange}, left, right = (Ts.Expression expr)} =
+    case (left, expr) of
+      (Prj Ts.Identifier {text, ann}, Prj Ts.Function {}) -> yield text ann
+      (Prj Ts.Identifier {text, ann}, Prj Ts.ArrowFunction {}) -> yield text ann
+      (Prj Ts.MemberExpression {property = Ts.PropertyIdentifier {text, ann}}, Prj Ts.Function {}) -> yield text ann
+      (Prj Ts.MemberExpression {property = Ts.PropertyIdentifier {text, ann}}, Prj Ts.ArrowFunction {}) -> yield text ann
+      _ -> gtags t
     where
-      yield text = yieldTag text Function loc byteRange >> gtags t
-
+      yield text loc = yieldTag text Function loc byteRange >> gtags t
 
 instance (ToTags l, ToTags r) => ToTags (l :+: r) where
   tags (L1 l) = tags l
@@ -151,28 +122,28 @@ instance (ToTags l, ToTags r) => ToTags (l :+: r) where
 
 instance ToTags (Token sym n) where tags _ = pure ()
 
-gtags
-  :: ( Has (Reader Source) sig m
-     , Has (Writer Tags.Tags) sig m
-     , Traversable1 ToTags t
-     )
-  => t Loc
-  -> m ()
+gtags ::
+  ( Has (Reader Source) sig m,
+    Has (Writer Tags.Tags) sig m,
+    Traversable1 ToTags t
+  ) =>
+  t Loc ->
+  m ()
 gtags = traverse1_ @ToTags (const (pure ())) tags
 
 -- These are all valid, but point to built-in functions (e.g. require) that a la
 -- carte doesn't display and since we have nothing to link to yet (can't
 -- jump-to-def), we hide them from the current tags output.
 nameBlacklist :: [Text]
-nameBlacklist =
-  [ "require"
-  ]
+nameBlacklist = ["require"]
 
 yieldTag :: (Has (Reader Source) sig m, Has (Writer Tags.Tags) sig m) => Text -> Kind -> Loc -> Range -> m ()
 yieldTag name Call _ _ | name `elem` nameBlacklist = pure ()
-yieldTag name kind loc range = do
+yieldTag name kind loc srcLineRange = do
   src <- ask @Source
-  Tags.yield (Tag name kind loc (Tags.firstLine src range) Nothing)
+  Tags.yield (Tag name kind loc (Tags.firstLine src srcLineRange) Nothing)
+
+{- ORMOLU_DISABLE -}
 
 instance ToTags Ts.AbstractClassDeclaration
 instance ToTags Ts.AbstractMethodSignature
@@ -193,7 +164,7 @@ instance ToTags Ts.BreakStatement
 -- instance ToTags Ts.CallExpression
 instance ToTags Ts.CallSignature
 instance ToTags Ts.CatchClause
-instance ToTags Ts.Class
+-- instance ToTags Ts.Class
 instance ToTags Ts.ClassBody
 -- instance ToTags Ts.ClassDeclaration
 instance ToTags Ts.ClassHeritage
@@ -333,3 +304,5 @@ instance ToTags Ts.VariableDeclaration
 instance ToTags Ts.WhileStatement
 instance ToTags Ts.WithStatement
 instance ToTags Ts.YieldExpression
+
+{- ORMOLU_ENABLE -}

--- a/test/Semantic/CLI/Spec.hs
+++ b/test/Semantic/CLI/Spec.hs
@@ -47,7 +47,7 @@ testForDiffFixture (diffRenderer, runDiff, files, expected) =
 testForParseFixture :: (String, [Blob] -> ParseC TaskC Builder, [File Language], Path.RelFile) -> TestTree
 testForParseFixture (format, runParse, files, expected) =
   goldenVsStringDiff
-    ("diff fixture renders to " <> format)
+    ("parse fixture renders to " <> format)
     renderDiff
     (Path.toString expected)
     (fmap toLazyByteString . runTaskOrDie $ readBlobs (FilesFromPaths files) >>= runParse)

--- a/test/Tags/Spec.hs
+++ b/test/Tags/Spec.hs
@@ -14,16 +14,16 @@ spec = do
   describe "go" $ do
     it "produces tags for functions with docs (TODO)" $
       parseTestFile [Function] (Path.relFile "test/fixtures/go/tags/simple_functions.go") `shouldReturn`
-        [ Tag "TestFromBits" Function (Loc (Range 51 92) (Span (Pos 6 1) (Pos 8 2))) "func TestFromBits(t *testing.T) {" Nothing
-        , Tag "Hi" Function (Loc (Range 94 107) (Span (Pos 10 1) (Pos 11 2))) "func Hi() {" Nothing ]
+        [ Tag "TestFromBits" Function (Loc (Range 56 68) (Span (Pos 6 6) (Pos 6 18))) "func TestFromBits(t *testing.T) {" Nothing
+        , Tag "Hi" Function (Loc (Range 99 101) (Span (Pos 10 6) (Pos 10 8))) "func Hi() {" Nothing ]
 
     it "produces tags for methods" $
       parseTestFile [Method] (Path.relFile "test/fixtures/go/tags/method.go") `shouldReturn`
-        [ Tag "CheckAuth" Method (Loc (Range 19 118) (Span (Pos 3 1) (Pos 3 100))) "func (c *apiClient) CheckAuth(req *http.Request, user, repo string) (*authenticatedActor, error) {}" Nothing]
+        [ Tag "CheckAuth" Method (Loc (Range 39 48) (Span (Pos 3 21) (Pos 3 30))) "func (c *apiClient) CheckAuth(req *http.Request, user, repo string) (*authenticatedActor, error) {}" Nothing]
 
     it "produces tags for calls" $
       parseTestFile [Call] (Path.relFile "test/fixtures/go/tags/simple_functions.go") `shouldReturn`
-        [ Tag "Hi" Call (Loc (Range 86 90) (Span (Pos 7 2) (Pos 7 6))) "Hi()" Nothing]
+        [ Tag "Hi" Call (Loc (Range 86 88) (Span (Pos 7 2) (Pos 7 4))) "Hi()" Nothing]
 
   describe "javascript and typescript" $ do
     it "produces tags for functions with docs (TODO)" $
@@ -41,53 +41,53 @@ spec = do
   describe "python" $ do
     it "produces tags for functions" $
       parseTestFile [Function] (Path.relFile "test/fixtures/python/tags/simple_functions.py") `shouldReturn`
-        [ Tag "Foo" Function (Loc (Range 0 68) (Span (Pos 1 1) (Pos 5 17))) "def Foo(x):" Nothing
-        , Tag "Bar" Function (Loc (Range 70 136) (Span (Pos 7 1) (Pos 11 13))) "def Bar():" Nothing
-        , Tag "local" Function (Loc (Range 85 114) (Span (Pos 8 5) (Pos 9 17))) "def local():" Nothing
+        [ Tag "Foo" Function (Loc (Range 4 7) (Span (Pos 1 5) (Pos 1 8))) "def Foo(x):" Nothing
+        , Tag "Bar" Function (Loc (Range 74 77) (Span (Pos 7 5) (Pos 7 8))) "def Bar():" Nothing
+        , Tag "local" Function (Loc (Range 89 94) (Span (Pos 8 9) (Pos 8 14))) "def local():" Nothing
         ]
 
     it "produces tags for functions with docs" $
       parseTestFile [Function] (Path.relFile "test/fixtures/python/tags/simple_function_with_docs.py") `shouldReturn`
-        [ Tag "Foo" Function (Loc (Range 0 59) (Span (Pos 1 1) (Pos 3 13))) "def Foo(x):" (Just "\"\"\"This is the foo function\"\"\"") ]
+        [ Tag "Foo" Function (Loc (Range 4 7) (Span (Pos 1 5) (Pos 1 8))) "def Foo(x):" (Just "\"\"\"This is the foo function\"\"\"") ]
 
     it "produces tags for classes" $
       parseTestFile [Class, Function] (Path.relFile "test/fixtures/python/tags/class.py") `shouldReturn`
-        [ Tag "Foo" Class (Loc (Range 0 95) (Span (Pos 1 1) (Pos 5 17))) "class Foo:" (Just "\"\"\"The Foo class\"\"\"")
-        , Tag "f" Function (Loc (Range 39 95) (Span (Pos 3 5) (Pos 5 17))) "def f(self):" (Just "\"\"\"The f method\"\"\"")
+        [ Tag "Foo" Class (Loc (Range 6 9) (Span (Pos 1 7) (Pos 1 10))) "class Foo:" (Just "\"\"\"The Foo class\"\"\"")
+        , Tag "f" Function (Loc (Range 43 44) (Span (Pos 3 9) (Pos 3 10))) "def f(self):" (Just "\"\"\"The f method\"\"\"")
         ]
 
     it "produces tags for multi-line functions" $
       parseTestFile [Function] (Path.relFile "test/fixtures/python/tags/multiline.py") `shouldReturn`
-        [ Tag "Foo" Function (Loc (Range 0 29) (Span (Pos 1 1) (Pos 3 13))) "def Foo(x," Nothing ]
+        [ Tag "Foo" Function (Loc (Range 4 7) (Span (Pos 1 5) (Pos 1 8))) "def Foo(x," Nothing ]
 
   describe "ruby" $ do
     it "produces tags for methods" $
       parseTestFile [Method] (Path.relFile "test/fixtures/ruby/tags/simple_method.rb") `shouldReturn`
-        [ Tag "foo" Method (Loc (Range 0 31) (Span (Pos 1 1) (Pos 4 4))) "def foo" Nothing ]
+        [ Tag "foo" Method (Loc (Range 4 7) (Span (Pos 1 5) (Pos 1 8))) "def foo" Nothing ]
 
     it "produces tags for sends" $
       parseTestFile [Call] (Path.relFile "test/fixtures/ruby/tags/simple_method.rb") `shouldReturn`
-        [ Tag "puts" Call (Loc (Range 10 19) (Span (Pos 2 3) (Pos 2 12))) "puts \"hi\"" Nothing
-        , Tag "bar" Call (Loc (Range 22 27) (Span (Pos 3 3) (Pos 3 8))) "a.bar" Nothing
+        [ Tag "puts" Call (Loc (Range 10 14) (Span (Pos 2 3) (Pos 2 7))) "puts \"hi\"" Nothing
+        , Tag "bar" Call (Loc (Range 24 27) (Span (Pos 3 5) (Pos 3 8))) "a.bar" Nothing
         , Tag "a" Call (Loc (Range 22 23) (Span (Pos 3 3) (Pos 3 4))) "a" Nothing
         ]
 
     it "produces tags for methods with docs (TODO)" $
       parseTestFile [Method] (Path.relFile "test/fixtures/ruby/tags/simple_method_with_docs.rb") `shouldReturn`
-        [ Tag "foo" Method (Loc (Range 14 25) (Span (Pos 2 1) (Pos 3 4))) "def foo" Nothing ]
+        [ Tag "foo" Method (Loc (Range 18 21) (Span (Pos 2 5) (Pos 2 8))) "def foo" Nothing ]
 
     it "correctly tags files containing multibyte UTF-8 characters (TODO)" $
       parseTestFile [Method] (Path.relFile "test/fixtures/ruby/tags/unicode_identifiers.rb") `shouldReturn`
-        [ Tag "日本語" Method (Loc (Range 16 43) (Span (Pos 2 1) (Pos 4 4))) "def 日本語" Nothing]
+        [ Tag "日本語" Method (Loc (Range 20 29) (Span (Pos 2 5) (Pos 2 14))) "def 日本語" Nothing]
 
     it "produces tags for methods and classes with docs (TODO)" $
       parseTestFile [Class, Method, Tags.Module] (Path.relFile "test/fixtures/ruby/tags/class_module.rb") `shouldReturn`
-        [ Tag "Foo" Tags.Module (Loc (Range 14 118) (Span (Pos 2 1 ) (Pos 12 4))) "module Foo" Nothing
-        , Tag "Bar" Class  (Loc (Range 44 114) (Span (Pos 5 3 ) (Pos 11 6))) "class Bar" Nothing
-        , Tag "baz" Method (Loc (Range 77 108) (Span (Pos 8 5 ) (Pos 10 8))) "def baz(a)" Nothing
-        , Tag "C" Class (Loc (Range 120 188) (Span (Pos 14 1) (Pos 20 4))) "class A::B::C" Nothing
-        , Tag "foo" Method (Loc (Range 136 163) (Span (Pos 15 3) (Pos 17 6))) "def foo" Nothing
-        , Tag "foo" Method (Loc (Range 166 184) (Span (Pos 18 3) (Pos 19 6))) "def self.foo" Nothing
+        [ Tag "Foo" Tags.Module (Loc (Range 21 24) (Span (Pos 2 8) (Pos 2 11))) "module Foo" Nothing
+        , Tag "Bar" Class  (Loc (Range 50 53) (Span (Pos 5 9) (Pos 5 12))) "class Bar" Nothing
+        , Tag "baz" Method (Loc (Range 81 84) (Span (Pos 8 9) (Pos 8 12))) "def baz(a)" Nothing
+        , Tag "C" Class (Loc (Range 132 133) (Span (Pos 14 13) (Pos 14 14))) "class A::B::C" Nothing
+        , Tag "foo" Method (Loc (Range 140 143) (Span (Pos 15 7) (Pos 15 10))) "def foo" Nothing
+        , Tag "foo" Method (Loc (Range 175 178) (Span (Pos 18 12) (Pos 18 15))) "def self.foo" Nothing
         ]
 
 parseTestFile :: Foldable t => t Tags.Kind -> Path.RelFile -> IO [Tag]

--- a/test/Tags/Spec.hs
+++ b/test/Tags/Spec.hs
@@ -28,15 +28,15 @@ spec = do
   describe "javascript and typescript" $ do
     it "produces tags for functions with docs (TODO)" $
       parseTestFile [Function] (Path.relFile "test/fixtures/javascript/tags/simple_function_with_docs.js") `shouldReturn`
-        [ Tag "myFunction" Function (Loc (Range 22 59) (Span (Pos 2 1) (Pos 4 2))) "function myFunction() {" Nothing ]
+        [ Tag "myFunction" Function (Loc (Range 31 41) (Span (Pos 2 10) (Pos 2 20))) "function myFunction() {" Nothing ]
 
     it "produces tags for classes" $
       parseTestFile [Class] (Path.relFile "test/fixtures/typescript/tags/class.ts") `shouldReturn`
-        [ Tag "FooBar" Class (Loc (Range 0 15) (Span (Pos 1 1) (Pos 1 16))) "class FooBar {}" Nothing ]
+        [ Tag "FooBar" Class (Loc (Range 6 12) (Span (Pos 1 7) (Pos 1 13))) "class FooBar {}" Nothing ]
 
     it "produces tags for modules" $
       parseTestFile [Tags.Module] (Path.relFile "test/fixtures/typescript/tags/module.ts") `shouldReturn`
-        [ Tag "APromise" Tags.Module (Loc (Range 0 19) (Span (Pos 1 1) (Pos 1 20))) "module APromise { }" Nothing ]
+        [ Tag "APromise" Tags.Module (Loc (Range 7 15) (Span (Pos 1 8) (Pos 1 16))) "module APromise { }" Nothing ]
 
   describe "python" $ do
     it "produces tags for functions" $

--- a/test/fixtures/cli/parse-tree.symbols.json
+++ b/test/fixtures/cli/parse-tree.symbols.json
@@ -1,1 +1,1 @@
-{"files":[{"path":"test/fixtures/ruby/corpus/method-declaration.A.rb","language":"Ruby","symbols":[{"symbol":"foo","kind":"Method","line":"def foo","span":{"start":{"line":1,"column":1},"end":{"line":2,"column":4}}}]}]}
+{"files":[{"path":"test/fixtures/ruby/corpus/method-declaration.A.rb","language":"Ruby","symbols":[{"symbol":"foo","kind":"Method","line":"def foo","span":{"start":{"line":1,"column":5},"end":{"line":1,"column":8}}}]}]}

--- a/test/fixtures/cli/parse-tree.symbols.protobuf.bin
+++ b/test/fixtures/cli/parse-tree.symbols.protobuf.bin
@@ -2,4 +2,4 @@
 _
 1test/fixtures/ruby/corpus/method-declaration.A.rbRuby$
 fooMethoddef foo"
-
+


### PR DESCRIPTION
The AST tagging code was returning spans for source locations that included the outer syntax, this changes the `ToTags` instances to produce much more constrained ranges/spans for just the named identifiers.

Since I was changing every `ToTags` instance, I also did an experiment with [ormolu](https://github.com/tweag/ormolu) for code formatting. This is definitely a difference style than we are use to, but I very much appreciate the zero config and no need to mess with the formatting. This should be diff friendly going forward. It's easy to reformat with our existing stylish haskell rules, so let me know what you all think.