### PR TITLE
Proof of concept of "side channel" for diagnostics

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -20,7 +20,7 @@ packages: semantic
           semantic-tags
           semantic-tsx
           semantic-typescript
-          -- ../../alanz/haskell-tree-sitter/tree-sitter
+          -- ../../tree-sitter/haskell-tree-sitter/tree-sitter
 
 source-repository-package
   type: git
@@ -30,5 +30,5 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/alanz/haskell-tree-sitter.git
-    tag: 8f6d94e6bbb7035851492160fa6e642c8612d2b
+    tag: ec8a82021017f644c77156c33a249073d013f73b
     subdir: tree-sitter

--- a/cabal.project
+++ b/cabal.project
@@ -20,8 +20,15 @@ packages: semantic
           semantic-tags
           semantic-tsx
           semantic-typescript
+          -- ../../alanz/haskell-tree-sitter/tree-sitter
 
 source-repository-package
   type: git
   location: https://github.com/antitypical/fused-syntax.git
   tag: 4a383d57c8fd7592f54a33f43eb9666314a6e80e
+
+source-repository-package
+    type: git
+    location: https://github.com/alanz/haskell-tree-sitter.git
+    tag: 8f6d94e6bbb7035851492160fa6e642c8612d2b
+    subdir: tree-sitter

--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -26,6 +26,12 @@ source-repository-package
   location: https://github.com/antitypical/fused-syntax.git
   tag: 4a383d57c8fd7592f54a33f43eb9666314a6e80e
 
+source-repository-package
+    type: git
+    location: https://github.com/alanz/haskell-tree-sitter.git
+    tag: 8f6d94e6bbb7035851492160fa6e642c8612d2b
+    subdir: tree-sitter
+
 -- Treat warnings as errors for CI builds
 package semantic
   ghc-options: -Werror

--- a/semantic-ast/src/AST/Unmarshal.hs
+++ b/semantic-ast/src/AST/Unmarshal.hs
@@ -16,6 +16,8 @@ module AST.Unmarshal
 ( parseByteString
 , UnmarshalState(..)
 , UnmarshalDiagnostics(..)
+, TSDiagnostic(..)
+, parseDiagnostics
 , UnmarshalError(..)
 , FieldName(..)
 , Unmarshal(..)
@@ -33,6 +35,7 @@ import           AST.Token as TS
 import           AST.Parse
 import           Control.Carrier.State.Strict
 import           Control.Exception
+import           Control.Monad (void)
 import           Control.Monad.IO.Class
 import           Data.Attoparsec.Text as Attoparsec (Parser, char, takeWhile1, string, many', endOfInput, decimal, choice, parseOnly)
 import           Data.ByteString (ByteString)
@@ -62,7 +65,6 @@ import           TreeSitter.Language as TS
 import           TreeSitter.Node as TS
 import           TreeSitter.Parser as TS
 import           TreeSitter.Tree as TS
-import Control.Monad (void)
 
 -- Parse source code and produce AST
 parseByteString :: (Unmarshal t, UnmarshalAnn a) => Ptr TS.Language -> ByteString -> IO (Either String (UnmarshalDiagnostics, (t a)))

--- a/semantic/src/Parsing/TreeSitter.hs
+++ b/semantic/src/Parsing/TreeSitter.hs
@@ -12,7 +12,8 @@ module Parsing.TreeSitter
 , parseToPreciseAST
 ) where
 
-import Control.Carrier.Reader
+import Control.Carrier.State.Strict
+-- import Control.Carrier.Reader
 import Control.Exception as Exc
 import Control.Monad.IO.Class
 import Foreign
@@ -51,7 +52,7 @@ parseToPreciseAST
 parseToPreciseAST parseTimeout unmarshalTimeout language blob = runParse parseTimeout language blob $ \ rootPtr ->
   withTimeout $
     TS.withCursor (castPtr rootPtr) $ \ cursor ->
-      runReader (TS.UnmarshalState (Source.bytes (blobSource blob)) cursor) (liftIO (peek rootPtr) >>= TS.unmarshalNode)
+      runState (TS.UnmarshalState (Source.bytes (blobSource blob)) cursor mempty) (liftIO (peek rootPtr) >>= TS.unmarshalNode)
         `Exc.catch` (Exc.throw . UnmarshalFailure . TS.getUnmarshalError)
   where
     withTimeout :: IO a -> IO a


### PR DESCRIPTION
Replaces `ReaderC` with `StateC` in `Unmarshal`, and checks for diagnostics
at each visited node, kept in the state.

The diagnostic determination is dodgy, but the concept works

See https://gist.github.com/alanz/2ae23a75bba75ed09780d3fa043bd28e

Note: haskell-tree-sitter is a git dep, it needs a
"git submodule update" in the appropriate "dist-newstyle/src" directory.

Related issues: #574 #638 .

Alternative approaches are to extend the query capabilities, as requested in https://github.com/tree-sitter/tree-sitter/issues/606

The `ts_node_has_error` and `ts_node_is_missing_p` calls are not the right ones, the detailed info comes from the logic in 
https://github.com/tree-sitter/tree-sitter/blob/2b0de9dfec62af7e74c319abe80912b02dca74be/lib/src/subtree.c#L846-L894

and

https://github.com/tree-sitter/tree-sitter/blob/2b0de9dfec62af7e74c319abe80912b02dca74be/lib/src/language.c#L67-L80 