### PR TITLE
Updates unofficial stack configuration information

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ cabal v2-test
 cabal v2-run semantic -- --help
 ```
 
- `stack` as a build tool is not officially supported; there is an unofficial [`stack.yaml`](https://gist.github.com/jkachmar/f200caee83280f1f25e9cfa2dd2b16bb) available, though we cannot make guarantees as to its stability.
+ `stack` as a build tool is not officially supported; there is [unofficial `stack.yaml` support](https://github.com/jkachmar/semantic-stack-yaml) available, though we cannot make guarantees as to its stability.
 
 [nix]: https://www.haskell.org/cabal/users-guide/nix-local-build-overview.html
 [ghcup]: https://www.haskell.org/ghcup/


### PR DESCRIPTION
I was reading through the README recently and I realized that I hadn't updated the gist that you were pointing to in quite some time.

Since I'm not actively using `semantic` and I'm not likely to fix things unless I'm prodded to do so, I set up a small repository tracking the latest LTS (15.13 at the time of writing) and validate that it works using a simple GitHub Actions workflow.

I'm still a little too lazy to have my repo perform a full build and test run, but this at least should at least provide the user with a build plan that's valid with respect to package versions.