### PR TITLE
Re-enable `semantic parse --json` output.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,6 +48,10 @@ rules_haskell_toolchains(
     version = "8.8.3",
 )
 
+# Enable GHC persistent worker mode, if that's your bag.
+load("@rules_haskell//tools:repositories.bzl", "rules_haskell_worker_dependencies")
+
+rules_haskell_worker_dependencies()
 load(
     "@rules_haskell//haskell:cabal.bzl",
     "stack_snapshot",

--- a/semantic-codeql/src/Language/CodeQL.hs
+++ b/semantic-codeql/src/Language/CodeQL.hs
@@ -1,9 +1,12 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# OPTIONS_GHC -freduction-depth=0 #-}
 -- | Semantic functionality for CodeQL programs.
 module Language.CodeQL
 ( Term(..)
 , TreeSitter.QL.tree_sitter_ql
 ) where
 
+import           AST.Marshal.JSON
 import qualified AST.Unmarshal as TS
 import           Data.Proxy
 import qualified Language.CodeQL.AST as CodeQL
@@ -12,6 +15,7 @@ import qualified Tags.Tagging.Precise as Tags
 import qualified TreeSitter.QL (tree_sitter_ql)
 
 newtype Term a = Term { getTerm :: CodeQL.Ql a }
+  deriving MarshalJSON
 
 instance TS.SymbolMatching Term where
   matchedSymbols _ = TS.matchedSymbols (Proxy :: Proxy CodeQL.Ql)

--- a/semantic-go/src/Language/Go.hs
+++ b/semantic-go/src/Language/Go.hs
@@ -1,10 +1,11 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -- | Semantic functionality for Go programs.
 module Language.Go
 ( Term(..)
 , Language.Go.Grammar.tree_sitter_go
 ) where
 
-
+import           AST.Marshal.JSON
 import           Data.Proxy
 import qualified Language.Go.AST as Go
 import qualified Language.Go.Tags as GoTags
@@ -13,6 +14,7 @@ import qualified Language.Go.Grammar (tree_sitter_go)
 import qualified AST.Unmarshal as TS
 
 newtype Term a = Term { getTerm :: Go.SourceFile a }
+  deriving MarshalJSON
 
 instance TS.SymbolMatching Term where
   matchedSymbols _ = TS.matchedSymbols (Proxy :: Proxy Go.SourceFile)

--- a/semantic-java/src/Language/Java.hs
+++ b/semantic-java/src/Language/Java.hs
@@ -1,9 +1,11 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -- | Semantic functionality for Java programs.
 module Language.Java
 ( Term(..)
 , Language.Java.Grammar.tree_sitter_java
 ) where
 
+import           AST.Marshal.JSON
 import           Data.Proxy
 import qualified Language.Java.AST as Java
 import qualified Language.Java.Tags as JavaTags
@@ -12,6 +14,7 @@ import qualified Language.Java.Grammar (tree_sitter_java)
 import qualified AST.Unmarshal as TS
 
 newtype Term a = Term { getTerm :: Java.Program a }
+  deriving MarshalJSON
 
 instance TS.SymbolMatching Term where
   matchedSymbols _ = TS.matchedSymbols (Proxy :: Proxy Java.Program)

--- a/semantic-json/src/Language/JSON.hs
+++ b/semantic-json/src/Language/JSON.hs
@@ -1,9 +1,11 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -- | Semantic functionality for JSON programs.
 module Language.JSON
 ( Term(..)
 , TreeSitter.JSON.tree_sitter_json
 ) where
 
+import           AST.Marshal.JSON
 import           Data.Proxy
 import qualified Language.JSON.AST as JSON
 import qualified Tags.Tagging.Precise as Tags
@@ -11,6 +13,7 @@ import qualified TreeSitter.JSON (tree_sitter_json)
 import qualified AST.Unmarshal as TS
 
 newtype Term a = Term { getTerm :: JSON.Document a }
+  deriving MarshalJSON
 
 instance TS.SymbolMatching Term where
   matchedSymbols _ = TS.matchedSymbols (Proxy :: Proxy JSON.Document)

--- a/semantic-php/src/Language/PHP.hs
+++ b/semantic-php/src/Language/PHP.hs
@@ -1,9 +1,11 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -- | Semantic functionality for PHP programs.
 module Language.PHP
 ( Term(..)
 , TreeSitter.PHP.tree_sitter_php
 ) where
 
+import           AST.Marshal.JSON
 import qualified AST.Unmarshal as TS
 import           Data.Proxy
 import qualified Language.PHP.AST as PHP
@@ -12,6 +14,7 @@ import qualified Tags.Tagging.Precise as Tags
 import qualified TreeSitter.PHP (tree_sitter_php)
 
 newtype Term a = Term { getTerm :: PHP.Program a }
+  deriving MarshalJSON
 
 instance TS.SymbolMatching Term where
   matchedSymbols _ = TS.matchedSymbols (Proxy :: Proxy PHP.Program)

--- a/semantic-python/src/Language/Python.hs
+++ b/semantic-python/src/Language/Python.hs
@@ -1,9 +1,11 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -- | Semantic functionality for Python programs.
 module Language.Python
 ( Term(..)
 , Language.Python.Grammar.tree_sitter_python
 ) where
 
+import           AST.Marshal.JSON
 import qualified AST.Unmarshal as TS
 import           Data.Proxy
 import qualified Language.Python.AST as Py
@@ -14,6 +16,7 @@ import qualified Language.Python.Tags as PyTags
 import qualified Tags.Tagging.Precise as Tags
 
 newtype Term a = Term { getTerm :: Py.Module a }
+  deriving MarshalJSON
 
 instance TS.SymbolMatching Term where
   matchedSymbols _ = TS.matchedSymbols (Proxy :: Proxy Py.Module)

--- a/semantic-ruby/src/Language/Ruby.hs
+++ b/semantic-ruby/src/Language/Ruby.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 
 -- | Semantic functionality for Ruby programs.
@@ -6,6 +7,7 @@ module Language.Ruby
 , Language.Ruby.Grammar.tree_sitter_ruby
 ) where
 
