### PR TITLE
Drop pathtype, part two

### DIFF
--- a/semantic-analysis/cabal.project
+++ b/semantic-analysis/cabal.project
@@ -1,4 +1,4 @@
 -- NB: This file exists solely for development of this single package. For cross-package development, cd to the root of the project and run `script/repl` from there.
 
 -- Local packages
-packages: .
+packages: . ../semantic-source

--- a/semantic-analysis/cabal.project
+++ b/semantic-analysis/cabal.project
@@ -1,4 +1,4 @@
 -- NB: This file exists solely for development of this single package. For cross-package development, cd to the root of the project and run `script/repl` from there.
 
 -- Local packages
-packages: . ../semantic-source
+packages: .

--- a/semantic-analysis/semantic-analysis.cabal
+++ b/semantic-analysis/semantic-analysis.cabal
@@ -77,7 +77,7 @@ library
     , fused-effects               ^>= 1.1
     , hashable
     , pathtype                    ^>= 0.8.1
-    , semantic-source             ^>= 0.1.0.1
+    , semantic-source             ^>= 0.2
     , text                        ^>= 1.2.3.1
     , transformers                ^>= 0.5
     , vector                      ^>= 0.12.3

--- a/semantic-analysis/semantic-analysis.cabal
+++ b/semantic-analysis/semantic-analysis.cabal
@@ -76,7 +76,6 @@ library
     , filepath
     , fused-effects               ^>= 1.1
     , hashable
-    , pathtype                    ^>= 0.8.1
     , semantic-source             ^>= 0.2
     , text                        ^>= 1.2.3.1
     , transformers                ^>= 0.5

--- a/semantic-analysis/src/Analysis/Blob.hs
+++ b/semantic-analysis/src/Analysis/Blob.hs
@@ -8,13 +8,11 @@ module Analysis.Blob
   , nullBlob
   ) where
 
-import           Analysis.File as A
-import           Analysis.Reference as A
-import           Data.Aeson
-import           Source.Language as Language
-import           Source.Source as Source
-import qualified System.Path as Path
-import qualified System.Path.PartClass as Path.PartClass
+import Analysis.File as A
+import Analysis.Reference as A
+import Data.Aeson
+import Source.Language as Language
+import Source.Source as Source
 
 -- | The source, path information, and language of a file read from disk.
 data Blob = Blob
@@ -25,27 +23,27 @@ data Blob = Blob
 instance FromJSON Blob where
   parseJSON = withObject "Blob" $ \b -> do
     src <- b .: "content"
-    Right pth <- fmap Path.parse (b .: "path")
+    pth <- b .: "path"
     lang <- b .: "language"
     let lang' = if knownLanguage lang then lang else Language.forPath pth
