### PR TITLE
Ensure parse-examples test suite succeeds.

### DIFF
--- a/test/Examples.hs
+++ b/test/Examples.hs
@@ -124,6 +124,7 @@ tsxSkips = Path.relFile <$>
 typescriptSkips :: [Path.RelFile]
 typescriptSkips = Path.relFile <$>
   [ "npm/node_modules/slide/lib/async-map-ordered.js"
+  , "npm/node_modules/request/node_modules/har-validator/node_modules/ajv/dist/regenerator.min.js"
   ]
 
 buildExamples :: TaskSession -> LanguageExample -> Path.RelDir -> IO Tasty.TestTree


### PR DESCRIPTION
The precise parsers were getting hung up on a large JS file, so the
easiest thing is to just ignore this in the skips.

Fixes #549.