+import           AST.Marshal.JSON
 import qualified AST.Unmarshal as TS
 import           Control.Carrier.State.Strict
 import           Data.Proxy
@@ -16,6 +18,7 @@ import qualified Language.Ruby.Tags as RbTags
 import qualified Tags.Tagging.Precise as Tags
 
 newtype Term a = Term { getTerm :: Rb.Program a }
+  deriving MarshalJSON
 
 instance TS.SymbolMatching Term where
   matchedSymbols _ = TS.matchedSymbols (Proxy :: Proxy Rb.Program)

--- a/semantic-tsx/src/Language/TSX.hs
+++ b/semantic-tsx/src/Language/TSX.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# OPTIONS_GHC -freduction-depth=0 #-}
 -- | Semantic functionality for TSX programs.
 module Language.TSX
@@ -5,6 +6,7 @@ module Language.TSX
 , Language.TSX.Grammar.tree_sitter_tsx
 ) where
 
+import           AST.Marshal.JSON
 import           Data.Proxy
 import qualified Language.TSX.AST as TSX
 import qualified Language.TSX.Tags as TsxTags
@@ -13,6 +15,7 @@ import qualified Language.TSX.Grammar (tree_sitter_tsx)
 import qualified AST.Unmarshal as TS
 
 newtype Term a = Term { getTerm :: TSX.Program a }
+  deriving MarshalJSON
 
 instance TS.SymbolMatching Term where
   matchedSymbols _ = TS.matchedSymbols (Proxy :: Proxy TSX.Program)

--- a/semantic-typescript/src/Language/TypeScript.hs
+++ b/semantic-typescript/src/Language/TypeScript.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# OPTIONS_GHC -freduction-depth=0 #-}
 -- | Semantic functionality for TypeScript programs.
 module Language.TypeScript
@@ -5,6 +6,7 @@ module Language.TypeScript
 , Language.TypeScript.Grammar.tree_sitter_typescript
 ) where
 
+import           AST.Marshal.JSON
 import           Data.Proxy
 import qualified Language.TypeScript.AST as TypeScript
 import qualified Language.TypeScript.Tags as TsTags
@@ -13,6 +15,7 @@ import qualified Language.TypeScript.Grammar (tree_sitter_typescript)
 import qualified AST.Unmarshal as TS
 
 newtype Term a = Term { getTerm :: TypeScript.Program a }
+  deriving MarshalJSON
 
 instance TS.SymbolMatching Term where
   matchedSymbols _ = TS.matchedSymbols (Proxy :: Proxy TypeScript.Program)