-    pure (fromSource (pth :: Path.AbsRelFile) lang' src)
+    pure (fromSource pth lang' src)
 
 
 -- | Create a Blob from a provided path, language, and UTF-8 source.
 -- The resulting Blob's span is taken from the 'totalSpan' of the source.
-fromSource :: Path.PartClass.AbsRel ar => Path.File ar -> Language -> Source -> Blob
+fromSource :: FilePath -> Language -> Source -> Blob
 fromSource filepath language source
-  = Blob source (A.File (A.Reference (Path.toAbsRel filepath) (totalSpan source)) language)
+  = Blob source (A.File (A.Reference filepath (totalSpan source)) language)
 
 blobLanguage :: Blob -> Language
 blobLanguage = A.fileBody . blobFile
 
-blobPath :: Blob -> Path.AbsRelFile
+blobPath :: Blob -> FilePath
 blobPath = A.refPath . A.fileRef . blobFile
 
 -- | Show FilePath for error or json outputs.
 blobFilePath :: Blob -> String
-blobFilePath = Path.toString . blobPath
+blobFilePath = blobPath
 
 nullBlob :: Blob -> Bool
 nullBlob = Source.null . blobSource

--- a/semantic-analysis/src/Analysis/File.hs
+++ b/semantic-analysis/src/Analysis/File.hs
@@ -14,8 +14,6 @@ import           Data.Maybe (fromJust, listToMaybe)
 import           GHC.Stack
 import           Source.Language as Language
 import           Source.Span
-import qualified System.Path as Path
-import qualified System.Path.PartClass as Path.PartClass
 
 -- Files
 
@@ -29,10 +27,10 @@ data File a = File
 -- Constructors
 
 fromBody :: HasCallStack => a -> File a
-fromBody body = File (A.Reference (Path.absRel (srcLocFile srcLoc)) (spanFromSrcLoc srcLoc)) body where
+fromBody body = File (A.Reference (srcLocFile srcLoc) (spanFromSrcLoc srcLoc)) body where
   srcLoc = snd (fromJust (listToMaybe (getCallStack callStack)))
 
-fromPath :: Path.PartClass.AbsRel ar => Path.File ar -> File Language
+fromPath :: FilePath -> File Language
 fromPath p = File (A.fromPath p) (Language.forPath p)
 
 

--- a/semantic-analysis/src/Analysis/Module.hs
+++ b/semantic-analysis/src/Analysis/Module.hs
@@ -48,7 +48,7 @@ instance Monoid (ModuleSet a) where
   mempty = ModuleSet mempty
 
 fromList :: [File (Module a)] -> ModuleSet a
-fromList = ModuleSet . Map.fromList . map (\ (File ref mod) -> (refName ref , mod))
+fromList = ModuleSet . Map.fromList . map (\ (File ref mod) -> (refName ref, mod))
   where
   refName (Reference path _) = name (Text.pack (Path.toString (Path.takeBaseName path)))
 

--- a/semantic-analysis/src/Analysis/Module.hs
+++ b/semantic-analysis/src/Analysis/Module.hs
@@ -13,7 +13,7 @@ import           Data.Foldable (foldl')
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text as Text
-import qualified System.Path as Path
+import           System.FilePath as Path
 
 data Module a = Module
   { body    :: Map.Map Name a -> a
@@ -50,7 +50,7 @@ instance Monoid (ModuleSet a) where
 fromList :: [File (Module a)] -> ModuleSet a
 fromList = ModuleSet . Map.fromList . map (\ (File ref mod) -> (refName ref, mod))
   where
-  refName (Reference path _) = name (Text.pack (Path.toString (Path.takeBaseName path)))
+  refName (Reference path _) = name (Text.pack (Path.takeBaseName path))
 
 link :: ModuleSet a -> Module a -> Module a
 link (ModuleSet ms) m = Module body' (imports m Set.\\ Map.keysSet ms) (exports m) unknown' where

--- a/semantic-analysis/src/Analysis/Project.hs
+++ b/semantic-analysis/src/Analysis/Project.hs
@@ -12,19 +12,19 @@ import           Analysis.File
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Source.Language
-import qualified System.Path as Path
+import           System.FilePath (takeFileName)
 
 -- | A 'Project' contains all the information that semantic needs
 -- to execute an analysis, diffing, or graphing pass.
 data Project = Project
-  { projectRootDir     :: Path.AbsRelDir
+  { projectRootDir     :: FilePath
   , projectBlobs       :: [Blob]
   , projectLanguage    :: Language
-  , projectExcludeDirs :: [Path.AbsRelDir]
+  , projectExcludeDirs :: [FilePath]
   } deriving (Eq, Show)
 
 projectName :: Project -> Text
-projectName = T.pack . maybe "" Path.toString . Path.takeDirName . projectRootDir
+projectName = T.pack . takeFileName . projectRootDir
 
 projectExtensions :: Project -> [String]
 projectExtensions = extensionsForLanguage . projectLanguage

--- a/semantic-analysis/src/Analysis/Reference.hs
+++ b/semantic-analysis/src/Analysis/Reference.hs
@@ -6,13 +6,11 @@ module Analysis.Reference
 ) where
 
 import Source.Span
-import System.Path as Path
-import System.Path.PartClass as Path.PartClass
 
 -- Reference
 
 data Reference = Reference
-  { refPath :: Path.AbsRelFile
+  { refPath :: FilePath
   , refSpan :: Span
   }
   deriving (Eq, Ord, Show)
@@ -20,5 +18,5 @@ data Reference = Reference
 
 -- Constructors
 
-fromPath :: Path.PartClass.AbsRel ar => Path.File ar -> Reference
-fromPath p = Reference (Path.toAbsRel p) (point (Pos 0 0))
+fromPath :: FilePath -> Reference
+fromPath p = Reference p (point (Pos 0 0))

--- a/semantic-analysis/src/Analysis/Syntax.hs
+++ b/semantic-analysis/src/Analysis/Syntax.hs
@@ -55,7 +55,6 @@ import qualified Data.Vector as V
 import qualified Source.Source as Source
 import           Source.Span
 import           System.FilePath
-import qualified System.Path as Path
 
 data Term
   = Var Name
@@ -140,7 +139,7 @@ parseFile path = do
   case (A.eitherDecodeWith A.json' (A.iparse parseGraph) contents) of
     Left  (_, err)       -> throwError err
     Right (_, Nothing)   -> throwError "no root node found"
-    Right (_, Just root) -> pure (sourceContents, File (Reference (Path.absRel sourcePath) span) root)
+    Right (_, Just root) -> pure (sourceContents, File (Reference sourcePath span) root)
   where
   decrSpan (Span (Pos sl sc) (Pos el ec)) = Span (Pos (sl - 1) (sc - 1)) (Pos (el - 1) (ec - 1))
 

--- a/semantic-ast/semantic-ast.cabal
+++ b/semantic-ast/semantic-ast.cabal
@@ -74,7 +74,7 @@ library
     , fused-effects        ^>= 1.1
     , Glob                 ^>= 0.10.0
     , pathtype             ^>= 0.8.1
-    , semantic-source      ^>= 0.1.0.1
+    , semantic-source      ^>= 0.2
     , tasty                ^>= 1.2.3
     , tasty-hunit          ^>= 0.10.0.2
     , template-haskell      >= 2.15 && < 2.19

--- a/semantic-ast/semantic-ast.cabal
+++ b/semantic-ast/semantic-ast.cabal
@@ -73,7 +73,6 @@ library
     , filepath             ^>= 1.4.1
     , fused-effects        ^>= 1.1
     , Glob                 ^>= 0.10.0
-    , pathtype             ^>= 0.8.1
     , semantic-source      ^>= 0.2
     , tasty                ^>= 1.2.3
     , tasty-hunit          ^>= 0.10.0.2

--- a/semantic-ast/src/System/Path/Fixture.hs
+++ b/semantic-ast/src/System/Path/Fixture.hs
@@ -21,7 +21,7 @@ import qualified Bazel.Runfiles as Bazel
 
 type HasFixture =
   ( ?runfiles :: Bazel.Runfiles,
-    ?project :: Path.RelDir,
+    ?project :: FilePath,
     HasCallStack
   )
 
@@ -29,13 +29,13 @@ create :: IO Bazel.Runfiles
 create = Bazel.create
 
 root :: HasFixture => FilePath
-root = Path.absRel (Bazel.rlocation ?runfiles ".")
+root = Bazel.rlocation ?runfiles "."
 
-absRelFile :: (HasFixture) => String -> FilePath
-absRelFile x = Path.toAbsRel (root </> Path.relDir "semantic" </> ?project </> Path.relFile x)
+absRelFile :: HasFixture => String -> FilePath
+absRelFile x = root </> "semantic" </> ?project </> x
 
 absRelDir :: HasFixture => String -> FilePath
-absRelDir x = Path.toAbsRel (root </> Path.relDir "semantic" </> ?project </> Path.relDir x)
+absRelDir x = root </> "semantic" </> ?project </> x
 
 #else
 

--- a/semantic-ast/src/System/Path/Fixture.hs
+++ b/semantic-ast/src/System/Path/Fixture.hs
@@ -13,9 +13,8 @@ where
 
 import Control.Concurrent
 import GHC.Stack
+import System.FilePath
 import System.IO
-import qualified System.Path as Path
-import System.Path ((</>))
 
 #if BAZEL_BUILD
 import qualified Bazel.Runfiles as Bazel
@@ -29,13 +28,13 @@ type HasFixture =
 create :: IO Bazel.Runfiles
 create = Bazel.create
 
-root :: HasFixture => Path.AbsRelDir
+root :: HasFixture => FilePath
 root = Path.absRel (Bazel.rlocation ?runfiles ".")
 
-absRelFile :: (HasFixture) => String -> Path.AbsRelFile
+absRelFile :: (HasFixture) => String -> FilePath
 absRelFile x = Path.toAbsRel (root </> Path.relDir "semantic" </> ?project </> Path.relFile x)
 
-absRelDir :: HasFixture => String -> Path.AbsRelDir
+absRelDir :: HasFixture => String -> FilePath
 absRelDir x = Path.toAbsRel (root </> Path.relDir "semantic" </> ?project </> Path.relDir x)
 
 #else
@@ -46,11 +45,11 @@ type HasFixture = HasCallStack
 create :: IO ()
 create = pure ()
 
-absRelFile :: String -> Path.AbsRelFile
-absRelFile x = Path.absRel "semantic" </> Path.relFile x
+absRelFile :: String -> FilePath
+absRelFile x = "semantic" </> x
 
-absRelDir :: String -> Path.AbsRelDir
-absRelDir x = Path.absRel "semantic" </> Path.relDir x
+absRelDir :: String -> FilePath
+absRelDir x = "semantic" </> x
 
 #endif
 

--- a/semantic-codeql/semantic-codeql.cabal
+++ b/semantic-codeql/semantic-codeql.cabal
@@ -71,7 +71,6 @@ test-suite test
   main-is:          PreciseTest.hs
   build-depends:
     , base
-    , pathtype ^>= 0.8.1
     , semantic-ast
     , semantic-codeql
     , tasty

--- a/semantic-codeql/semantic-codeql.cabal
+++ b/semantic-codeql/semantic-codeql.cabal
@@ -57,7 +57,7 @@ library
     , fused-effects ^>= 1.1
     , semantic-ast
     , semantic-proto ^>= 0
-    , semantic-source ^>= 0.1.0.1
+    , semantic-source ^>= 0.2
     , semantic-tags ^>= 0.0
     , template-haskell >= 2.15 && < 2.19
     , text ^>= 1.2.3

--- a/semantic-codeql/test/PreciseTest.hs
+++ b/semantic-codeql/test/PreciseTest.hs
@@ -1,4 +1,8 @@
-{-# LANGUAGE CPP, DisambiguateRecordFields, OverloadedStrings, TypeApplications, ImplicitParams #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 module Main (main) where
 
@@ -6,20 +10,19 @@ import           AST.TestHelpers
 import           AST.Unmarshal
 import qualified Language.CodeQL.AST as CodeQL
 import           Language.CodeQL.Grammar
-import qualified System.Path as Path
-import           Test.Tasty
 import qualified System.Path.Fixture as Fixture
+import           Test.Tasty
 
 main :: IO ()
 main = do
 #if BAZEL_BUILD
   rf <- Fixture.create
-  let ?project = Path.relDir "external/tree-sitter-ql"
+  let ?project = "external/tree-sitter-ql"
       ?runfiles = rf
 
   let dirs = Fixture.absRelDir "test/corpus"
 #else
-  dirs <- Path.absRel <$> CodeQL.getTestCorpusDir
+  dirs <- CodeQL.getTestCorpusDir
 #endif
   let parse = parseByteString @CodeQL.Ql @() tree_sitter_ql
 

--- a/semantic-go/semantic-go.cabal
+++ b/semantic-go/semantic-go.cabal
@@ -71,7 +71,6 @@ test-suite test
   main-is:          PreciseTest.hs
   build-depends:
     , base
-    , pathtype ^>= 0.8.1
     , semantic-ast
     , semantic-go
     , tasty

--- a/semantic-go/semantic-go.cabal
+++ b/semantic-go/semantic-go.cabal
@@ -57,7 +57,7 @@ library
     , fused-effects ^>= 1.1
     , semantic-ast
     , semantic-proto ^>= 0
-    , semantic-source ^>= 0.1.0.1
+    , semantic-source ^>= 0.2
     , semantic-tags ^>= 0.0
     , template-haskell  >= 2.15 && < 2.19
     , text ^>= 1.2.3

--- a/semantic-go/test/PreciseTest.hs
+++ b/semantic-go/test/PreciseTest.hs
@@ -1,25 +1,28 @@
-{-# LANGUAGE CPP, DisambiguateRecordFields, OverloadedStrings, TypeApplications, ImplicitParams #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 module Main (main) where
 
 
-import qualified Language.Go.AST as Go
-import           Language.Go.Grammar
 import           AST.TestHelpers
 import           AST.Unmarshal
-import qualified System.Path as Path
-import           Test.Tasty
+import qualified Language.Go.AST as Go
+import           Language.Go.Grammar
 import qualified System.Path.Fixture as Fixture
+import           Test.Tasty
 
 main :: IO ()
 main = do
 #if BAZEL_BUILD
   rf <- Fixture.create
-  let ?project = Path.relDir "external/tree-sitter-go"
+  let ?project = "external/tree-sitter-go"
       ?runfiles = rf
   let dirs = Fixture.absRelDir "corpus"
 #else
-  dirs <- Path.absRel <$> Go.getTestCorpusDir
+  dirs <- Go.getTestCorpusDir
 #endif
 
   readCorpusFiles' dirs

--- a/semantic-java/semantic-java.cabal
+++ b/semantic-java/semantic-java.cabal
@@ -57,7 +57,7 @@ library
     , fused-effects ^>= 1.1
     , semantic-ast
     , semantic-proto ^>= 0
-    , semantic-source ^>= 0.1.0.1
+    , semantic-source ^>= 0.2
     , semantic-tags ^>= 0.0
     , template-haskell  >= 2.15 && < 2.19
     , text ^>= 1.2.3

--- a/semantic-java/semantic-java.cabal
+++ b/semantic-java/semantic-java.cabal
@@ -71,7 +71,6 @@ test-suite test
   main-is:          PreciseTest.hs
   build-depends:
     , base
-    , pathtype ^>= 0.8.1
     , semantic-ast
     , semantic-java
     , tasty

--- a/semantic-java/test/PreciseTest.hs
+++ b/semantic-java/test/PreciseTest.hs
@@ -8,24 +8,23 @@ module Main
   )
 where
 
-import AST.TestHelpers
-import AST.Unmarshal
+import           AST.TestHelpers
+import           AST.Unmarshal
 import qualified Language.Java.AST as Java
-import qualified System.Path as Path
 import qualified System.Path.Fixture as Fixture
-import Test.Tasty
-import TreeSitter.Java
+import           Test.Tasty
+import           TreeSitter.Java
 
 main :: IO ()
 main = do
 #if BAZEL_BUILD
   rf <- Fixture.create
   --
-  let ?project = Path.relDir "external/tree-sitter-java"
+  let ?project = "external/tree-sitter-java"
       ?runfiles = rf
   let dirs = Fixture.absRelDir "corpus"
 #else
-  dirs <- Path.absRel <$> Java.getTestCorpusDir
+  dirs <- Java.getTestCorpusDir
 #endif
   readCorpusFiles' dirs
     >>= traverse (testCorpus parse)

--- a/semantic-json/semantic-json.cabal
+++ b/semantic-json/semantic-json.cabal
@@ -68,7 +68,6 @@ test-suite test
   main-is:          PreciseTest.hs
   build-depends:
     , base
-    , pathtype ^>= 0.8.1
     , semantic-ast
     , semantic-json
     , tasty

--- a/semantic-json/test/PreciseTest.hs
+++ b/semantic-json/test/PreciseTest.hs
@@ -8,18 +8,17 @@ import           AST.TestHelpers
 import           AST.Unmarshal
 import qualified Language.JSON.AST as JSON
 import           Language.JSON.Grammar
-import qualified System.Path as Path
 import           Test.Tasty
 
 main :: IO ()
 main = do
 #if BAZEL_BUILD
   rf <- Fixture.create
-  let ?project = Path.relDir "external/semantic-json"
+  let ?project = "external/semantic-json"
       ?runfiles = rf
   let dirs = Fixture.absRelDir "corpus"
 #else
-  dirs <- Path.absRel <$> JSON.getTestCorpusDir
+  dirs <- JSON.getTestCorpusDir
 #endif
   readCorpusFiles' dirs
     >>= traverse (testCorpus parse)

--- a/semantic-parse/semantic-parse.cabal
+++ b/semantic-parse/semantic-parse.cabal
@@ -56,6 +56,6 @@ executable semantic-parse
     , pretty-simple
     , semantic-ast
     , semantic-python
-    , semantic-source ^>= 0.1.0.1
+    , semantic-source ^>= 0.2
   hs-source-dirs:      app
   default-language:    Haskell2010

--- a/semantic-php/semantic-php.cabal
+++ b/semantic-php/semantic-php.cabal
@@ -55,7 +55,7 @@ library
     , fused-effects ^>= 1.1
     , semantic-ast
     , semantic-proto ^>= 0
-    , semantic-source ^>= 0.1.0.1
+    , semantic-source ^>= 0.2
     , semantic-tags ^>= 0.0
     , template-haskell  >= 2.15 && < 2.19
     , text ^>= 1.2.3

--- a/semantic-python/semantic-python.cabal
+++ b/semantic-python/semantic-python.cabal
@@ -63,7 +63,7 @@ library
     , semantic-analysis ^>= 0
     , semantic-ast
     , semantic-proto ^>= 0
-    , semantic-source ^>= 0.1.0.1
+    , semantic-source ^>= 0.2
     , semantic-tags ^>= 0.0
     , template-haskell  >= 2.15 && < 2.19
     , text ^>= 1.2.3

--- a/semantic-python/semantic-python.cabal
+++ b/semantic-python/semantic-python.cabal
@@ -84,7 +84,6 @@ library
   --              , containers ^>= 0.6
   --              , directory ^>= 1.3.3
   --              , exceptions ^>= 0.10.2
-  --              , pathtype ^>= 0.8.1
   --              , pretty-show ^>= 1.9.5
   --              , process ^>= 1.6.5
   --              , resourcet ^>= 1.2.2
@@ -112,7 +111,6 @@ library
   --              , semantic-python
   --             --  , semantic-scope-graph
   --              , bytestring
-  --              , pathtype
   --              , tasty
   --              , tasty-hunit
 
@@ -124,7 +122,6 @@ test-suite test
   main-is:          PreciseTest.hs
   build-depends:
     , base
-    , pathtype ^>= 0.8.1
     , semantic-ast
     , semantic-python
     , tasty

--- a/semantic-python/test/PreciseTest.hs
+++ b/semantic-python/test/PreciseTest.hs
@@ -1,24 +1,27 @@
-{-# LANGUAGE CPP, DisambiguateRecordFields, OverloadedStrings, TypeApplications, ImplicitParams #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 module Main (main) where
 
-import qualified System.Path as Path
-import           Test.Tasty
-import           TreeSitter.Python
-import qualified Language.Python.AST as Py
 import           AST.TestHelpers
 import           AST.Unmarshal
+import qualified Language.Python.AST as Py
 import qualified System.Path.Fixture as Fixture
+import           Test.Tasty
+import           TreeSitter.Python
 
 main :: IO ()
 main = do
 #if BAZEL_BUILD
   rf <- Fixture.create
-  let ?project = Path.relDir "external/tree-sitter-python"
+  let ?project = "external/tree-sitter-python"
       ?runfiles = rf
   let dirs = Fixture.absRelDir "test/corpus"
 #else
-  dirs <- Path.absRel <$> Py.getTestCorpusDir
+  dirs <- Py.getTestCorpusDir
 #endif
 
   let parse = parseByteString @Py.Module @() tree_sitter_python

--- a/semantic-ruby/bench/Parsing.hs
+++ b/semantic-ruby/bench/Parsing.hs
@@ -1,31 +1,29 @@
-{-# LANGUAGE TypeApplications         #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Parsing (benchmarks) where
 
+import           AST.Unmarshal
 import           Control.Monad
 import qualified Data.ByteString as B
 import           Data.Foldable
 import           Gauge
-import           System.Exit (die)
-import           System.FilePath.Glob
-import qualified System.Path as Path
 import           Language.Ruby
 import qualified Language.Ruby.AST as Rb
-import           AST.Unmarshal
+import           System.Exit (die)
+import           System.FilePath.Glob
 
 benchmarks :: Benchmark
 benchmarks = bgroup "parsing" [ rubyBenchmarks ]
 
 rubyBenchmarks :: Benchmark
 rubyBenchmarks = bench "ruby" $ parseAllFiles dir "*.rb"
-  where dir = Path.relDir "../semantic/tmp/ruby-examples/ruby_spec/command_line"
+  where dir = "../semantic/tmp/ruby-examples/ruby_spec/command_line"
 
-parseAllFiles :: Path.RelDir -> String -> Benchmarkable
+parseAllFiles :: FilePath -> String -> Benchmarkable
 parseAllFiles dir glob = nfIO $ do
-  files <- globDir1 (compile glob) (Path.toString dir)
-  let paths = Path.relFile <$> files
-  when (null paths) (die $ "No files found in " <> (Path.toString dir))
+  paths <- globDir1 (compile glob) dir
+  when (null paths) (die $ "No files found in " <> dir)
   for_ paths $ \ file -> do
     -- print (Path.toString file)
-    contents <- B.readFile (Path.toString file)
+    contents <- B.readFile file
     either die pure =<< parseByteString @Rb.Program @() tree_sitter_ruby contents

--- a/semantic-ruby/semantic-ruby.cabal
+++ b/semantic-ruby/semantic-ruby.cabal
@@ -57,7 +57,7 @@ library
     , fused-effects ^>= 1.1
     , semantic-ast
     , semantic-proto ^>= 0
-    , semantic-source ^>= 0.1.0.1
+    , semantic-source ^>= 0.2
     , semantic-tags ^>= 0.0
     , template-haskell  >= 2.15 && < 2.19
     , text ^>= 1.2.3

--- a/semantic-ruby/semantic-ruby.cabal
+++ b/semantic-ruby/semantic-ruby.cabal
@@ -71,7 +71,6 @@ test-suite test
   main-is:          PreciseTest.hs
   build-depends:
     , base
-    , pathtype ^>= 0.8.1
     , semantic-ast
     , semantic-ruby
     , tasty
@@ -89,7 +88,6 @@ executable benchmarks
     , bytestring
     , gauge ^>= 0.2.5
     , Glob
-    , pathtype ^>= 0.8.1
     , semantic-ast
     , semantic-ruby
 

--- a/semantic-ruby/test/PreciseTest.hs
+++ b/semantic-ruby/test/PreciseTest.hs
@@ -1,26 +1,29 @@
-{-# LANGUAGE CPP, DisambiguateRecordFields, OverloadedStrings, TypeApplications, ImplicitParams #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 module Main (main) where
 
-import           TreeSitter.Ruby
 import           AST.TestHelpers
 import           AST.Unmarshal
+import           Control.Concurrent
 import qualified Language.Ruby.AST as Ruby
-import qualified System.Path as Path
-import           Test.Tasty
+import           System.IO
 import qualified System.Path.Fixture as Fixture
-import System.IO
-import Control.Concurrent
+import           Test.Tasty
+import           TreeSitter.Ruby
 
 main :: IO ()
 main = do
 #if BAZEL_BUILD
   rf <- Fixture.create
-  let ?project = Path.relDir "external/tree-sitter-ruby"
+  let ?project = "external/tree-sitter-ruby"
       ?runfiles = rf
   let dirs = Fixture.absRelDir "test/corpus"
 #else
-  dirs <- Path.absRel <$> Ruby.getTestCorpusDir
+  dirs <- Ruby.getTestCorpusDir
 #endif
   readCorpusFiles' dirs
     >>= traverse (testCorpus parse)

--- a/semantic-rust/semantic-rust.cabal
+++ b/semantic-rust/semantic-rust.cabal
@@ -70,6 +70,7 @@ test-suite test
   main-is:          Test.hs
   build-depends:
     , base
+    , filepath
     , semantic-ast
     , semantic-rust
     , tasty

--- a/semantic-rust/semantic-rust.cabal
+++ b/semantic-rust/semantic-rust.cabal
@@ -56,7 +56,7 @@ library
     , base  >= 4.13 && < 5
     , fused-effects ^>= 1.1
     , semantic-ast
-    , semantic-source ^>= 0.1.0.1
+    , semantic-source ^>= 0.2
     , semantic-tags ^>= 0.0
     , template-haskell  >= 2.15 && < 2.19
     , text ^>= 1.2.3

--- a/semantic-rust/semantic-rust.cabal
+++ b/semantic-rust/semantic-rust.cabal
@@ -70,7 +70,6 @@ test-suite test
   main-is:          Test.hs
   build-depends:
     , base
-    , pathtype ^>= 0.8.1
     , semantic-ast
     , semantic-rust
     , tasty

--- a/semantic-rust/test/Test.hs
+++ b/semantic-rust/test/Test.hs
@@ -6,21 +6,21 @@ module Main (main) where
 
 import           AST.TestHelpers
 import           AST.Unmarshal (parseByteString)
-import           Language.Rust.Grammar
+import           Control.Monad (liftM)
 import qualified Language.Rust.AST as Rust
-import qualified System.Path as Path
+import           Language.Rust.Grammar
+import           System.FilePath
 import           Test.Tasty
-import Control.Monad (liftM)
 
 main :: IO ()
 main = do
 #if BAZEL_BUILD
   rf <- Fixture.create
-  let ?project = Path.relDir "external/tree-sitter-python"
+  let ?project = "external/tree-sitter-python"
       ?runfiles = rf
   let dirs = Fixture.absRelDir "test/corpus"
 #else
-  dirs <- Path.absRel <$> Rust.getTestCorpusDir
+  dirs <- Rust.getTestCorpusDir
 #endif
 
 
@@ -30,7 +30,7 @@ main = do
   where
     parse = parseByteString @Rust.SourceFile @() tree_sitter_rust
     excludeMacrosCorpus l = liftM (filter (f "expressions") ) l
-      where f p bn = p /= (Path.toString . Path.takeBaseName) bn
+      where f p bn = p /= takeBaseName bn
 
 tests :: [TestTree] -> TestTree
 tests = testGroup "tree-sitter-rust corpus tests"

--- a/semantic-scope-graph/semantic-scope-graph.cabal
+++ b/semantic-scope-graph/semantic-scope-graph.cabal
@@ -43,7 +43,6 @@ library
     , generic-lens
     , hashable
     , lens
-    , pathtype
     , semantic-analysis
     , semantic-source    ^>= 0.2
     , semilattices

--- a/semantic-scope-graph/semantic-scope-graph.cabal
+++ b/semantic-scope-graph/semantic-scope-graph.cabal
@@ -45,7 +45,7 @@ library
     , lens
     , pathtype
     , semantic-analysis
-    , semantic-source    ^>= 0.1.0.1
+    , semantic-source    ^>= 0.2
     , semilattices
     , text               ^>= 1.2.3.1
   hs-source-dirs:      src

--- a/semantic-scope-graph/src/Data/Module.hs
+++ b/semantic-scope-graph/src/Data/Module.hs
@@ -14,7 +14,6 @@ import Data.Maybe
 import Data.Semilattice.Lower
 import Data.Text (Text)
 import GHC.Stack
-import qualified System.Path as Path
 
 data Module body = Module { moduleInfo :: ModuleInfo, moduleBody :: body }
   deriving (Eq, Foldable, Functor, Ord, Traversable)
@@ -23,20 +22,20 @@ instance Show body => Show (Module body) where
   showsPrec d Module{..} = showsBinaryWith showsPrec showsPrec "Module" d (modulePath moduleInfo) moduleBody
 
 
-type ModulePath = Path.AbsRelFile
+type ModulePath = FilePath
 
 data ModuleInfo = ModuleInfo { modulePath :: ModulePath, moduleLanguage :: Text, moduleOid :: Text }
   deriving (Eq, Ord)
 
 instance Lower ModuleInfo where
-  lowerBound = ModuleInfo (Path.toAbsRel Path.emptyFile) "Unknown" mempty
+  lowerBound = ModuleInfo "" "Unknown" mempty
 
 instance Show ModuleInfo where
   showsPrec d = showsUnaryWith showsPrec "ModuleInfo" d . modulePath
 
 moduleInfoFromSrcLoc :: SrcLoc -> ModuleInfo
-moduleInfoFromSrcLoc loc = ModuleInfo (Path.absRel $ srcLocModule loc) "Unknown" mempty
+moduleInfoFromSrcLoc loc = ModuleInfo (srcLocModule loc) "Unknown" mempty
 
 -- | Produce 'ModuleInfo' from the top location on the Haskell call stack (i.e. the file where the call to 'moduleInfoFromCallStack' was made).
 moduleInfoFromCallStack :: HasCallStack => ModuleInfo
-moduleInfoFromCallStack = maybe (ModuleInfo (Path.absRel "?") "Unknown" mempty) (moduleInfoFromSrcLoc . snd) (listToMaybe (getCallStack callStack))
+moduleInfoFromCallStack = maybe (ModuleInfo "?" "Unknown" mempty) (moduleInfoFromSrcLoc . snd) (listToMaybe (getCallStack callStack))

--- a/semantic-tags/semantic-tags.cabal
+++ b/semantic-tags/semantic-tags.cabal
@@ -54,7 +54,7 @@ library
     , containers         ^>= 0.6.0.1
     , fused-effects      ^>= 1.1
     , semantic-proto     ^>= 0
-    , semantic-source    ^>= 0.1.0.1
+    , semantic-source    ^>= 0.2
     , text               ^>= 1.2.3.1
   hs-source-dirs:      src
 
@@ -65,7 +65,7 @@ test-suite test
   main-is: Test.hs
   build-depends:
     , base             >= 4.13 && < 5
-    , semantic-source ^>= 0.1.0.1
+    , semantic-source ^>= 0.2
     , semantic-tags
     , tasty            >= 1.2 && <2
     , tasty-hunit      >= 0.10 && <1

--- a/semantic-tsx/semantic-tsx.cabal
+++ b/semantic-tsx/semantic-tsx.cabal
@@ -71,7 +71,6 @@ test-suite test
   main-is:          PreciseTest.hs
   build-depends:
     , base
-    , pathtype ^>= 0.8.1
     , semantic-ast
     , semantic-tsx
     , tasty

--- a/semantic-tsx/semantic-tsx.cabal
+++ b/semantic-tsx/semantic-tsx.cabal
@@ -57,7 +57,7 @@ library
     , fused-effects ^>= 1.1
     , semantic-ast
     , semantic-proto ^>= 0
-    , semantic-source ^>= 0.1.0.1
+    , semantic-source ^>= 0.2
     , semantic-tags ^>= 0.0
     , template-haskell  >= 2.15 && < 2.19
     , text ^>= 1.2.3

--- a/semantic-tsx/test/PreciseTest.hs
+++ b/semantic-tsx/test/PreciseTest.hs
@@ -1,25 +1,28 @@
-{-# LANGUAGE CPP, DisambiguateRecordFields, OverloadedStrings, TypeApplications, ImplicitParams #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 module Main (main) where
 
 
-import           TreeSitter.TSX
 import           AST.TestHelpers
 import           AST.Unmarshal
 import qualified Language.TSX.AST as Tsx
-import qualified System.Path as Path
-import           Test.Tasty
 import qualified System.Path.Fixture as Fixture
+import           Test.Tasty
+import           TreeSitter.TSX
 
 main :: IO ()
 main = do
 #if BAZEL_BUILD
   rf <- Fixture.create
-  let ?project = Path.relDir "external/semantic-typescript"
+  let ?project = "external/semantic-typescript"
       ?runfiles = rf
   let dirs = Fixture.absRelDir "tsx/corpus"
 #else
-  dirs <- Path.absRel <$> Tsx.getTestCorpusDir
+  dirs <- Tsx.getTestCorpusDir
 #endif
 
   readCorpusFiles' dirs

--- a/semantic-typescript/semantic-typescript.cabal
+++ b/semantic-typescript/semantic-typescript.cabal
@@ -71,7 +71,6 @@ test-suite test
   main-is:          PreciseTest.hs
   build-depends:
     , base
-    , pathtype ^>= 0.8.1
     , semantic-ast
     , semantic-typescript
     , tasty

--- a/semantic-typescript/semantic-typescript.cabal
+++ b/semantic-typescript/semantic-typescript.cabal
@@ -57,7 +57,7 @@ library
     , fused-effects ^>= 1.1
     , semantic-ast
     , semantic-proto ^>= 0
-    , semantic-source ^>= 0.1.0.1
+    , semantic-source ^>= 0.2
     , semantic-tags ^>= 0.0
     , template-haskell  >= 2.15 && < 2.19
     , text ^>= 1.2.3

--- a/semantic-typescript/test/PreciseTest.hs
+++ b/semantic-typescript/test/PreciseTest.hs
@@ -1,24 +1,27 @@
-{-# LANGUAGE CPP, DisambiguateRecordFields, OverloadedStrings, TypeApplications, ImplicitParams #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 module Main (main) where
 
-import           TreeSitter.TypeScript
 import           AST.TestHelpers
 import           AST.Unmarshal
 import qualified Language.TypeScript.AST as Ts
-import qualified System.Path as Path
-import           Test.Tasty
 import qualified System.Path.Fixture as Fixture
+import           Test.Tasty
+import           TreeSitter.TypeScript
 
 main :: IO ()
 main = do
 #if BAZEL_BUILD
   rf <- Fixture.create
-  let ?project = Path.relDir "external/tree-sitter-typescript"
+  let ?project = "external/tree-sitter-typescript"
       ?runfiles = rf
   let dirs = Fixture.absRelDir "typescript/corpus"
 #else
-  dirs <- Path.absRel <$> Ts.getTestCorpusDir
+  dirs <- Ts.getTestCorpusDir
 #endif
 
   readCorpusFiles' dirs

--- a/semantic/semantic.cabal
+++ b/semantic/semantic.cabal
@@ -136,7 +136,7 @@ library
     , semantic-python ^>= 0
     , semantic-ruby ^>= 0
     , semantic-scope-graph ^>= 0
-    , semantic-source ^>= 0.1.0.1
+    , semantic-source ^>= 0.2
     , semantic-tags ^>= 0
     , semantic-tsx ^>= 0
     , semantic-typescript ^>= 0
@@ -188,7 +188,7 @@ test-suite test
     , semantic-analysis
     , semantic-ast
     , semantic-proto
-    , semantic-source ^>= 0.1.0.1
+    , semantic-source ^>= 0.2
     , semantic-tags
     , semilattices
     , tasty ^>= 1.2.3

--- a/semantic/semantic.cabal
+++ b/semantic/semantic.cabal
@@ -176,6 +176,8 @@ test-suite test
     , algebraic-graphs >= 0.3 && < 0.7
     , base >= 4.13 && < 5
     , bytestring >= 0.10.8.2 && < 0.13
+    , directory
+    , filepath
     , fused-effects
     , Glob ^>= 0.10.0
     , hedgehog >= 1 && < 1.2
@@ -203,6 +205,7 @@ test-suite parse-examples
   build-depends:
     , async ^>= 2.2.1
     , base
+    , filepath
     , fused-effects ^>= 1.1
     , Glob
     , lens >= 4.17 && < 5.2

--- a/semantic/semantic.cabal
+++ b/semantic/semantic.cabal
@@ -122,7 +122,6 @@ library
     , network >= 2.8 && < 3.2
     , network-uri ^>= 2.6.1.0
     , optparse-applicative >= 0.14.3 && < 0.16
-    , pathtype ^>= 0.8.1
     , pretty-show ^>= 1.9.5
     , proto-lens >= 0.5 && < 0.8
     , semantic-analysis ^>= 0
@@ -183,7 +182,6 @@ test-suite test
     , hspec >= 2.6 && <3
     , hspec-expectations ^>= 0.8.2
     , network >= 2.8 && < 3.2
-    , pathtype ^>= 0.8.1
     , semantic
     , semantic-analysis
     , semantic-ast
@@ -208,7 +206,6 @@ test-suite parse-examples
     , fused-effects ^>= 1.1
     , Glob
     , lens >= 4.17 && < 5.2
-    , pathtype ^>= 0.8.1
     , process ^>= 1.6.3.0
     , semantic
     , semantic-analysis ^>= 0
@@ -230,7 +227,6 @@ benchmark benchmarks
     , fused-effects ^>= 1.1
     , gauge ^>= 0.2.5
     , Glob
-    , pathtype ^>= 0.8.1
     , semantic
     , semantic-analysis ^>= 0
     , semantic-proto

--- a/semantic/src/Data/Blob/IO.hs
+++ b/semantic/src/Data/Blob/IO.hs
@@ -21,25 +21,16 @@ import           Semantic.IO
 import           Source.Language
 import qualified Source.Source as Source
 import           Source.Span
-import qualified System.Path as Path
 
 -- | Deprecated: this has very weird semantics.
 readProjectFromPaths :: MonadIO m
-                     => Maybe Path.AbsRelDir -- ^ An optional root directory for the project
-                     -> Path.AbsRelFileDir   -- ^ A file or directory to parse. Passing a file path loads all files in that file's parent directory.
+                     => Maybe FilePath -- ^ An optional root directory for the project
+                     -> FilePath       -- ^ A file or directory to parse. Passing a file path loads all files in that file's parent directory.
                      -> Language
-                     -> [Path.AbsRelDir]     -- ^ Directories to exclude.
+                     -> [FilePath]     -- ^ Directories to exclude.
                      -> m Project
 readProjectFromPaths maybeRoot path lang excludeDirs = do
-  let rootDir :: Path.AbsRelDir
-      rootDir = case maybeRoot >>= Path.fromAbsRel of
-        -- If we were provided a root directory, use that.
-        Just root -> root
-        Nothing   -> case Path.fileFromFileDir path of
-          -- If we weren't and the path is a file, drop its file name.
-          Just fp -> Path.takeDirectory fp
-          -- Otherwise, load from the path.
-          Nothing -> Path.dirFromFileDir path
+  let rootDir = fromMaybe path maybeRoot
 
   paths <- liftIO $ findFilesInDir rootDir exts excludeDirs
   blobs <- liftIO $ traverse (readBlobFromFile' . toFile) paths
@@ -51,9 +42,9 @@ readProjectFromPaths maybeRoot path lang excludeDirs = do
 
 -- | Read a utf8-encoded file to a 'Blob'.
 readBlobFromFile :: MonadIO m => File Language -> m (Maybe Blob)
-readBlobFromFile (File (Reference (Path.toString -> "/dev/null") _) _) = pure Nothing
+readBlobFromFile (File (Reference "/dev/null" _) _) = pure Nothing
 readBlobFromFile file@(File (Reference path _) _language) = do
-  raw <- liftIO $ B.readFile (Path.toString path)
+  raw <- liftIO $ B.readFile path
   let newblob = Blob (Source.fromUTF8 raw) file
   pure . Just $ newblob
 
@@ -64,7 +55,7 @@ readBlobFromFile' file = do
   maybeM (fail ("cannot read '" <> show file <> "', file not found or language not supported.")) maybeFile
 
 -- | Read a blob from the provided absolute or relative path , failing if it can't be found.
-readBlobFromPath :: (MonadFail m, MonadIO m) => Path.AbsRelFile -> m Blob
+readBlobFromPath :: (MonadFail m, MonadIO m) => FilePath -> m Blob
 readBlobFromPath = readBlobFromFile' . File.fromPath
 
 readFilePair :: MonadIO m => File Language -> File Language -> m BlobPair

--- a/semantic/src/Data/Handle.hs
+++ b/semantic/src/Data/Handle.hs
@@ -20,11 +20,10 @@ module Data.Handle
 import           Control.Exception (Exception, throw)
 import           Control.Monad.IO.Class
 import           Data.Aeson
+import           Data.Blob
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Lazy.Char8 as BLC
 import qualified System.IO as IO
-import qualified System.Path as Path
-import Data.Blob
 
 data Handle mode where
   ReadHandle  :: IO.Handle -> Handle 'IO.ReadMode
@@ -46,8 +45,8 @@ stdout = WriteHandle IO.stdout
 stderr :: Handle 'IO.WriteMode
 stderr = WriteHandle IO.stderr
 
-openFileForReading :: Path.AbsRelFile -> IO (Handle 'IO.ReadMode)
-openFileForReading path = ReadHandle <$> IO.openFile (Path.toString path) IO.ReadMode
+openFileForReading :: FilePath -> IO (Handle 'IO.ReadMode)
+openFileForReading path = ReadHandle <$> IO.openFile path IO.ReadMode
 
 -- | Read JSON encoded blobs from a handle.
 readBlobsFromHandle :: MonadIO m => Handle 'IO.ReadMode -> m [Blob]

--- a/semantic/src/Semantic/Api/Bridge.hs
+++ b/semantic/src/Semantic/Api/Bridge.hs
@@ -12,7 +12,6 @@ import           Analysis.File
 import           Analysis.Reference
 import           Control.Lens
 import qualified Data.Blob as Data
-import           Data.Either
 import           Data.ProtoLens (defMessage)
 import qualified Data.Text as T
 import           Data.Text.Lens
@@ -22,7 +21,6 @@ import qualified Source.Language as Data
 import qualified Source.Range as Source
 import qualified Source.Source as Source (fromText, toText, totalSpan)
 import qualified Source.Span as Source
-import qualified System.Path as Path
 
 -- | An @APIBridge x y@ instance describes an isomorphism between @x@ and @y@.
 -- This is suitable for types such as 'Pos' which are representationally equivalent
@@ -80,7 +78,7 @@ instance APIBridge API.Blob Data.Blob where
       & P.language .~ (bridging # Data.blobLanguage b)
     apiBlobToBlob blob =
       let src = blob ^. content.to Source.fromText
-          pth = fromRight (Path.toAbsRel Path.emptyFile) (blob ^. path._Text.to Path.parse)
+          pth = blob ^. path._Text
       in Data.Blob
       { blobSource = src
       , blobFile = File (Reference pth (Source.totalSpan src)) (blob ^. language.bridging)

--- a/semantic/src/Semantic/CLI.hs
+++ b/semantic/src/Semantic/CLI.hs
@@ -20,8 +20,6 @@ import           Semantic.Version
 import           Serializing.Format
 import qualified Source.Language as Language
 import           System.Exit (die)
-import qualified System.Path as Path
-import qualified System.Path.PartClass as Path.PartClass
 
 import Control.Concurrent (mkWeakThreadId, myThreadId)
 import Proto.Semantic_JSON ()
@@ -112,10 +110,10 @@ parseCommand = command "parse" (info parseArgumentsParser (progDesc "Generate pa
 filePathReader :: ReadM (File.File Language.Language)
 filePathReader = File.fromPath <$> path
 
-path :: (Path.PartClass.FileDir fd) => ReadM (Path.AbsRel fd)
-path = eitherReader Path.parse
+path :: ReadM FilePath
+path = eitherReader Right
 
-pathOption :: Path.PartClass.FileDir fd => Mod OptionFields (Path.AbsRel fd) -> Parser (Path.AbsRel fd)
+pathOption :: Mod OptionFields FilePath -> Parser FilePath
 pathOption = option path
 
 options :: Eq a => [(String, a)] -> Mod OptionFields a -> Parser a

--- a/semantic/src/Semantic/IO.hs
+++ b/semantic/src/Semantic/IO.hs
@@ -13,22 +13,20 @@ import           Control.Monad.IO.Class
 import           System.Directory.Tree (AnchoredDirTree (..))
 import qualified System.Directory.Tree as Tree
 import           System.FilePath
-import qualified System.Path as Path
-import qualified System.Path.PartClass as Path.PartClass
 
 pathIsMinified :: FilePath -> Bool
 pathIsMinified = isExtensionOf ".min.js"
 
 -- Recursively find files in a directory.
-findFilesInDir :: (Path.PartClass.AbsRel ar, MonadIO m) => Path.Dir ar -> [String] -> [Path.Dir ar] -> m [Path.File ar]
+findFilesInDir :: MonadIO m => FilePath -> [String] -> [FilePath] -> m [FilePath]
 findFilesInDir path exts excludeDirs = do
-  _:/dir <- liftIO $ Tree.build (Path.toString path)
+  _:/dir <- liftIO $ Tree.build path
   pure $ (onlyFiles . Tree.filterDir (withExtensions exts) . Tree.filterDir (notIn excludeDirs)) dir
   where
     -- Build a list of only FilePath's (remove directories and failures)
     onlyFiles (Tree.Dir _ fs)   = concatMap onlyFiles fs
     onlyFiles (Tree.Failed _ _) = []
-    onlyFiles (Tree.File _ f)   = [Path.file f]
+    onlyFiles (Tree.File _ f)   = [f]
 
     -- Predicate for Files with one of the extensions in 'exts'.
     withExtensions exts (Tree.File n _)
@@ -40,6 +38,6 @@ findFilesInDir path exts excludeDirs = do
     -- Predicate for contents NOT in a directory
     notIn dirs (Tree.Dir n _)
       | (x:_) <- n, x == '.' = False -- Don't include directories that start with '.'.
-      | Path.dir n `elem` dirs = False
+      | n `elem` dirs = False
       | otherwise = True
     notIn _ _ = True

--- a/semantic/src/Semantic/Util.hs
+++ b/semantic/src/Semantic/Util.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-missing-signatures -Wno-missing-exported-signatures -Wno-partial-type-signatures -O0 #-}
 module Semantic.Util
   ( parseFile
@@ -25,14 +24,13 @@ import           Semantic.Task
 import qualified Source.Language as Language
 import           Source.Span (Pos (..), point)
 import           System.Exit (die)
-import qualified System.Path as Path
 
 parseFile, parseFileQuiet :: Parser term -> FilePath -> IO term
 parseFile      parser = runTask'     . (parse parser <=< readBlob . fileForPath)
 parseFileQuiet parser = runTaskQuiet . (parse parser <=< readBlob . fileForPath)
 
 fileForPath :: FilePath -> File Language.Language
-fileForPath (Path.absRel -> p) = File (Reference p (point (Pos 1 1))) (Language.forPath p)
+fileForPath p = File (Reference p (point (Pos 1 1))) (Language.forPath p)
 
 runTask', runTaskQuiet :: ParseC TaskC a -> IO a
 runTask'     task = runTaskWithOptions debugOptions   (asks configTreeSitterParseTimeout >>= \ timeout -> runParse timeout task) >>= either (die . displayException) pure

--- a/semantic/test/Data/Language/Spec.hs
+++ b/semantic/test/Data/Language/Spec.hs
@@ -1,14 +1,13 @@
 module Data.Language.Spec (testTree) where
 
-import           Source.Language as Language
-import qualified System.Path as Path
-import           Test.Tasty
-import           Test.Tasty.HUnit
+import Source.Language as Language
+import Test.Tasty
+import Test.Tasty.HUnit
 
 testTree :: TestTree
 testTree = testGroup "Data.Language"
   [ testCase "languageForFilePath works for languages with ambiguous lingo extensions" $ do
-      Language.forPath (Path.relFile "foo.php") @=? PHP
-      Language.forPath (Path.relFile "foo.md" ) @=? Markdown
-      Language.forPath (Path.relFile "foo.tsx") @=? TSX
+      Language.forPath "foo.php" @=? PHP
+      Language.forPath "foo.md"  @=? Markdown
+      Language.forPath "foo.tsx" @=? TSX
   ]

--- a/semantic/test/Examples.hs
+++ b/semantic/test/Examples.hs
@@ -17,37 +17,34 @@ import           Control.Exception (displayException)
 import           Control.Lens
 import           Control.Monad
 import           Data.Blob
+import           Data.Flag
 import           Data.Foldable
 import           Data.Int
 import qualified Data.Text as Text
 import           Data.Traversable
+import           Proto.Semantic as P hiding (Blob)
+import           Proto.Semantic_Fields as P
+import           Semantic.Api.Symbols (parseSymbols)
+import           Semantic.Config as Config
+import           Semantic.Task
+import           Semantic.Task.Files
+import           System.FilePath
 import           System.FilePath.Glob
-import           System.Path ((</>))
-import qualified System.Path as Path
-import qualified System.Path.Directory as Path
-import qualified System.Process as Process
 import qualified System.Path.Fixture as Fixture
+import qualified System.Process as Process
 import qualified Test.Tasty as Tasty
 import qualified Test.Tasty.HUnit as HUnit
-
-import Data.Flag
-import Proto.Semantic as P hiding (Blob)
-import Proto.Semantic_Fields as P
-import Semantic.Api.Symbols (parseSymbols)
-import Semantic.Config as Config
-import Semantic.Task
-import Semantic.Task.Files
 
 data LanguageExample =
   LanguageExample
     { languageName      :: String
     , languageExtension :: String
-    , languageSkips     :: [Path.RelFile]
-    , languageDirSkips  :: [Path.RelDir]
+    , languageSkips     :: [FilePath]
+    , languageDirSkips  :: [FilePath]
     }
   deriving (Eq, Show)
 
-le :: String -> String -> [Path.RelFile] -> [Path.RelDir] -> LanguageExample
+le :: String -> String -> [FilePath] -> [FilePath] -> LanguageExample
 le = LanguageExample
 
 examples :: [LanguageExample]
@@ -59,8 +56,8 @@ examples =
   -- , le "typescript" "**/*.[jt]sx" tsxSkips mempty
   ]
 
-goFileSkips :: [Path.RelFile]
-goFileSkips = Path.relPath <$>
+goFileSkips :: [FilePath]
+goFileSkips =
   [
   -- Super slow
     "go/src/vendor/golang_org/x/text/unicode/norm/tables.go"
@@ -83,8 +80,8 @@ goFileSkips = Path.relPath <$>
 
   ]
 
-goDirSkips :: [Path.RelDir]
-goDirSkips = Path.relDir <$>
+goDirSkips :: [FilePath]
+goDirSkips =
   [ "go/src/cmd/compile/internal/ssa"
   , "go/test/fixedbugs"
   , "go/test/syntax"
@@ -92,11 +89,11 @@ goDirSkips = Path.relDir <$>
   , "go/test"
   ]
 
-pythonFileSkips :: [Path.RelFile]
+pythonFileSkips :: [FilePath]
 pythonFileSkips = []
 
-rubySkips :: [Path.RelFile]
-rubySkips = Path.relFile <$>
+rubySkips :: [FilePath]
+rubySkips =
   [
   -- Doesn't parse b/c of issue with r<<i
     "ruby_spec/core/enumerable/shared/inject.rb"
@@ -117,33 +114,31 @@ rubySkips = Path.relFile <$>
   , "ruby_spec/language/lambda_spec.rb"
   ]
 
-tsxSkips :: [Path.RelFile]
-tsxSkips = Path.relFile <$>
+tsxSkips :: [FilePath]
+tsxSkips =
   [
   ]
 
-typescriptSkips :: [Path.RelFile]
-typescriptSkips = Path.relFile <$>
+typescriptSkips :: [FilePath]
+typescriptSkips =
   [ "npm/node_modules/slide/lib/async-map-ordered.js"
   , "npm/node_modules/request/node_modules/har-validator/node_modules/ajv/dist/regenerator.min.js"
   ]
 
 
 
-buildExamples :: Fixture.HasFixture => TaskSession -> LanguageExample -> Path.AbsRelDir -> IO Tasty.TestTree
+buildExamples :: Fixture.HasFixture => TaskSession -> LanguageExample -> FilePath -> IO Tasty.TestTree
 buildExamples session lang tsDir = do
   let fileSkips = fmap (tsDir </>) (languageSkips lang)
       dirSkips  = fmap (tsDir </>) (languageDirSkips lang)
 
-
-
-  files <- globDir1 (compile (languageExtension lang)) (Path.toString tsDir)
+  files <- globDir1 (compile (languageExtension lang)) tsDir
   when (null files)
-    (fail ("Nothing in dir " <> Path.toString tsDir))
+    (fail ("Nothing in dir " <> tsDir))
 
-  let paths = filter (\x -> Path.takeDirectory x `notElem` dirSkips) . filter (`notElem` fileSkips) $ Path.absRel <$> files
+  let paths = filter (\x -> takeDirectory x `notElem` dirSkips) . filter (`notElem` fileSkips) $ files
   trees <- for paths $ \file -> do
-    pure . HUnit.testCase (Path.toString file) $ do
+    pure . HUnit.testCase file $ do
       precise <- runTask session (runParse (parseSymbolsFilePath file))
       assertOK "precise" precise
   pure (Tasty.testGroup (languageName lang) trees)
@@ -172,7 +167,7 @@ main = withOptions testOptions $ \ config logger statter -> do
 #if BAZEL_BUILD
   rf <- Fixture.create
   let ?runfiles = rf
-  let ?project = Path.relDir "semantic"
+  let ?project = FilePath "semantic"
 #endif
 
   let session = TaskSession config "-" False logger statter
@@ -188,6 +183,6 @@ parseSymbolsFilePath ::
   , Has Parse sig m
   , Has Files sig m
   )
-  => Path.AbsRelFile
+  => FilePath
   -> m ParseTreeSymbolResponse
 parseSymbolsFilePath path = readBlob (File.fromPath path) >>= parseSymbols . pure @[]

--- a/semantic/test/Integration/Spec.hs
+++ b/semantic/test/Integration/Spec.hs
@@ -1,42 +1,40 @@
-{-# LANGUAGE ImplicitParams, LambdaCase #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE LambdaCase #-}
 module Integration.Spec (testTree) where
 
-import Control.Exception (throw)
-import Data.Foldable (find)
-import Data.List (union, transpose)
+import           Control.Exception (throw)
 import qualified Data.ByteString.Lazy as BL
-import System.FilePath.Glob
-import System.IO.Unsafe
+import           Data.Foldable (find)
+import           Data.List (transpose, union)
+import           SpecHelpers
+import           System.FilePath
+import           System.FilePath.Glob
+import           System.IO.Unsafe
+import           Test.Tasty
+import           Test.Tasty.Golden
 
-import SpecHelpers
-import qualified System.Path as Path
-import System.Path ((</>))
-
-import Test.Tasty
-import Test.Tasty.Golden
-
-languages :: [Path.RelDir]
-languages = fmap Path.relDir ["go", "javascript", "json", "python", "ruby", "typescript", "tsx"]
+languages :: [FilePath]
+languages = ["go", "javascript", "json", "python", "ruby", "typescript", "tsx"]
 
 testTree :: (?session :: TaskSession) => TestTree
 testTree = testGroup "Integration (golden tests)" $ fmap testsForLanguage languages
 
-testsForLanguage :: (?session :: TaskSession) => Path.RelDir -> TestTree
+testsForLanguage :: (?session :: TaskSession) => FilePath -> TestTree
 testsForLanguage language = do
-  let dir = Path.relDir "test/fixtures" </> language </> Path.relDir "corpus"
+  let dir = "test/fixtures" </> language </> "corpus"
   let items = unsafePerformIO (examples dir)
-  localOption (mkTimeout 3000000) $ testGroup (Path.toString language) $ fmap testForExample items
+  localOption (mkTimeout 3000000) $ testGroup language $ fmap testForExample items
 {-# NOINLINE testsForLanguage #-}
 
-data Example = ParseExample Path.RelFile Path.RelFile
+data Example = ParseExample FilePath FilePath
              deriving (Eq, Show)
 
 testForExample :: (?session :: TaskSession) => Example -> TestTree
 testForExample (ParseExample file parseOutput) =
     goldenVsStringDiff
-      ("parses " <> Path.toString parseOutput)
+      ("parses " <> parseOutput)
       (\ref new -> ["git", "diff", ref, new])
-      (Path.toString parseOutput)
+      parseOutput
       (parseFilePath ?session file >>= either throw (pure . BL.fromStrict))
 
 
@@ -51,7 +49,7 @@ testForExample (ParseExample file parseOutput) =
 -- |
 -- | example-name.parseA.txt - The expected sexpression parse tree for example-name.A.rb
 -- | example-name.parseB.txt - The expected sexpression parse tree for example-name.B.rb
-examples :: Path.RelDir -> IO [Example]
+examples :: FilePath -> IO [Example]
 examples directory = do
   as <- globFor "*.A.*"
   bs <- globFor "*.B.*"
@@ -69,19 +67,19 @@ examples directory = do
     getExamples f list = foldr (go f list) []
       where go f list name acc = case lookupNormalized' name list of
               Just out -> f out name : acc
-              Nothing -> acc
+              Nothing  -> acc
 
-    lookupNormalized :: Path.RelFile -> [Path.RelFile] -> Path.RelFile
+    lookupNormalized :: FilePath -> [FilePath] -> FilePath
     lookupNormalized name xs = fromMaybe
-      (error ("cannot find " <> Path.toString name <> " make sure .A, .B and exist."))
+      (error ("cannot find " <> name <> " make sure .A, .B and exist."))
       (lookupNormalized' name xs)
 
-    lookupNormalized' :: Path.RelFile -> [Path.RelFile] -> Maybe Path.RelFile
+    lookupNormalized' :: FilePath -> [FilePath] -> Maybe FilePath
     lookupNormalized' name = find ((== name) . normalizeName)
 
-    globFor :: String -> IO [Path.RelFile]
-    globFor p = fmap Path.relFile <$> globDir1 (compile p) (Path.toString directory)
+    globFor :: String -> IO [FilePath]
+    globFor p = globDir1 (compile p) directory
 
 -- | Given a test name like "foo.A.js", return "foo".
-normalizeName :: Path.RelFile -> Path.RelFile
-normalizeName = Path.dropExtension . Path.dropExtension
+normalizeName :: FilePath -> FilePath
+normalizeName = dropExtension . dropExtension

--- a/semantic/test/Semantic/CLI/Spec.hs
+++ b/semantic/test/Semantic/CLI/Spec.hs
@@ -6,20 +6,19 @@ import           Analysis.File
 import           Analysis.Reference
 import           Control.Carrier.Parse.Simple
 import           Control.Carrier.Reader
+import           Control.Exception
 import           Data.ByteString.Builder
-import Control.Exception
-import           Source.Language
 import           Semantic.Api hiding (Blob, File)
 import           Semantic.Task
 import           Serializing.Format
+import           Source.Language
+import           SpecHelpers
+import           System.Directory
+import           System.FilePath
 import           System.IO.Unsafe
-import qualified System.Path as Path
 import qualified System.Path.Fixture as Fixture
-import qualified System.Path.Directory as Path
-
-import SpecHelpers
-import Test.Tasty
-import Test.Tasty.Golden
+import           Test.Tasty
+import           Test.Tasty.Golden
 
 testTree :: TestTree
 testTree = testGroup "Semantic.CLI"
@@ -34,31 +33,31 @@ testTree = testGroup "Semantic.CLI"
 renderDiff :: String -> String -> [String]
 renderDiff ref new = unsafePerformIO $ do
   let check p = do
-        exists <- Path.doesFileExist (Path.absRel p)
+        exists <- doesFileExist p
         unless exists (throwIO (userError ("Can't find path " <> p)))
 
   check ref
   check new
-  useJD <- (Path.hasExtension ".json" (Path.absRel ref) &&) <$> fmap isJust (Path.findExecutable "jd")
+  useJD <- (takeExtension ref == ".json" &&) <$> fmap isJust (findExecutable "jd")
   pure $ if useJD
     then ["jd", "-set", ref, new]
     else ["diff", ref, new]
 {-# NOINLINE renderDiff #-}
 
 
-testForParseFixture :: (String, [Blob] -> ParseC TaskC Builder, [File Language], Path.AbsRelFile) -> TestTree
+testForParseFixture :: (String, [Blob] -> ParseC TaskC Builder, [File Language], FilePath) -> TestTree
 testForParseFixture (format, runParse, files, expected) =
   goldenVsStringDiff
     ("parse fixture renders to " <> format)
     renderDiff
-    (Path.toString expected)
+    expected
     (fmap toLazyByteString . runTaskOrDie $ readBlobs (FilesFromPaths files) >>= runParse)
 
-parseFixtures :: [(String, [Blob] -> ParseC TaskC Builder, [File Language], Path.AbsRelFile)]
+parseFixtures :: [(String, [Blob] -> ParseC TaskC Builder, [File Language], FilePath)]
 parseFixtures =
-  [ ("s-expression", parseTermBuilder TermSExpression, path, Path.absRel "semantic/test/fixtures/ruby/corpus/and-or.parseA.txt")
-  , ("symbols", parseSymbolsBuilder Serializing.Format.JSON, path'', Path.absRel "semantic/test/fixtures/cli/parse-tree.symbols.json")
-  , ("protobuf symbols", parseSymbolsBuilder Serializing.Format.Proto, path'', Path.absRel "semantic/test/fixtures/cli/parse-tree.symbols.protobuf.bin")
+  [ ("s-expression", parseTermBuilder TermSExpression, path, "semantic/test/fixtures/ruby/corpus/and-or.parseA.txt")
+  , ("symbols", parseSymbolsBuilder Serializing.Format.JSON, path'', "semantic/test/fixtures/cli/parse-tree.symbols.json")
+  , ("protobuf symbols", parseSymbolsBuilder Serializing.Format.Proto, path'', "semantic/test/fixtures/cli/parse-tree.symbols.protobuf.bin")
   ]
-  where path = [File (Reference (Path.absRel "semantic/test/fixtures/ruby/corpus/and-or.A.rb") lowerBound) Ruby]
-        path'' = [File (Reference (Path.absRel "semantic/test/fixtures/ruby/corpus/method-declaration.A.rb") lowerBound) Ruby]
+  where path = [File (Reference "semantic/test/fixtures/ruby/corpus/and-or.A.rb" lowerBound) Ruby]
+        path'' = [File (Reference "semantic/test/fixtures/ruby/corpus/method-declaration.A.rb" lowerBound) Ruby]

--- a/semantic/test/Semantic/IO/Spec.hs
+++ b/semantic/test/Semantic/IO/Spec.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
@@ -13,14 +13,13 @@ import           Analysis.Reference as Ref
 import           Data.Blob as Blob
 import           Data.Handle
 import           SpecHelpers
-import qualified System.Path as Path
 import qualified System.Path.Fixture as Fixture
 
 spec :: Fixture.HasFixture => Spec
 spec = do
 #if BAZEL_BUILD
   rf <- runIO Fixture.create
-  let ?project = Path.relDir "semantic"
+  let ?project = "semantic"
       ?runfiles = rf
 #endif
   let blobsFromFilePath path = do
@@ -32,14 +31,14 @@ spec = do
     it "returns a blob for extant files" $ do
       let path = Fixture.absRelFile "test/fixtures/cli/diff.json"
       Just blob <- readBlobFromFile (File (Reference path lowerBound) Unknown)
-      blobFilePath blob `shouldBe` Path.toString path
+      blobFilePath blob `shouldBe` path
 
     it "throws for absent files" $ do
-      readBlobFromFile (File (Reference (Path.absRel "/dev/doesnotexist") lowerBound) Unknown) `shouldThrow` anyIOException
+      readBlobFromFile (File (Reference "/dev/doesnotexist" lowerBound) Unknown) `shouldThrow` anyIOException
 
   describe "readBlobPairsFromHandle" $ do
-    let a = Blob.fromSource (Path.relFile "method.rb") Ruby "def foo; end"
-    let b = Blob.fromSource (Path.relFile "method.rb") Ruby "def bar(x); end"
+    let a = Blob.fromSource "method.rb" Ruby "def foo; end"
+    let b = Blob.fromSource "method.rb" Ruby "def bar(x); end"
     it "returns blobs for valid JSON encoded diff input" $ do
       blobs <- blobsFromFilePath "test/fixtures/cli/diff.json"
       blobs `shouldBe` [Compare a b]
@@ -64,7 +63,7 @@ spec = do
     it "returns blobs for unsupported language" $ do
       h <- openFileForReading (Fixture.absRelFile "test/fixtures/cli/diff-unsupported-language.json")
       blobs <- readBlobPairsFromHandle h
-      let b' = Blob.fromSource (Path.relFile "test.kt") Unknown "fun main(args: Array<String>) {\nprintln(\"hi\")\n}\n"
+      let b' = Blob.fromSource "test.kt" Unknown "fun main(args: Array<String>) {\nprintln(\"hi\")\n}\n"
       blobs `shouldBe` [Insert b']
 
     it "detects language based on filepath for empty language" $ do
@@ -87,7 +86,7 @@ spec = do
     it "returns blobs for valid JSON encoded parse input" $ do
       h <- openFileForReading (Fixture.absRelFile "test/fixtures/cli/parse.json")
       blobs <- readBlobsFromHandle h
-      let a = Blob.fromSource (Path.relFile "method.rb") Ruby "def foo; end"
+      let a = Blob.fromSource "method.rb" Ruby "def foo; end"
       blobs `shouldBe` [a]
 
     it "throws on blank input" $ do

--- a/semantic/test/Semantic/Spec.hs
+++ b/semantic/test/Semantic/Spec.hs
@@ -5,7 +5,6 @@ import           Analysis.File
 import           Control.Exception (fromException)
 import qualified Data.Blob as Blob
 import           SpecHelpers
-import qualified System.Path as Path
 
 import Semantic.Api hiding (Blob)
 
@@ -16,12 +15,12 @@ setBlobLanguage lang b = b { blobFile = (blobFile b) { fileBody = lang }}
 spec :: Spec
 spec = do
   describe "parseBlob" $ do
-    let methodsBlob = Blob.fromSource (Path.relFile "methods.rb") Ruby "def foo\nend\n"
+    let methodsBlob = Blob.fromSource "methods.rb" Ruby "def foo\nend\n"
 
     it "throws if given an unknown language for sexpression output" $ do
       res <- runTaskWithOptions defaultOptions (runParseWithConfig (parseTermBuilder TermSExpression [setBlobLanguage Unknown methodsBlob]))
       case res of
-        Left exc   -> fromException exc `shouldBe` Just (NoLanguageForBlob $ Path.absRel "methods.rb")
+        Left exc   -> fromException exc `shouldBe` Just (NoLanguageForBlob "methods.rb")
         Right _bad -> fail "Expected parseTermBuilder to fail for an unknown language"
 
     it "renders with the specified renderer" $ do

--- a/semantic/test/Spec.hs
+++ b/semantic/test/Spec.hs
@@ -7,18 +7,17 @@ import qualified Data.Graph.Spec
 import qualified Data.Language.Spec
 import qualified Data.Semigroup.App.Spec
 import qualified Integration.Spec
-import qualified Tags.Spec
-import qualified Semantic.Spec
 import qualified Semantic.CLI.Spec
+import           Semantic.Config (defaultOptions, optionsLogLevel)
 import qualified Semantic.IO.Spec
+import qualified Semantic.Spec
 import qualified Semantic.Stat.Spec
-import qualified System.Path as Path
+import           Semantic.Task (TaskSession (..), withOptions)
 import qualified System.Path.Fixture as Fixture
-import Semantic.Config (defaultOptions, optionsLogLevel)
-import Semantic.Task (withOptions, TaskSession(..))
-import Test.Hspec
-import Test.Tasty as Tasty
-import Test.Tasty.Hspec as Tasty
+import qualified Tags.Spec
+import           Test.Hspec
+import           Test.Tasty as Tasty
+import           Test.Tasty.Hspec as Tasty
 
 tests :: (?session :: TaskSession, Fixture.HasFixture) => [TestTree]
 tests =
@@ -55,7 +54,7 @@ main :: IO ()
 main = do
   runfiles <- Fixture.create
   let ?runfiles = runfiles
-      ?project = Path.relDir "semantic"
+      ?project = "semantic"
 
   withOptions defaultOptions { optionsLogLevel = Nothing } $ \ config logger statter ->
     let ?session = TaskSession config "-" False logger statter

--- a/semantic/test/SpecHelpers.hs
+++ b/semantic/test/SpecHelpers.hs
@@ -52,7 +52,6 @@ import           Source.Source as X (Source)
 import           Source.Span as X hiding (HasSpan (..), end, point, start)
 import qualified Source.Span
 import           System.Exit (die)
-import qualified System.Path as Path
 import           Test.Hspec as X (Spec, SpecWith, around, context, describe, it, parallel, pendingWith, runIO, xit)
 import           Test.Hspec.Expectations as X
 
@@ -63,7 +62,7 @@ runBuilder :: Builder -> ByteString
 runBuilder = toStrict . toLazyByteString
 
 -- | Returns an s-expression parse tree for the specified path.
-parseFilePath :: TaskSession -> Path.RelFile -> IO (Either SomeException ByteString)
+parseFilePath :: TaskSession -> FilePath -> IO (Either SomeException ByteString)
 parseFilePath session path = do
   blob <- readBlobFromFile (File.fromPath path)
   res <- runTask session . runParse (configTreeSitterParseTimeout (config session)) $ parseTermBuilder TermSExpression (toList blob)
@@ -73,7 +72,7 @@ runParseWithConfig :: Has (Reader Config) sig m => ParseC m a -> m a
 runParseWithConfig task = asks configTreeSitterParseTimeout >>= \ timeout -> runParse timeout task
 
 -- | Read two files to a BlobPair.
-readFilePathPair :: Path.RelFile -> Path.RelFile -> IO BlobPair
+readFilePathPair :: FilePath -> FilePath -> IO BlobPair
 readFilePathPair p1 p2 = readFilePair (File.fromPath p1) (File.fromPath p2)
 
 -- Run a Task and call `die` if it returns an Exception.

--- a/semantic/test/Tags/Spec.hs
+++ b/semantic/test/Tags/Spec.hs
@@ -6,13 +6,12 @@ module Tags.Spec
 where
 
 import qualified Analysis.File as File
-import Proto.Semantic as P
-import Semantic.Api.Symbols
-import Source.Loc
-import SpecHelpers
-import qualified System.Path as Path
+import           Proto.Semantic as P
+import           Semantic.Api.Symbols
+import           Source.Loc
+import           SpecHelpers
 import qualified System.Path.Fixture as Fixture
-import Tags.Tagging.Precise
+import           Tags.Tagging.Precise
 
 spec :: Fixture.HasFixture => Spec
 spec = do
@@ -92,7 +91,7 @@ spec = do
                          Tag "foo" P.METHOD P.DEFINITION (Range 175 178) (OneIndexedSpan (Span (Pos 18 12) (Pos 18 15))) "def self.foo" (UTF16CodeUnitSpan (Span (Pos 17 11) (Pos 17 14)))
                        ]
 
-parseTestFile :: Foldable t => t P.SyntaxType -> Path.AbsRelFile -> IO [Tag]
+parseTestFile :: Foldable t => t P.SyntaxType -> FilePath -> IO [Tag]
 parseTestFile include path = runTaskOrDie $ readBlob (File.fromPath path) >>= fmap (filter only) . tagsForBlob
   where
     only t = null include || (`elem` include) (tagSyntaxType t)


### PR DESCRIPTION
This PR removes uses of and dependencies on `pathtype` from the rest of the repo.

Depends on #687. In particular, CI won't succeed until we publish `semantic-source` 0.2 to hackage.