### PR TITLE
Fix annoying warning re. inter-project dependencies.

### DIFF
--- a/semantic-python/semantic-python.cabal
+++ b/semantic-python/semantic-python.cabal
@@ -73,7 +73,7 @@ test-suite compiling
   main-is: CoreTest.hs
   ghc-options: -threaded
 
-  build-depends: semantic-python == 0.0.0.0
+  build-depends: semantic-python
                , aeson ^>= 1.4.4
                , aeson-pretty ^>= 0.8.7
                , bytestring ^>= 0.10.8.2


### PR DESCRIPTION
Building `semantic-python` would result in a warning like this:

```
Warning: The package has an extraneous version range for a dependency on an
internal library: semantic-python ==0.0.0.0. This version range includes the
current package but isn't needed as the current package's library will always
be used.
```

Removing this indeed-extraneous bound makes it go away.


----

#