--- a/semantic/src/Semantic/Api/Terms.hs
+++ b/semantic/src/Semantic/Api/Terms.hs
@@ -69,38 +69,32 @@ showTermParsers = preciseParsers
 class ShowTerm term where
   showTerm :: (Has (Reader Config) sig m) => term Loc -> m Builder
 
-instance (ShowTermBy term) => ShowTerm term where
-  showTerm = showTermBy @term
+instance ShowTerm Go.Term where
+  showTerm = serialize Show . void . Go.getTerm
 
-class ShowTermBy term where
-  showTermBy :: (Has (Reader Config) sig m) => term Loc -> m Builder
+instance ShowTerm Java.Term where
+  showTerm = serialize Show . void . Java.getTerm
 
-instance ShowTermBy Go.Term where
-  showTermBy = serialize Show . void . Go.getTerm
+instance ShowTerm JSON.Term where
+  showTerm = serialize Show . void . JSON.getTerm
 
-instance ShowTermBy Java.Term where
-  showTermBy = serialize Show . void . Java.getTerm
+instance ShowTerm PHP.Term where
+  showTerm = serialize Show . void . PHP.getTerm
 
-instance ShowTermBy JSON.Term where
-  showTermBy = serialize Show . void . JSON.getTerm
+instance ShowTerm Python.Term where
+  showTerm = serialize Show . void . Python.getTerm
 
-instance ShowTermBy PHP.Term where
-  showTermBy = serialize Show . void . PHP.getTerm
+instance ShowTerm CodeQL.Term where
+  showTerm = serialize Show . void . CodeQL.getTerm
 
-instance ShowTermBy Python.Term where
-  showTermBy = serialize Show . void . Python.getTerm
+instance ShowTerm Ruby.Term where
+  showTerm = serialize Show . void . Ruby.getTerm
 
-instance ShowTermBy CodeQL.Term where
-  showTermBy = serialize Show . void . CodeQL.getTerm
+instance ShowTerm TSX.Term where
+  showTerm = serialize Show . void . TSX.getTerm
 
-instance ShowTermBy Ruby.Term where
-  showTermBy = serialize Show . void . Ruby.getTerm
-
-instance ShowTermBy TSX.Term where
-  showTermBy = serialize Show . void . TSX.getTerm
-
-instance ShowTermBy TypeScript.Term where
-  showTermBy = serialize Show . void . TypeScript.getTerm
+instance ShowTerm TypeScript.Term where
+  showTerm = serialize Show . void . TypeScript.getTerm
 
 sexprTermParsers :: Map Language (SomeParser SExprTerm Loc)
 sexprTermParsers = preciseParsers
@@ -108,35 +102,29 @@ sexprTermParsers = preciseParsers
 class SExprTerm term where
   sexprTerm :: term Loc -> Builder
 
-instance (SExprTermBy term) => SExprTerm term where
-  sexprTerm = sexprTermBy @term
+instance SExprTerm Go.Term where
+  sexprTerm = SExpr.Precise.serializeSExpression . Go.getTerm
 
-class SExprTermBy term where
-  sexprTermBy :: term Loc -> Builder
+instance SExprTerm Java.Term where
+  sexprTerm = SExpr.Precise.serializeSExpression . Java.getTerm
 
-instance SExprTermBy Go.Term where
-  sexprTermBy = SExpr.Precise.serializeSExpression . Go.getTerm
+instance SExprTerm JSON.Term where
+  sexprTerm = SExpr.Precise.serializeSExpression . JSON.getTerm
 
-instance SExprTermBy Java.Term where
-  sexprTermBy = SExpr.Precise.serializeSExpression . Java.getTerm
+instance SExprTerm PHP.Term where
+  sexprTerm = SExpr.Precise.serializeSExpression . PHP.getTerm
 
-instance SExprTermBy JSON.Term where
-  sexprTermBy = SExpr.Precise.serializeSExpression . JSON.getTerm
+instance SExprTerm Python.Term where
+  sexprTerm = SExpr.Precise.serializeSExpression . Python.getTerm
 
-instance SExprTermBy PHP.Term where
-  sexprTermBy = SExpr.Precise.serializeSExpression . PHP.getTerm
+instance SExprTerm CodeQL.Term where
+  sexprTerm = SExpr.Precise.serializeSExpression . CodeQL.getTerm
 
-instance SExprTermBy Python.Term where
-  sexprTermBy = SExpr.Precise.serializeSExpression . Python.getTerm
+instance SExprTerm Ruby.Term where
+  sexprTerm = SExpr.Precise.serializeSExpression . Ruby.getTerm
 
