### PR TITLE
8.10 support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -39,11 +39,6 @@ source-repository-package
 
 source-repository-package
   type: git
-  location: https://github.com/fused-effects/fused-effects.git
-  tag: a3518b31193d9a53fe8f0a61b2132298964ffc48
-
-source-repository-package
-  type: git
   location: https://github.com/tree-sitter/haskell-tree-sitter.git
   tag: 7698d999a85b34d95dd85a75aee0ff94d4a67335
   subdir: tree-sitter-typescript

--- a/cabal.project
+++ b/cabal.project
@@ -24,10 +24,89 @@ packages: .
 -- ATTENTION: remember to update cabal.project.ci when bumping SHAs here!
 source-repository-package
   type: git
-  location: https://github.com/tclem/proto-lens-jsonpb
-  tag: 5d40444be689bef1e12cbe38da0261283775ec64
+  location: https://github.com/joshvera/proto-lens-jsonpb
+  tag: 186611729bb2a9f2962703e814c9528154ef04fc
 
 source-repository-package
   type: git
-  location: https://github.com/antitypical/fused-syntax.git
-  tag: d11e14581217590a5c67f79cbaeee35ac8acee6a
+  location: https://github.com/haskell/text
+  tag: a01843250166b5559936ba5eb81f7873e709587a
+
+source-repository-package
+  type: git
+  location: https://github.com/joshvera/fused-syntax.git
+  tag: b7e5a53f9e8e57ae4da4b8be271b6885852cb2c1
+
+source-repository-package
+  type: git
+  location: https://github.com/fused-effects/fused-effects.git
+  tag: a3518b31193d9a53fe8f0a61b2132298964ffc48
+
+source-repository-package
+  type: git
+  location: https://github.com/tree-sitter/haskell-tree-sitter.git
+  tag: 7698d999a85b34d95dd85a75aee0ff94d4a67335
+  subdir: tree-sitter-typescript
+
+source-repository-package
+  type: git
+  location: https://github.com/tree-sitter/haskell-tree-sitter.git
+  tag: 7698d999a85b34d95dd85a75aee0ff94d4a67335
+  subdir: tree-sitter-tsx
+
+source-repository-package
+  type: git
+  location: https://github.com/tree-sitter/haskell-tree-sitter.git
+  tag: 7698d999a85b34d95dd85a75aee0ff94d4a67335
+  subdir: tree-sitter-rust
+
+source-repository-package
+  type: git
+  location: https://github.com/tree-sitter/haskell-tree-sitter.git
+  tag: 7698d999a85b34d95dd85a75aee0ff94d4a67335
+  subdir: tree-sitter-ruby
+
+
+source-repository-package
+  type: git
+  location: https://github.com/tree-sitter/haskell-tree-sitter.git
+  tag: 7698d999a85b34d95dd85a75aee0ff94d4a67335
+  subdir: tree-sitter-ql
+
+source-repository-package
+  type: git
+  location: https://github.com/tree-sitter/haskell-tree-sitter.git
+  tag: 7698d999a85b34d95dd85a75aee0ff94d4a67335
+  subdir: tree-sitter-python
+
+
+source-repository-package
+  type: git
+  location: https://github.com/tree-sitter/haskell-tree-sitter.git
+  tag: 7698d999a85b34d95dd85a75aee0ff94d4a67335
+  subdir: tree-sitter-php
+
+source-repository-package
+  type: git
+  location: https://github.com/tree-sitter/haskell-tree-sitter.git
+  tag: 7698d999a85b34d95dd85a75aee0ff94d4a67335
+  subdir: tree-sitter-json
+
+source-repository-package
+  type: git
+  location: https://github.com/tree-sitter/haskell-tree-sitter.git
+  tag: 7698d999a85b34d95dd85a75aee0ff94d4a67335
+  subdir: tree-sitter-java
+
+
+source-repository-package
+  type: git
+  location: https://github.com/tree-sitter/haskell-tree-sitter.git
+  tag: 7698d999a85b34d95dd85a75aee0ff94d4a67335
+  subdir: tree-sitter-go
+
+source-repository-package
+  type: git
+  location: https://github.com/tree-sitter/haskell-tree-sitter.git
+  tag: 7698d999a85b34d95dd85a75aee0ff94d4a67335
+  subdir: tree-sitter

