### PR TITLE
Drop pathtype, part one

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -66,7 +66,7 @@ jobs:
         cabal v2-run   --project-file=cabal.project.ci semantic-tags:test
         cabal v2-run   --project-file=cabal.project.ci semantic-tsx:test
         cabal v2-run   --project-file=cabal.project.ci semantic-typescript:test
-        cabal v2-run   --project-file=cabal.project.ci semantic-source:test
+        cd semantic-source && cabal v2-run   --project-file=cabal.project.ci semantic-source:test
 
     - name: Write out cache
       run: ./cabal-cache sync-to-archive --threads=2 --archive-uri=dist-cache

--- a/cabal.project
+++ b/cabal.project
@@ -15,7 +15,6 @@ packages: semantic
           semantic-ruby
           semantic-rust
           semantic-scope-graph
-          semantic-source
           semantic-tags
           semantic-tsx
           semantic-typescript

--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -15,7 +15,6 @@ packages: semantic
           semantic-ruby
           semantic-rust
           semantic-scope-graph
-          semantic-source
           semantic-tags
           semantic-tsx
           semantic-typescript
@@ -52,9 +51,6 @@ package semantic-ruby
   ghc-options: -Werror
 
 package semantic-scope-graph
-  ghc-options: -Werror
-
-package semantic-source
   ghc-options: -Werror
 
 package semantic-tags

--- a/semantic-source/CHANGELOG.md
+++ b/semantic-source/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.0.0
+
+- Finds languages for `FilePath`s.
+- Drops dependency on `pathtype`.
+
+
 # 0.1.0.2
 
 - Support ghc 9.2.

--- a/semantic-source/semantic-source.cabal
+++ b/semantic-source/semantic-source.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.4
 
 name:                semantic-source
-version:             0.1.0.2
+version:             0.2.0.0
 synopsis:            Types and functionality for working with source code
 description:         Types and functionality for working with source code (program text).
 homepage:            https://github.com/github/semantic/tree/master/semantic-source#readme

--- a/semantic-source/semantic-source.cabal
+++ b/semantic-source/semantic-source.cabal
@@ -64,7 +64,6 @@ library
     , containers     ^>= 0.6.2
     , hashable        >= 1.2.7 && < 1.4
     , lingo          ^>= 0.5.0.3
-    , pathtype       ^>= 0.8.1
     , semilattices   ^>= 0.0.0.3
     , text           ^>= 1.2.3.2
   hs-source-dirs: src

--- a/semantic-source/src/Source/Language.hs
+++ b/semantic-source/src/Source/Language.hs
@@ -109,34 +109,34 @@ forPath path =
 
 languageToText :: Language -> T.Text
 languageToText = \case
-  Unknown -> "Unknown"
-  CodeQL -> "CodeQL"
-  Go -> "Go"
-  Haskell -> "Haskell"
-  Java -> "Java"
+  Unknown    -> "Unknown"
+  CodeQL     -> "CodeQL"
+  Go         -> "Go"
+  Haskell    -> "Haskell"
+  Java       -> "Java"
   JavaScript -> "JavaScript"
-  JSON -> "JSON"
-  JSX -> "JSX"
-  Markdown -> "Markdown"
-  PHP -> "PHP"
-  Python -> "Python"
-  Ruby -> "Ruby"
+  JSON       -> "JSON"
+  JSX        -> "JSX"
+  Markdown   -> "Markdown"
+  PHP        -> "PHP"
+  Python     -> "Python"
+  Ruby       -> "Ruby"
   TypeScript -> "TypeScript"
-  TSX -> "TSX"
+  TSX        -> "TSX"
 
 textToLanguage :: T.Text -> Language
 textToLanguage = \case
-  "CodeQL" -> CodeQL
-  "Go" -> Go
-  "Haskell" -> Haskell
-  "Java" -> Java
+  "CodeQL"     -> CodeQL
+  "Go"         -> Go
+  "Haskell"    -> Haskell
+  "Java"       -> Java
   "JavaScript" -> JavaScript
-  "JSON" -> JSON
-  "JSX" -> JSX
-  "Markdown" -> Markdown
-  "PHP" -> PHP
-  "Python" -> Python
-  "Ruby" -> Ruby
+  "JSON"       -> JSON
+  "JSX"        -> JSX
+  "Markdown"   -> Markdown
+  "PHP"        -> PHP
+  "Python"     -> Python
+  "Ruby"       -> Ruby
   "TypeScript" -> TypeScript
-  "TSX" -> TSX
-  _ -> Unknown
+  "TSX"        -> TSX
+  _            -> Unknown

--- a/semantic-source/src/Source/Language.hs
+++ b/semantic-source/src/Source/Language.hs
@@ -20,8 +20,6 @@ import qualified Data.Languages as Lingo
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import           GHC.Generics (Generic)
-import qualified System.Path as Path
-import qualified System.Path.PartClass as Path.PartClass
 
 -- | The various languages we support.
 data Language
@@ -96,13 +94,13 @@ knownLanguage = (/= Unknown)
 extensionsForLanguage :: Language -> [String]
 extensionsForLanguage language = fmap T.unpack (maybe mempty Lingo.languageExtensions (Map.lookup (languageToText language) Lingo.languages))
 
-forPath :: Path.PartClass.AbsRel ar => Path.File ar -> Language
+forPath :: FilePath -> Language
 forPath path =
   let spurious lang = lang `elem` [ "Hack" -- .php files
                                   , "GCC Machine Description" -- .md files
                                   , "XML" -- .tsx files
                                   ]
-      allResults = Lingo.languageName <$> Lingo.languagesForPath (Path.toString path)
+      allResults = Lingo.languageName <$> Lingo.languagesForPath path
   in case filter (not . spurious) allResults of
     [result] -> textToLanguage result
     _        -> Unknown


### PR DESCRIPTION
This PR drops `semantic-source`'s dependency on `pathtype`, selecting languages from `FilePath`s instead. I'll release the new version once this PR is approved.

Our other packages get `semantic-source` from `cabal`, and are constrained to exclude 0.2+, so they shouldn't be disturbed by this change. Updating them to drop the `pathtype` dependency is postponed to a later PR.