-instance SExprTermBy CodeQL.Term where
-  sexprTermBy = SExpr.Precise.serializeSExpression . CodeQL.getTerm
+instance SExprTerm TSX.Term where
+  sexprTerm = SExpr.Precise.serializeSExpression . TSX.getTerm
 
-instance SExprTermBy Ruby.Term where
-  sexprTermBy = SExpr.Precise.serializeSExpression . Ruby.getTerm
-
-instance SExprTermBy TSX.Term where
-  sexprTermBy = SExpr.Precise.serializeSExpression . TSX.getTerm
-
-instance SExprTermBy TypeScript.Term where
-  sexprTermBy = SExpr.Precise.serializeSExpression . TypeScript.getTerm
+instance SExprTerm TypeScript.Term where
+  sexprTerm = SExpr.Precise.serializeSExpression . TypeScript.getTerm

--- a/semantic/src/Semantic/CLI.hs
+++ b/semantic/src/Semantic/CLI.hs
@@ -96,6 +96,9 @@ parseCommand = command "parse" (info parseArgumentsParser (progDesc "Generate pa
         <|> flag' (parseSymbolsBuilder Proto)
                   (  long "proto-symbols"
                   <> help "Output protobufs symbol list")
+        <|> flag' (parseTermBuilder TermJSON)
+                  (  long "json"
+                  <> help "Output JSON AST dump")
         <|> flag' (parseTermBuilder TermShow)
                   (  long "show"
                   <> help "Output using the Show instance (debug only, format subject to change without notice)")

--- a/semantic/src/Serializing/Format.hs
+++ b/semantic/src/Serializing/Format.hs
@@ -1,13 +1,16 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
-module Serializing.Format
-( Format(..)
-, FormatStyle(..)
-, Builder
-, runSerialize
-) where
 
+module Serializing.Format
+  ( Format (..),
+    FormatStyle (..),
+    Builder,
+    runSerialize,
+  )
+where
+
+import AST.Marshal.JSON
 import Algebra.Graph.Export.Dot
 import Algebra.Graph.ToGraph
 import Data.Aeson (ToJSON (..), fromEncoding)
@@ -16,19 +19,22 @@ import Data.ProtoLens.Encoding as Proto
 import Data.ProtoLens.Message (Message)
 import Language.Haskell.HsColour
 import Language.Haskell.HsColour.Colourise
+import Source.Loc
 import Text.Show.Pretty
 
 data Format input where
-  DOT         :: (Ord vertex, ToGraph graph, ToVertex graph ~ vertex) => Style vertex Builder -> Format graph
-  JSON        :: ToJSON input                                         =>                         Format input
-  Show        :: Show input                                           =>                         Format input
-  Proto       :: Message input                                        =>                         Format input
+  DOT :: (Ord vertex, ToGraph graph, ToVertex graph ~ vertex) => Style vertex Builder -> Format graph
+  JSON :: ToJSON input => Format input
+  Marshal :: MarshalJSON input => Format (input Loc)
+  Show :: Show input => Format input
+  Proto :: Message input => Format input
 
 data FormatStyle = Colourful | Plain
 
 runSerialize :: FormatStyle -> Format input -> input -> Builder
-runSerialize _         (DOT style)        = export style
-runSerialize _         JSON               = (<> "\n") . fromEncoding . toEncoding
-runSerialize Colourful Show               = (<> "\n") . stringUtf8 . hscolour TTY defaultColourPrefs False False "" False . ppShow
-runSerialize Plain     Show               = (<> "\n") . stringUtf8 . show
-runSerialize _         Proto              = Proto.buildMessage
+runSerialize _ (DOT style) = export style
+runSerialize _ JSON = (<> "\n") . fromEncoding . toEncoding
+runSerialize _ Marshal = fromEncoding . toEncoding . marshal
+runSerialize Colourful Show = (<> "\n") . stringUtf8 . hscolour TTY defaultColourPrefs False False "" False . ppShow
+runSerialize Plain Show = (<> "\n") . stringUtf8 . show
+runSerialize _ Proto = Proto.buildMessage


### PR DESCRIPTION
When we switched away from alacarte syntax, we lost the `--json`
option for AST output. However, the majority of the needed code was
already implemented by @aymannadeem, so all we had to do was have the
syntax types opt into the `MarshalJSON` API, and to define the
boilerplate needed to plug it into the `Serialize` interface.

Fixes #471.