--- a/semantic-proto/semantic-proto.cabal
+++ b/semantic-proto/semantic-proto.cabal
@@ -27,9 +27,9 @@ library
       base                >= 4.13 && < 5
     , aeson ^>= 1.4.2.0
     , text               ^>= 1.2.3.1
-    , proto-lens >= 0.5 && < 0.7
+    , proto-lens >= 0.5 && < 0.8
     , proto-lens-jsonpb
-    , proto-lens-runtime >= 0.5 && <0.7
+    , proto-lens-runtime >= 0.5 && <0.8
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:

--- a/semantic-ruby/semantic-ruby.cabal
+++ b/semantic-ruby/semantic-ruby.cabal
@@ -85,7 +85,7 @@ executable benchmarks
                      , gauge ^>= 0.2.5
                      , bytestring
                      , Glob
-                     , lens >= 4.17 && < 4.19
+                     , lens >= 4.17 && < 4.20
                      , pathtype ^>= 0.8.1
                      , semantic-ruby
 

--- a/semantic.cabal
+++ b/semantic.cabal
@@ -252,13 +252,13 @@ library
                      , directory-tree ^>= 0.12.1
                      , filepath ^>= 1.4.2.1
                      , generic-monoid ^>= 0.1.0.0
-                     , ghc-prim ^>= 0.5.3
+                     , ghc-prim ^>= 0.6.1
                      , gitrev ^>= 1.3.1
-                     , haskeline ^>= 0.7.5.0
+                     , haskeline ^>= 0.8.0.0
                      , hostname ^>= 1.0
                      , hscolour ^>= 1.24.4
                      , kdt ^>= 0.2.4
-                     , lens >= 4.17 && < 4.19
+                     , lens >= 4.17 && < 4.20
                      , mersenne-random-pure64 ^>= 0.2.2.0
                      , network-uri ^>= 2.6.1.0
                      , optparse-applicative >= 0.14.3 && < 0.16
@@ -267,7 +267,7 @@ library
                      , prettyprinter >= 1.2 && < 2
                      , pretty-show ^>= 1.9.5
                      , profunctors ^>= 5.3
-                     , proto-lens >= 0.5 && < 0.7
+                     , proto-lens >= 0.5 && < 0.8
                      , reducers ^>= 3.12.3
                      , semantic-go ^>= 0
                      , semantic-java ^>= 0
@@ -284,10 +284,10 @@ library
                      , semigroupoids ^>= 5.3.2
                      , split ^>= 0.2.3.3
                      , stm-chans ^>= 3.0.0.4
-                     , template-haskell >= 2.14 && < 2.16
+                     , template-haskell >= 2.14 && < 2.17
                      , time >= 1.8.0.2 && < 1.10
                      , utf8-string ^>= 1.0.1.1
-                     , unliftio-core ^>= 0.1.2.0
+                     , unliftio-core ^>= 0.2.0.1
                      , unordered-containers ^>= 0.2.9.0
                      , vector ^>= 0.12.0.2
                      , tree-sitter-go ^>= 0.5.0.0
@@ -374,7 +374,7 @@ test-suite parse-examples
   build-depends:       semantic
                      , Glob
                      , foldl ^>= 1.4.5
-                     , lens >= 4.17 && < 4.19
+                     , lens >= 4.17 && < 4.20
                      , resourcet ^>= 1.2
                      , semantic-proto ^>= 0
                      , streaming
@@ -394,7 +394,7 @@ benchmark benchmarks
                      , algebraic-graphs
                      , gauge ^>= 0.2.5
                      , Glob
-                     , lens >= 4.17 && < 4.19
+                     , lens >= 4.17 && < 4.20
                      , semantic
                      , semantic-ast
                      , semantic-proto


### PR DESCRIPTION
WIP PR to add 8.10 support to semantic.

- [x] Update fused-effects
- [x] Pin fused-effects to 1.0.2.2
- [x] Update `haskell-tree-sitter`
- [ ] Merge haskell-tree-sitter changes upstream and pin to an 8.10 release
- [x] Update text for 8.10 support
- [ ] Pin to an 8.10 release of text
- [x] Update proto-lens-jsonpb for 8.10 support
- [ ] Merge proto-lens-jsonpb changes to https://github.com/tclem/proto-lens-jsonpb
- [x] Update `fused-syntax for 8.10 support
- [x] Update fused-effects-resumable for 8.10 support