### PR TITLE
Add missing READMEs to subprojects.

### DIFF
--- a/semantic-scope-graph/README.md
+++ b/semantic-scope-graph/README.md
@@ -1,0 +1,1 @@
+This project contains efforts to build scope-graphing mechanisms atop the ASTs provided by semantic.

--- a/semantic-scope-graph/README.md
+++ b/semantic-scope-graph/README.md
@@ -1,1 +1,1 @@
-This project contains efforts to build scope-graphing mechanisms atop the ASTs provided by semantic.
+This project contains scope-graphing mechanisms atop the ASTs provided by semantic.

--- a/semantic/README.md
+++ b/semantic/README.md
@@ -1,0 +1,1 @@
+This package provides the `semantic` executable and its needed infrastructure.


### PR DESCRIPTION
These two subprojects were missing README files, and in my local build of downstream projects, I was hitting weird errors from `cabal` about missing READMEs. I guess newer versions of cabal started checking some invariants? Anyway, I added minimal READMEs and now I can build again.